### PR TITLE
feat: new changes to avatarURL method over GuildMember & User

### DIFF
--- a/src/api/Router.ts
+++ b/src/api/Router.ts
@@ -73,6 +73,7 @@ export interface CDNUrlOptions extends BaseCDNUrlOptions {
 
 export function parseCDNURL(route: string, options: CDNUrlOptions = {}) {
 	if (options.forceStatic && route.includes('a_')) options.extension = 'png';
+	if (!options.extension && route.includes('a_')) options.extension = 'gif';
 
 	const url = new URL(`${route}.${options.extension || 'png'}`);
 

--- a/src/common/shorters/emojis.ts
+++ b/src/common/shorters/emojis.ts
@@ -40,6 +40,7 @@ export class EmojiShorter extends BaseShorter {
 			body: bodyResolved,
 		});
 		await this.client.cache.channels?.setIfNI('GuildEmojisAndStickers', emoji.id!, guildId, emoji);
+		return new GuildEmoji(this.client, emoji, guildId);
 	}
 
 	/**

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -181,14 +181,11 @@ export class GuildMember extends BaseGuildMember {
 			return null;
 		}
 
-		return this.rest.cdn
-			.guilds(this.guildId)
-			.users(this.id)
-			.avatars(this.avatar)
-			.get({
-				...options,
-				extension: this.avatar.startsWith('a_') ? 'gif' : options?.extension ?? 'webp',
-			});
+		if (this.avatar.startsWith('a_') && !options?.extension) {
+			options = { ...options, extension: 'gif' };
+		}
+
+		return this.rest.cdn.guilds(this.guildId).users(this.id).avatars(this.avatar).get(options);
 	}
 
 	bannerURL(options?: ImageOptions) {

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -184,6 +184,14 @@ export class GuildMember extends BaseGuildMember {
 		return this.rest.cdn.guilds(this.guildId).users(this.id).avatars(this.avatar).get(options);
 	}
 
+	dynamicAvatarURL(options?: ImageOptions) {
+		if (!this.avatar) {
+			return this.user.avatarURL(options);
+		}
+
+		return this.rest.cdn.guilds(this.guildId).users(this.id).avatars(this.avatar).get(options);
+	}
+
 	bannerURL(options?: ImageOptions) {
 		return this.user.bannerURL(options);
 	}

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -177,15 +177,18 @@ export class GuildMember extends BaseGuildMember {
 	}
 
 	avatarURL(options?: ImageOptions) {
-		return this.user.avatarURL(options);
-	}
-
-	dynamicAvatarURL(options?: ImageOptions) {
 		if (!this.avatar) {
-			return this.user.avatarURL(options);
+			return null;
 		}
 
-		return this.rest.cdn.guilds(this.guildId).users(this.id).avatars(this.avatar).get(options);
+		return this.rest.cdn
+			.guilds(this.guildId)
+			.users(this.id)
+			.avatars(this.avatar)
+			.get({
+				...options,
+				extension: this.avatar.startsWith('a_') ? 'gif' : options?.extension ?? 'webp',
+			});
 	}
 
 	bannerURL(options?: ImageOptions) {

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -181,10 +181,6 @@ export class GuildMember extends BaseGuildMember {
 			return null;
 		}
 
-		if (this.avatar.startsWith('a_') && !options?.extension) {
-			options = { ...options, extension: 'gif' };
-		}
-
 		return this.rest.cdn.guilds(this.guildId).users(this.id).avatars(this.avatar).get(options);
 	}
 

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -37,7 +37,11 @@ export class User extends DiscordBase<APIUser> {
 		if (!this.avatar) {
 			return this.rest.cdn.embed.avatars.get(calculateUserDefaultAvatarIndex(this.id, this.discriminator));
 		}
-		return this.rest.cdn.avatars(this.id).get(this.avatar, options);
+
+		return this.rest.cdn.avatars(this.id).get(this.avatar, {
+			...options,
+			extension: this.avatar.startsWith('a_') ? 'gif' : options?.extension ?? 'webp',
+		});
 	}
 
 	avatarDecorationURL(options?: ImageOptions) {

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -38,10 +38,6 @@ export class User extends DiscordBase<APIUser> {
 			return this.rest.cdn.embed.avatars.get(calculateUserDefaultAvatarIndex(this.id, this.discriminator));
 		}
 
-		if (this.avatar.startsWith('a_') && !options?.extension) {
-			options = { ...options, extension: 'gif' };
-		}
-
 		return this.rest.cdn.avatars(this.id).get(this.avatar, options);
 	}
 

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -38,10 +38,11 @@ export class User extends DiscordBase<APIUser> {
 			return this.rest.cdn.embed.avatars.get(calculateUserDefaultAvatarIndex(this.id, this.discriminator));
 		}
 
-		return this.rest.cdn.avatars(this.id).get(this.avatar, {
-			...options,
-			extension: this.avatar.startsWith('a_') ? 'gif' : options?.extension ?? 'webp',
-		});
+		if (this.avatar.startsWith('a_') && !options?.extension) {
+			options = { ...options, extension: 'gif' };
+		}
+
+		return this.rest.cdn.avatars(this.id).get(this.avatar, options);
 	}
 
 	avatarDecorationURL(options?: ImageOptions) {


### PR DESCRIPTION
# Changes
1. Removed dynamicAvatarURL from GuildMember, as we could have the same output from GuildMember#user
2. Added a default extension option in avatarURL method, to return a gif if the user has a gif avatar and if not return specified extension.

These approaches are similar to discord.js, but i feel these are useful as this makes the user write less code on their end.