### PR TITLE
feat: add componentcontext export to index

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,7 @@ export type MessageComponents =
 export type ActionRowMessageComponents = Exclude<MessageComponents, TextInputComponent>;
 
 export * from './command';
+export * from './componentcontext';
 
 /**
  * Return a new component instance based on the component type.


### PR DESCRIPTION
This commit adds the export statement export * from './componentcontext'; to the index.ts file.