### PR TITLE
fix: ban user id

### DIFF
--- a/src/structures/GuildBan.ts
+++ b/src/structures/GuildBan.ts
@@ -14,7 +14,8 @@ export class GuildBan extends DiscordBase {
 		data: APIBan,
 		readonly guildId: string,
 	) {
-		super(client, { ...data, id: data.user.id });
+		const id = 'user' in data ? data.user.id : (data as { id: string }).id;
+		super(client, { ...data, id });
 	}
 
 	create(body?: Parameters<BanShorter['create']>[2], reason?: string) {


### PR DESCRIPTION
For some reason, checking in the code, a "raw ban" is returned in a different way as seyfert expects.
![image](https://github.com/user-attachments/assets/50705c89-7089-4ff3-82c4-acc3a870d4f2)
![image](https://github.com/user-attachments/assets/a73d2408-bfdc-4469-b2a0-fb38f04ef2e7)

With this change, we make sure the 'id' is always present even if the 'user' object is presented.