### PR TITLE
feat: allow disabled caching data without intents

### DIFF
--- a/src/cache/resources/default/base.ts
+++ b/src/cache/resources/default/base.ts
@@ -31,14 +31,14 @@ export class BaseResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string) {
-		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.remove && this.cache.hasIntent(intent)) {
 			return this.remove(id);
 		}
 		return;
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, data: any) {
-		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.set && this.cache.hasIntent(intent)) {
 			return this.set(id, data);
 		}
 	}

--- a/src/cache/resources/default/base.ts
+++ b/src/cache/resources/default/base.ts
@@ -31,14 +31,14 @@ export class BaseResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
 			return this.remove(id);
 		}
 		return;
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, data: any) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
 			return this.set(id, data);
 		}
 	}

--- a/src/cache/resources/default/guild-based.ts
+++ b/src/cache/resources/default/guild-based.ts
@@ -37,14 +37,13 @@ export class GuildBasedResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string | string[], guildId: string) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
 			return this.remove(id, guildId);
 		}
-		return;
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, guildId: string, data: any) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
 			return this.set(id, guildId, data);
 		}
 	}

--- a/src/cache/resources/default/guild-based.ts
+++ b/src/cache/resources/default/guild-based.ts
@@ -37,13 +37,13 @@ export class GuildBasedResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string | string[], guildId: string) {
-		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.remove && this.cache.hasIntent(intent)) {
 			return this.remove(id, guildId);
 		}
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, guildId: string, data: any) {
-		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.set && this.cache.hasIntent(intent)) {
 			return this.set(id, guildId, data);
 		}
 	}

--- a/src/cache/resources/default/guild-related.ts
+++ b/src/cache/resources/default/guild-related.ts
@@ -38,13 +38,13 @@ export class GuildRelatedResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string | string[], guildId: string) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
 			return this.remove(id, guildId);
 		}
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, guildId: string, data: any) {
-		if (!this.cache.hasIntent(intent)) {
+		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
 			return this.set(id, guildId, data);
 		}
 	}

--- a/src/cache/resources/default/guild-related.ts
+++ b/src/cache/resources/default/guild-related.ts
@@ -38,13 +38,13 @@ export class GuildRelatedResource<T = any> {
 	}
 
 	removeIfNI(intent: keyof typeof GatewayIntentBits, id: string | string[], guildId: string) {
-		if (this.client.options.disabledIfNoIntent?.remove && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.remove && this.cache.hasIntent(intent)) {
 			return this.remove(id, guildId);
 		}
 	}
 
 	setIfNI(intent: keyof typeof GatewayIntentBits, id: string, guildId: string, data: any) {
-		if (this.client.options.disabledIfNoIntent?.set && !this.cache.hasIntent(intent)) {
+		if (!this.client.options.disabledIfNoIntent?.set && this.cache.hasIntent(intent)) {
 			return this.set(id, guildId, data);
 		}
 	}

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -10,11 +10,7 @@ import type {
 	RegisteredMiddlewares,
 	UsingClient,
 } from '../commands';
-import {
-	IgnoreCommand,
-	type InferWithPrefix,
-	type MiddlewareContext,
-} from '../commands/applications/shared';
+import { IgnoreCommand, type InferWithPrefix, type MiddlewareContext } from '../commands/applications/shared';
 import { CommandHandler } from '../commands/handler';
 import {
 	ChannelShorter,
@@ -37,18 +33,8 @@ import {
 	type MakeRequired,
 } from '../common';
 
-import type {
-	LocaleString,
-	RESTPostAPIChannelMessageJSONBody,
-} from 'discord-api-types/rest/v10';
-import type {
-	Awaitable,
-	DeepPartial,
-	IntentStrings,
-	OmitInsert,
-	PermissionStrings,
-	When,
-} from '../common/types/util';
+import type { LocaleString, RESTPostAPIChannelMessageJSONBody } from 'discord-api-types/rest/v10';
+import type { Awaitable, DeepPartial, IntentStrings, OmitInsert, PermissionStrings, When } from '../common/types/util';
 import { ComponentHandler } from '../components/handler';
 import { LangsHandler } from '../langs/handler';
 import type {
@@ -59,12 +45,7 @@ import type {
 	ModalSubmitInteraction,
 	UserCommandInteraction,
 } from '../structures';
-import type {
-	ComponentCommand,
-	ComponentContext,
-	ModalCommand,
-	ModalContext,
-} from '../components';
+import type { ComponentCommand, ComponentContext, ModalCommand, ModalContext } from '../components';
 import { promises } from 'node:fs';
 import { BanShorter } from '../common/shorters/bans';
 
@@ -100,10 +81,7 @@ export class BaseClient {
 	private _botId?: string;
 	middlewares?: Record<string, MiddlewareContext>;
 
-	protected static assertString(
-		value: unknown,
-		message?: string
-	): asserts value is string {
+	protected static assertString(value: unknown, message?: string): asserts value is string {
 		if (!(typeof value === 'string' && value !== '')) {
 			throw new Error(message ?? 'Value is not a string');
 		}
@@ -123,94 +101,43 @@ export class BaseClient {
 			{
 				commands: {
 					defaults: {
-						onRunError(
-							context: CommandContext<any>,
-							error: unknown
-						): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onRunError>`,
-								context.author.id,
-								error
-							);
+						onRunError(context: CommandContext<any>, error: unknown): any {
+							context.client.logger.fatal(`${context.command.name}.<onRunError>`, context.author.id, error);
 						},
-						onOptionsError(
-							context: CommandContext<{}, never>,
-							metadata: OnOptionsReturnObject
-						): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onOptionsError>`,
-								context.author.id,
-								metadata
-							);
+						onOptionsError(context: CommandContext<{}, never>, metadata: OnOptionsReturnObject): any {
+							context.client.logger.fatal(`${context.command.name}.<onOptionsError>`, context.author.id, metadata);
 						},
-						onMiddlewaresError(
-							context: CommandContext<{}, never>,
-							error: string
-						): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onMiddlewaresError>`,
-								context.author.id,
-								error
-							);
+						onMiddlewaresError(context: CommandContext<{}, never>, error: string): any {
+							context.client.logger.fatal(`${context.command.name}.<onMiddlewaresError>`, context.author.id, error);
 						},
-						onBotPermissionsFail(
-							context: CommandContext<{}, never>,
-							permissions: PermissionStrings
-						): any {
+						onBotPermissionsFail(context: CommandContext<{}, never>, permissions: PermissionStrings): any {
 							context.client.logger.fatal(
 								`${context.command.name}.<onBotPermissionsFail>`,
 								context.author.id,
-								permissions
+								permissions,
 							);
 						},
-						onPermissionsFail(
-							context: CommandContext<{}, never>,
-							permissions: PermissionStrings
-						): any {
+						onPermissionsFail(context: CommandContext<{}, never>, permissions: PermissionStrings): any {
 							context.client.logger.fatal(
 								`${context.command.name}.<onPermissionsFail>`,
 								context.author.id,
-								permissions
+								permissions,
 							);
 						},
-						onInternalError(
-							client: UsingClient,
-							command: Command,
-							error?: unknown
-						): any {
-							client.logger.fatal(
-								`${command.name}.<onInternalError>`,
-								error
-							);
+						onInternalError(client: UsingClient, command: Command, error?: unknown): any {
+							client.logger.fatal(`${command.name}.<onInternalError>`, error);
 						},
 					},
 				},
 				components: {
 					defaults: {
-						onRunError(
-							context: ComponentContext,
-							error: unknown
-						): any {
-							context.client.logger.fatal(
-								'ComponentCommand.<onRunError>',
-								context.author.id,
-								error
-							);
+						onRunError(context: ComponentContext, error: unknown): any {
+							context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
 						},
-						onMiddlewaresError(
-							context: ComponentContext,
-							error: string
-						): any {
-							context.client.logger.fatal(
-								'ComponentCommand.<onMiddlewaresError>',
-								context.author.id,
-								error
-							);
+						onMiddlewaresError(context: ComponentContext, error: string): any {
+							context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
 						},
-						onInternalError(
-							client: UsingClient,
-							error?: unknown
-						): any {
+						onInternalError(client: UsingClient, error?: unknown): any {
 							client.logger.fatal(error);
 						},
 					},
@@ -218,32 +145,18 @@ export class BaseClient {
 				modals: {
 					defaults: {
 						onRunError(context: ModalContext, error: unknown): any {
-							context.client.logger.fatal(
-								'ComponentCommand.<onRunError>',
-								context.author.id,
-								error
-							);
+							context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
 						},
-						onMiddlewaresError(
-							context: ModalContext,
-							error: string
-						): any {
-							context.client.logger.fatal(
-								'ComponentCommand.<onMiddlewaresError>',
-								context.author.id,
-								error
-							);
+						onMiddlewaresError(context: ModalContext, error: string): any {
+							context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
 						},
-						onInternalError(
-							client: UsingClient,
-							error?: unknown
-						): any {
+						onInternalError(client: UsingClient, error?: unknown): any {
 							client.logger.fatal(error);
 						},
 					},
 				},
 			} satisfies BaseClientOptions,
-			options
+			options,
 		);
 	}
 
@@ -252,9 +165,7 @@ export class BaseClient {
 	}
 
 	get botId() {
-		return (
-			this._botId ?? BaseClient.getBotIdFromToken(this.rest.options.token)
-		);
+		return this._botId ?? BaseClient.getBotIdFromToken(this.rest.options.token);
 	}
 
 	set applicationId(id: string) {
@@ -269,13 +180,7 @@ export class BaseClient {
 		return new Router(this.rest).createProxy();
 	}
 
-	setServices({
-		rest,
-		cache,
-		langs,
-		middlewares,
-		handlers,
-	}: ServicesOptions) {
+	setServices({ rest, cache, langs, middlewares, handlers }: ServicesOptions) {
 		if (rest) {
 			this.rest = rest;
 		}
@@ -284,7 +189,7 @@ export class BaseClient {
 				this.cache?.intents ?? 0,
 				cache?.adapter ?? this.cache?.adapter ?? new MemoryAdapter(),
 				cache.disabledCache ?? this.cache?.disabledCache ?? [],
-				this
+				this,
 			);
 		}
 		if (middlewares) {
@@ -326,8 +231,7 @@ export class BaseClient {
 		}
 		if (langs) {
 			if (langs.default) this.langs!.defaultLang = langs.default;
-			if (langs.aliases)
-				this.langs!.aliases = Object.entries(langs.aliases);
+			if (langs.aliases) this.langs!.aliases = Object.entries(langs.aliases);
 		}
 	}
 
@@ -341,20 +245,13 @@ export class BaseClient {
 	}
 
 	async start(
-		options: Pick<
-			DeepPartial<StartOptions>,
-			| 'langsDir'
-			| 'commandsDir'
-			| 'connection'
-			| 'token'
-			| 'componentsDir'
-		> = {
+		options: Pick<DeepPartial<StartOptions>, 'langsDir' | 'commandsDir' | 'connection' | 'token' | 'componentsDir'> = {
 			token: undefined,
 			langsDir: undefined,
 			commandsDir: undefined,
 			connection: undefined,
 			componentsDir: undefined,
-		}
+		},
 	) {
 		await this.loadLangs(options.langsDir);
 		await this.loadCommands(options.commandsDir);
@@ -385,32 +282,21 @@ export class BaseClient {
 	}
 
 	shouldUploadCommands(cachePath: string) {
-		return this.commands!.shouldUpload(cachePath).then(async (should) => {
-			if (should)
-				await promises.writeFile(
-					cachePath,
-					JSON.stringify(this.commands!.values.map((x) => x.toJSON()))
-				);
+		return this.commands!.shouldUpload(cachePath).then(async should => {
+			if (should) await promises.writeFile(cachePath, JSON.stringify(this.commands!.values.map(x => x.toJSON())));
 			return should;
 		});
 	}
 
 	async uploadCommands(applicationId?: string) {
-		applicationId ??= await this.getRC().then(
-			(x) => x.applicationId ?? this.applicationId
-		);
+		applicationId ??= await this.getRC().then(x => x.applicationId ?? this.applicationId);
 		BaseClient.assertString(applicationId, 'applicationId is not a string');
 
 		const commands = this.commands!.values;
-		const filter = filterSplit(commands, (command) => !command.guildId);
+		const filter = filterSplit(commands, command => !command.guildId);
 
 		await this.proxy.applications(applicationId).commands.put({
-			body: filter.expect
-				.filter(
-					(cmd) =>
-						!('ignore' in cmd) || cmd.ignore !== IgnoreCommand.Slash
-				)
-				.map((x) => x.toJSON()),
+			body: filter.expect.filter(cmd => !('ignore' in cmd) || cmd.ignore !== IgnoreCommand.Slash).map(x => x.toJSON()),
 		});
 
 		const guilds = new Set<string>();
@@ -427,19 +313,14 @@ export class BaseClient {
 				.guilds(guild)
 				.commands.put({
 					body: filter.never
-						.filter(
-							(cmd) =>
-								cmd.guildId?.includes(guild) &&
-								(!('ignore' in cmd) ||
-									cmd.ignore !== IgnoreCommand.Slash)
-						)
-						.map((x) => x.toJSON()),
+						.filter(cmd => cmd.guildId?.includes(guild) && (!('ignore' in cmd) || cmd.ignore !== IgnoreCommand.Slash))
+						.map(x => x.toJSON()),
 				});
 		}
 	}
 
 	async loadCommands(dir?: string) {
-		dir ??= await this.getRC().then((x) => x.commands);
+		dir ??= await this.getRC().then(x => x.commands);
 		if (dir && this.commands) {
 			await this.commands.load(dir, this);
 			this.logger.info('CommandHandler loaded');
@@ -447,7 +328,7 @@ export class BaseClient {
 	}
 
 	async loadComponents(dir?: string) {
-		dir ??= await this.getRC().then((x) => x.components);
+		dir ??= await this.getRC().then(x => x.components);
 		if (dir && this.components) {
 			await this.components.load(dir);
 			this.logger.info('ComponentHandler loaded');
@@ -455,7 +336,7 @@ export class BaseClient {
 	}
 
 	async loadLangs(dir?: string) {
-		dir ??= await this.getRC().then((x) => x.langs);
+		dir ??= await this.getRC().then(x => x.langs);
 		if (dir && this.langs) {
 			await this.langs.load(dir);
 			this.logger.info('LangsHandler loaded');
@@ -467,37 +348,23 @@ export class BaseClient {
 	}
 
 	async getRC<
-		T extends InternalRuntimeConfigHTTP | InternalRuntimeConfig =
-			| InternalRuntimeConfigHTTP
-			| InternalRuntimeConfig
+		T extends InternalRuntimeConfigHTTP | InternalRuntimeConfig = InternalRuntimeConfigHTTP | InternalRuntimeConfig,
 	>() {
 		const seyfertConfig = (BaseClient._seyfertConfig ||
 			(await this.options.getRC?.()) ||
-			(await magicImport(join(process.cwd(), 'seyfert.config.js')).then(
-				(x) => x.default ?? x
-			))) as T;
+			(await magicImport(join(process.cwd(), 'seyfert.config.js')).then(x => x.default ?? x))) as T;
 
 		const { locations, debug, ...env } = seyfertConfig;
 
 		const obj = {
 			debug: !!debug,
 			...env,
-			templates: locations.templates
-				? join(process.cwd(), locations.base, locations.templates)
-				: undefined,
-			langs: locations.langs
-				? join(process.cwd(), locations.output, locations.langs)
-				: undefined,
+			templates: locations.templates ? join(process.cwd(), locations.base, locations.templates) : undefined,
+			langs: locations.langs ? join(process.cwd(), locations.output, locations.langs) : undefined,
 			events:
-				'events' in locations && locations.events
-					? join(process.cwd(), locations.output, locations.events)
-					: undefined,
-			components: locations.components
-				? join(process.cwd(), locations.output, locations.components)
-				: undefined,
-			commands: locations.commands
-				? join(process.cwd(), locations.output, locations.commands)
-				: undefined,
+				'events' in locations && locations.events ? join(process.cwd(), locations.output, locations.events) : undefined,
+			components: locations.components ? join(process.cwd(), locations.output, locations.components) : undefined,
+			commands: locations.commands ? join(process.cwd(), locations.output, locations.commands) : undefined,
 			base: join(process.cwd(), locations.base),
 			output: join(process.cwd(), locations.output),
 		};
@@ -516,7 +383,7 @@ export interface BaseClientOptions {
 			| MessageCommandInteraction<boolean>
 			| ComponentInteraction
 			| ModalSubmitInteraction
-			| When<InferWithPrefix, Message, never>
+			| When<InferWithPrefix, Message, never>,
 	) => {};
 	globalMiddlewares?: readonly (keyof RegisteredMiddlewares)[];
 	commands?: {
@@ -547,13 +414,11 @@ export interface BaseClientOptions {
 			onAfterRun?: ModalCommand['onAfterRun'];
 		};
 	};
-	allowedMentions?: Omit<
-		NonNullable<RESTPostAPIChannelMessageJSONBody['allowed_mentions']>,
-		'parse'
-	> & {
+	allowedMentions?: Omit<NonNullable<RESTPostAPIChannelMessageJSONBody['allowed_mentions']>, 'parse'> & {
 		parse?: ('everyone' | 'roles' | 'users')[]; //nice types, d-api
 	};
 	getRC?(): Awaitable<InternalRuntimeConfig | InternalRuntimeConfigHTTP>;
+	disabledIfNoIntent?: { set?: boolean; remove?: boolean };
 }
 
 export interface StartOptions {
@@ -595,17 +460,11 @@ export type InternalRuntimeConfigHTTP = Omit<
 	MakeRequired<RC, 'publicKey' | 'port' | 'applicationId'>,
 	'intents' | 'locations'
 > & { locations: Omit<RC['locations'], 'events'> };
-export type RuntimeConfigHTTP = Omit<
-	MakeRequired<RC, 'publicKey' | 'applicationId'>,
-	'intents' | 'locations'
-> & {
+export type RuntimeConfigHTTP = Omit<MakeRequired<RC, 'publicKey' | 'applicationId'>, 'intents' | 'locations'> & {
 	locations: Omit<RC['locations'], 'events'>;
 };
 
-export type InternalRuntimeConfig = Omit<
-	MakeRequired<RC, 'intents'>,
-	'publicKey' | 'port'
->;
+export type InternalRuntimeConfig = Omit<MakeRequired<RC, 'intents'>, 'publicKey' | 'port'>;
 export type RuntimeConfig = OmitInsert<
 	InternalRuntimeConfig,
 	'intents',
@@ -622,9 +481,7 @@ export interface ServicesOptions {
 	middlewares?: Record<string, MiddlewareContext>;
 	handlers?: {
 		components?: ComponentHandler | ComponentHandler['callback'];
-		commands?:
-			| CommandHandler
-			| Parameters<CommandHandler['setHandlers']>[0];
+		commands?: CommandHandler | Parameters<CommandHandler['setHandlers']>[0];
 		langs?: LangsHandler | LangsHandler['callback'];
 	};
 }


### PR DESCRIPTION
Until now, seyfert automatically saved the data for which no intents were available without discrimination, although it has been left activated, a way to deactivate it has been added.