### PR TITLE
fix: update cache before executing the event?

### DIFF
--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -199,12 +199,6 @@ export class EventHandler extends BaseHandler {
 			await (Event.run as any)(hook, client, shardId);
 		} catch (e) {
 			await this.onFail(name, e);
-		} finally {
-			if (runCache)
-				await this.client.cache.onPacket({
-					t: name,
-					d: packet,
-				} as GatewayDispatchPayload);
 		}
 	}
 

--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -189,6 +189,13 @@ export class EventHandler extends BaseHandler {
 			}
 			Event.fired = true;
 			const hook = await RawEvents[name]?.(client, packet as never);
+
+			if (runCache)
+				await this.client.cache.onPacket({
+					t: name,
+					d: packet,
+				} as GatewayDispatchPayload);
+
 			await (Event.run as any)(hook, client, shardId);
 		} catch (e) {
 			await this.onFail(name, e);


### PR DESCRIPTION
A couple of days ago I noticed a strange behavior in the voiceStateUpdate event.

What was happening was this:

https://github.com/user-attachments/assets/12d422db-9611-4fb2-81b4-e8b84fda849a



And this is what is supposed to happen:

https://github.com/user-attachments/assets/91bd95d7-68bd-4ad3-8b3e-fdc9da7c1d0b

