### PR TITLE
chore: early conditional

### DIFF
--- a/src/commands/handle.ts
+++ b/src/commands/handle.ts
@@ -503,8 +503,9 @@ export class HandleCommand {
 	}
 
 	checkPermissions(app: PermissionsBitField, bot: bigint) {
+		if (!app.has('Administrator')) return;
 		const permissions = app.missings(...app.values([bot]));
-		if (!app.has('Administrator') && permissions.length) {
+		if (permissions.length) {
 			return app.keys(permissions);
 		}
 		return;

--- a/src/commands/handle.ts
+++ b/src/commands/handle.ts
@@ -503,7 +503,8 @@ export class HandleCommand {
 	}
 
 	checkPermissions(app: PermissionsBitField, bot: bigint) {
-		if (!app.has('Administrator')) return;
+		if (app.has('Administrator')) return;
+
 		const permissions = app.missings(...app.values([bot]));
 		if (permissions.length) {
 			return app.keys(permissions);


### PR DESCRIPTION
This PR should improve code logic by avoiding an additional permissions calculation when app has `Administrator`