### PR TITLE
Parsers overridden during client initialization making external parsers from not working.

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -57,6 +57,8 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
 				optionsParser: defaultParseOptions,
 			},
 		} satisfies ClientOptions);
+
+		console.log(this.options);
 	}
 
 	setServices({

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -53,12 +53,10 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
 		super(options);
 		this.options = MergeOptions(this.options, {
 			commands: {
-				argsParser: defaultArgsParser,
-				optionsParser: defaultParseOptions,
+				argsParser: options?.commands?.argsParser ?? defaultArgsParser,
+				optionsParser: options?.commands?.optionsParser ?? defaultParseOptions,
 			},
 		} satisfies ClientOptions);
-
-		console.log(this.options);
 	}
 
 	setServices({

--- a/src/common/it/colors.ts
+++ b/src/common/it/colors.ts
@@ -62,8 +62,8 @@ export function reset(str: string): string {
  * Make the text bold.
  * @param str text to make bold
  */
-export function bold(str: string): string {
-	return run(str, code([1], 22));
+export function bold(str: string): `**${string}**` {
+	return `**${str}**`;
 }
 
 /**

--- a/src/common/it/colors.ts
+++ b/src/common/it/colors.ts
@@ -62,8 +62,8 @@ export function reset(str: string): string {
  * Make the text bold.
  * @param str text to make bold
  */
-export function bold(str: string): `**${string}**` {
-	return `**${str}**`;
+export function bold(str: string): string {
+	return run(str, code([1], 22));
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR introduces a fix to the argument and options parser, the recent build for seyfert was replacing the parsers provided by the user with it's own default parser removing the flexibility.

## Steps To Reproduce
Below are the steps to reproducing this issue.

1. Construct a client
2.  Pass in your own argument parser
3. Parser doesn't work, due to being overridden

## Conclusion
Basically the passed in options for the arguments parser or options parser are not working for example, i tried using the YunaParser and it failed, due to being overridden by the library's default parser settings.