### PR TITLE
fix: 'Permissions' type truco

### DIFF
--- a/src/types/rest/channel.ts
+++ b/src/types/rest/channel.ts
@@ -1,4 +1,4 @@
-import type { Snowflake, ChannelType, VideoQualityMode, OverwriteType } from '..';
+import type { Snowflake, ChannelType, VideoQualityMode, OverwriteType, Permissions } from '..';
 
 import type {
 	APIChannel,


### PR DESCRIPTION
Fixed a problem where the `Permissions` type returned `any` due to an incorrect import.