### PR TITLE
fix: add error handling for undefined locale

### DIFF
--- a/src/langs/router.ts
+++ b/src/langs/router.ts
@@ -14,6 +14,7 @@ export const LangRouter = (userLocale: string, defaultLang: string, langs: Parti
 					function getValue(locale?: string) {
 						if (typeof locale === 'undefined') throw new Error('Undefined locale');
 						let value = langs[locale] as Record<string, any>;
+						if (typeof value === 'undefined') throw new Error(`Locale "${locale}" not found`);
 						for (const i of route) value = value[i];
 						return value;
 					}
@@ -51,4 +52,4 @@ export type __InternalParseLocale<T extends Record<string, any>> = {
 };
 
 export type ParseLocales<T extends Record<string, any>> = T;
-/**Idea inspiration from: FreeAoi */
+/**Idea inspiration from: FreeAoi | Fixed by: Drylozu */


### PR DESCRIPTION
When using the `ctx.t` proxy without any path (i.e., `ctx.t.get()`), as shown in the [documentation](https://www.seyfert.dev/guide/i18n/languages#using-translations-in-your-commands), it causes unexpected errors when the user's locale hasn't been configured in Seyfert.

This is because, when the route is empty (`[]`), the function returns `value` immediately after fetching it from `langs[locale]`. If the locale does not exist in `langs`, `value` becomes `undefined`—but since there’s no error thrown at that point, the function simply returns `undefined`. As a result, calling something like `const t = ctx.t.get()` leads to runtime errors down the line, because the returned value is not a valid translation object or function.

However, when calling a nested path like `ctx.t.some.property.get()`, the `route` is not empty (e.g., `['some', 'property']`), and the code proceeds to iterate over it:

```ts
for (const i of route) value = value[i];
```

In this case, if `value` is `undefined`, attempting to access a property (`value[i]`) throws an error, which is caught by the `try...catch` block. That fallback mechanism then correctly returns the default language instead.

To fix the issue for both scenarios, the following line was added:

```ts
if (typeof value === 'undefined') throw new Error(`Locale "${locale}" not found`);
```

This ensures that if the locale is missing, an error is thrown regardless of whether the route is empty or not—triggering the fallback to the default language in all cases. This change fully resolves the issue.
