### PR TITLE
Overwritting permissions for child commands

### DIFF
--- a/src/commands/decorators.ts
+++ b/src/commands/decorators.ts
@@ -1,11 +1,11 @@
 import type { FlatObjectKeys, PermissionStrings } from '../common';
+import { PermissionsBitField } from '../structures/extra/Permissions';
 import {
 	ApplicationCommandType,
 	ApplicationIntegrationType,
 	type EntryPointCommandHandlerType,
 	InteractionContextType,
 	type LocaleString,
-	PermissionFlagsBits,
 } from '../types';
 import type { CommandOption, OptionsRecord, SubCommand } from './applications/chat';
 import type { DefaultLocale, ExtraProps, IgnoreCommand, MiddlewareContext } from './applications/shared';
@@ -159,11 +159,11 @@ export function Declare(declare: CommandDeclareOptions) {
 			integrationTypes = declare.integrationTypes?.map(i => ApplicationIntegrationType[i]) ?? [
 				ApplicationIntegrationType.GuildInstall,
 			];
-			defaultMemberPermissions = Array.isArray(declare.defaultMemberPermissions)
-				? declare.defaultMemberPermissions?.reduce((acc, prev) => acc | PermissionFlagsBits[prev], BigInt(0))
+			defaultMemberPermissions = declare.defaultMemberPermissions
+				? PermissionsBitField.resolve(declare.defaultMemberPermissions)
 				: declare.defaultMemberPermissions;
-			botPermissions = Array.isArray(declare.botPermissions)
-				? declare.botPermissions?.reduce((acc, prev) => acc | PermissionFlagsBits[prev], BigInt(0))
+			botPermissions = declare.botPermissions
+				? PermissionsBitField.resolve(declare.botPermissions)
 				: declare.botPermissions;
 			description = '';
 			type: ApplicationCommandType = ApplicationCommandType.ChatInput;

--- a/src/commands/handle.ts
+++ b/src/commands/handle.ts
@@ -169,10 +169,18 @@ export class HandleCommand {
 		resolver: OptionResolverStructure,
 		context: CommandContext,
 	) {
-		if (context.guildId && command.botPermissions && interaction.appPermissions) {
-			const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
-			if (permissions) return command.onBotPermissionsFail?.(context, permissions);
+		if (context.guildId && interaction.appPermissions) {
+			if (command.botPermissions) {
+				const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
+				if (permissions) return command.onBotPermissionsFail?.(context, permissions);
+			}
+
+			if (command.defaultMemberPermissions) {
+				const permissions = this.checkPermissions(interaction.member!.permissions, command.defaultMemberPermissions);
+				if (permissions) return command.onBotPermissionsFail?.(context, permissions);
+			}
 		}
+
 		if (!(await this.runOptions(command, context, resolver))) return;
 
 		const resultGlobal = await this.runGlobalMiddlewares(command, context);

--- a/src/commands/handle.ts
+++ b/src/commands/handle.ts
@@ -177,7 +177,7 @@ export class HandleCommand {
 
 			if (command.defaultMemberPermissions) {
 				const permissions = this.checkPermissions(interaction.member!.permissions, command.defaultMemberPermissions);
-				if (permissions) return command.onBotPermissionsFail?.(context, permissions);
+				if (permissions) return command.onPermissionsFail?.(context, permissions);
 			}
 		}
 

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -3,6 +3,7 @@ import { basename, dirname } from 'node:path';
 import type { EntryPointCommand } from '.';
 import type { Logger, MakeRequired, NulleableCoalising, OmitInsert } from '../common';
 import { BaseHandler, isCloudfareWorker } from '../common';
+import { PermissionsBitField } from '../structures/extra/Permissions';
 import {
 	type APIApplicationCommandChannelOption,
 	type APIApplicationCommandIntegerOption,
@@ -483,8 +484,14 @@ export class CommandHandler extends BaseHandler {
 			option.onPermissionsFail?.bind(option) ??
 			commandInstance.onPermissionsFail?.bind(commandInstance) ??
 			this.client.options.commands?.defaults?.onPermissionsFail;
-		option.botPermissions ??= commandInstance.botPermissions;
-		option.defaultMemberPermissions ??= commandInstance.defaultMemberPermissions;
+		option.botPermissions = PermissionsBitField.add(
+			option.botPermissions ?? PermissionsBitField.None,
+			commandInstance.botPermissions,
+		);
+		option.defaultMemberPermissions ??= PermissionsBitField.add(
+			option.defaultMemberPermissions ?? PermissionsBitField.None,
+			commandInstance.defaultMemberPermissions,
+		);
 		option.contexts ??= commandInstance.contexts;
 		option.integrationTypes ??= commandInstance.integrationTypes;
 		option.props ??= commandInstance.props;

--- a/src/structures/extra/Permissions.ts
+++ b/src/structures/extra/Permissions.ts
@@ -20,4 +20,13 @@ export class PermissionsBitField extends BitField<typeof PermissionFlagsBits> {
 	strictHas(...bits: BitFieldResolvable<typeof PermissionFlagsBits>[]) {
 		return super.has(...bits);
 	}
+
+	static resolve<T extends object = typeof PermissionFlagsBits>(bits: BitFieldResolvable<T>): bigint {
+		switch (typeof bits) {
+			case 'string':
+				return PermissionsBitField.resolve(PermissionFlagsBits[bits as keyof typeof PermissionFlagsBits]);
+			default:
+				return BitField.resolve(bits);
+		}
+	}
 }


### PR DESCRIPTION
For some reason, discord takes the permissions of the parent command to manage the permissions of the sub-commands or command groups, forcing a server side check of the user permissions that discord already calculates.