### PR TITLE
chore: improve toString output with newly added formatters

### DIFF
--- a/src/common/it/formatter.ts
+++ b/src/common/it/formatter.ts
@@ -234,7 +234,7 @@ export class Formatter {
 	 * @param animated Whether the emoji is animated. Defaults to false.
 	 * @returns The formatted emoji.
 	 */
-	static emojiMention(emojiId: string, animated = false): string {
-		return `<${animated ? 'a' : ''}:${emojiId}>`;
+	static emojiMention(emojiId: string, name: string | null, animated = false): string {
+		return `<${animated ? 'a' : ''}:${name ?? '_'}:${emojiId}>`;
 	}
 }

--- a/src/common/it/formatter.ts
+++ b/src/common/it/formatter.ts
@@ -200,4 +200,41 @@ export class Formatter {
 	static timestamp(timestamp: Date, style: TimestampStyle = TimestampStyle.RelativeTime): Timestamp {
 		return `<t:${Math.floor(timestamp.getTime() / 1000)}:${style}>`;
 	}
+
+	/**
+	 * Formats a user mention.
+	 * @param userId The ID of the user to mention.
+	 * @returns The formatted user mention.
+	 */
+	static userMention(userId: string): `<@${string}>` {
+		return `<@${userId}>`;
+	}
+
+	/**
+	 * Formats a role mention.
+	 * @param roleId The ID of the role to mention.
+	 * @returns The formatted role mention.
+	 */
+	static roleMention(roleId: string): `<@&${string}>` {
+		return `<@&${roleId}>`;
+	}
+
+	/**
+	 * Formats a channel mention.
+	 * @param channelId The ID of the channel to mention.
+	 * @returns The formatted channel mention.
+	 */
+	static channelMention(channelId: string): `<#${string}>` {
+		return `<#${channelId}>`;
+	}
+
+	/**
+	 * Formats an emoji.
+	 * @param emojiId The ID of the emoji.
+	 * @param animated Whether the emoji is animated. Defaults to false.
+	 * @returns The formatted emoji.
+	 */
+	static emojiMention(emojiId: string, animated = false): string {
+		return `<${animated ? 'a' : ''}:${emojiId}>`;
+	}
 }

--- a/src/events/hooks/guild.ts
+++ b/src/events/hooks/guild.ts
@@ -57,7 +57,7 @@ export const GUILD_INTEGRATIONS_UPDATE = (_self: UsingClient, data: GatewayGuild
 };
 
 export const GUILD_MEMBER_ADD = (self: UsingClient, data: GatewayGuildMemberAddDispatchData) => {
-	return new GuildMember(self, data, data.user, data.guild_id);
+	return new GuildMember(self, data, data.user!, data.guild_id);
 };
 
 export const GUILD_MEMBER_REMOVE = (self: UsingClient, data: GatewayGuildMemberRemoveDispatchData) => {

--- a/src/structures/GuildBan.ts
+++ b/src/structures/GuildBan.ts
@@ -1,6 +1,6 @@
 import type { APIBan, RESTGetAPIGuildBansQuery } from 'discord-api-types/v10';
 import type { UsingClient } from '../commands';
-import type { MethodContext, ObjectToLower } from '../common';
+import { Formatter, type MethodContext, type ObjectToLower } from '../common';
 import { DiscordBase } from './extra/DiscordBase';
 import type { BanShorter } from '../common/shorters/bans';
 
@@ -32,7 +32,7 @@ export class GuildBan extends DiscordBase {
 	}
 
 	toString() {
-		return `<@${this.id}>`;
+		return Formatter.userMention(this.id);
 	}
 
 	static methods({ client, guildId }: MethodContext<{ guildId: string }>) {

--- a/src/structures/GuildEmoji.ts
+++ b/src/structures/GuildEmoji.ts
@@ -1,7 +1,7 @@
 import type { APIEmoji, RESTPatchAPIChannelJSONBody, RESTPatchAPIGuildEmojiJSONBody } from 'discord-api-types/v10';
 import type { BaseCDNUrlOptions } from '../api';
 import type { UsingClient } from '../commands';
-import type { EmojiShorter, MethodContext, ObjectToLower } from '../common';
+import { Formatter, type EmojiShorter, type MethodContext, type ObjectToLower } from '../common';
 import { DiscordBase } from './extra/DiscordBase';
 
 export interface GuildEmoji extends DiscordBase, ObjectToLower<Omit<APIEmoji, 'id'>> {}
@@ -37,7 +37,7 @@ export class GuildEmoji extends DiscordBase {
 	}
 
 	toString() {
-		return `<${this.animated ? 'a' : ''}:${this.name}:${this.id}>`;
+		return Formatter.emojiMention(this.id, this.animated);
 	}
 
 	toJSON() {

--- a/src/structures/GuildEmoji.ts
+++ b/src/structures/GuildEmoji.ts
@@ -37,7 +37,7 @@ export class GuildEmoji extends DiscordBase {
 	}
 
 	toString() {
-		return Formatter.emojiMention(this.id, this.animated);
+		return Formatter.emojiMention(this.id, this.name, this.animated);
 	}
 
 	toJSON() {

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -20,7 +20,7 @@ import type {
 	RESTPutAPIGuildMemberJSONBody,
 } from 'discord-api-types/v10';
 import type { UsingClient } from '../commands';
-import type { MessageCreateBodyRequest, ObjectToLower, ToClass } from '../common';
+import { Formatter, type MessageCreateBodyRequest, type ObjectToLower, type ToClass } from '../common';
 import type { ImageOptions, MethodContext } from '../common/types/options';
 import type { GuildMemberResolvable } from '../common/types/resolvables';
 import { User } from './User';
@@ -73,7 +73,7 @@ export class BaseGuildMember extends DiscordBase {
 	}
 
 	toString() {
-		return `<@${this.id}>`;
+		return Formatter.userMention(this.id);
 	}
 
 	private patch(data: GuildMemberData) {

--- a/src/structures/GuildRole.ts
+++ b/src/structures/GuildRole.ts
@@ -5,7 +5,7 @@ import type {
 	RESTPostAPIGuildRoleJSONBody,
 } from 'discord-api-types/v10';
 import type { UsingClient } from '../commands';
-import type { MethodContext, ObjectToLower } from '../common';
+import { Formatter, type MethodContext, type ObjectToLower } from '../common';
 import { DiscordBase } from './extra/DiscordBase';
 import { PermissionsBitField } from './extra/Permissions';
 
@@ -33,6 +33,10 @@ export class GuildRole extends DiscordBase {
 
 	delete(reason?: string) {
 		return this.client.roles.delete(this.guildId, this.id, reason);
+	}
+
+	toString() {
+		return Formatter.roleMention(this.id);
 	}
 
 	static methods(ctx: MethodContext<{ guildId: string }>) {

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -1,6 +1,6 @@
 import type { APIUser } from 'discord-api-types/v10';
 import { calculateUserDefaultAvatarIndex } from '../api';
-import type { MessageCreateBodyRequest, ObjectToLower } from '../common';
+import { Formatter, type MessageCreateBodyRequest, type ObjectToLower } from '../common';
 import type { ImageOptions } from '../common/types/options';
 import { DiscordBase } from './extra/DiscordBase';
 
@@ -60,6 +60,6 @@ export class User extends DiscordBase<APIUser> {
 	}
 
 	toString() {
-		return `<@${this.id}>`;
+		return Formatter.userMention(this.id);
 	}
 }

--- a/src/structures/channels.ts
+++ b/src/structures/channels.ts
@@ -41,7 +41,7 @@ import type { GuildMember } from './GuildMember';
 import type { GuildRole } from './GuildRole';
 import { DiscordBase } from './extra/DiscordBase';
 import { channelLink } from './extra/functions';
-import { Collection, type RawFile } from '..';
+import { Collection, Formatter, type RawFile } from '..';
 
 export class BaseChannel<T extends ChannelType> extends DiscordBase<APIChannelBase<ChannelType>> {
 	declare type: T;
@@ -77,7 +77,7 @@ export class BaseChannel<T extends ChannelType> extends DiscordBase<APIChannelBa
 	}
 
 	toString() {
-		return `<#${this.id}>`;
+		return Formatter.channelMention(this.id);
 	}
 
 	isStage(): this is StageChannel {


### PR DESCRIPTION
# Summary
- Added `toString` to `GuildRole` & `RoleShorter`.
- Added multiple mention formatters (role, channel, user).
- Added emoji formatter.

# Conclusion
Overall changed the way of `toString` method in most of the shorters and structures, instead of returning base strings i am now returing the output the formatters.