### PR TITLE
refactor: change method name for MentionableSelectMenu builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "seyfert",
-	"version": "1.0.1",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "seyfert",
-			"version": "1.0.1",
-			"license": "ISC",
+			"version": "1.1.1",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"chokidar": "^3.6.0",
 				"discord-api-types": "^0.37.76",

--- a/src/builders/SelectMenu.ts
+++ b/src/builders/SelectMenu.ts
@@ -195,7 +195,7 @@ export class MentionableSelectMenu extends SelectMenu<APIMentionableSelectCompon
 	 * @param mentionables - Role/User id and type to be set as default.
 	 * @returns The current MentionableSelectMenu instance.
 	 */
-	setDefaults(...mentionables: RestOrArray<MentionableDefaultElement>) {
+	setDefaultMentionables(...mentionables: RestOrArray<MentionableDefaultElement>) {
 		this.data.default_values = mentionables.flat().map(mentionable => ({
 			id: mentionable.id,
 			type: SelectMenuDefaultValueType[mentionable.type],


### PR DESCRIPTION
# CHANGES

Replaced `setDefaults` method from MentionableSelectMenu into `setDefaultMentionables` as pair as the other select menu times.