### PR TITLE
feat: waitFor modals

### DIFF
--- a/src/builders/Modal.ts
+++ b/src/builders/Modal.ts
@@ -90,20 +90,17 @@ export class Modal<T extends ModalBuilderComponents = TextInput> {
 		return this;
 	}
 
-	waitFor(func: ModalSubmitCallback, timeout: number): this {
-		this.run(
-			interaction =>
-				new Promise(resolve => {
-					const timer = setTimeout(() => {
-						resolve(null);
-					}, timeout);
-					func(interaction).then((data: ModalSubmitInteraction) => {
-						clearTimeout(timer);
-						resolve(data);
-					});
-				}),
-		);
-		return this;
+	waitFor(timeout?: number): Promise<ModalSubmitInteraction<boolean> | null> {
+		return new Promise<ModalSubmitInteraction<boolean> | null>(res => {
+			this.run(interaction => {
+				res(interaction);
+			});
+			if (timeout && timeout > 0) {
+				setTimeout(() => {
+					res(null);
+				}, timeout);
+			}
+		});
 	}
 
 	/**

--- a/src/builders/Modal.ts
+++ b/src/builders/Modal.ts
@@ -1,5 +1,4 @@
 import type { RestOrArray } from '../common';
-import { ModalSubmitInteraction } from '../structures';
 import {
 	type APIActionRowComponent,
 	type APIModalInteractionResponseCallbackData,
@@ -88,19 +87,6 @@ export class Modal<T extends ModalBuilderComponents = TextInput> {
 	run(func: ModalSubmitCallback): this {
 		this.__exec = func;
 		return this;
-	}
-
-	waitFor(timeout?: number): Promise<ModalSubmitInteraction<boolean> | null> {
-		return new Promise<ModalSubmitInteraction<boolean> | null>(res => {
-			this.run(interaction => {
-				res(interaction);
-			});
-			if (timeout && timeout > 0) {
-				setTimeout(() => {
-					res(null);
-				}, timeout);
-			}
-		});
 	}
 
 	/**

--- a/src/builders/Modal.ts
+++ b/src/builders/Modal.ts
@@ -1,4 +1,5 @@
 import type { RestOrArray } from '../common';
+import { ModalSubmitInteraction } from '../structures';
 import {
 	type APIActionRowComponent,
 	type APIModalInteractionResponseCallbackData,
@@ -86,6 +87,22 @@ export class Modal<T extends ModalBuilderComponents = TextInput> {
 	 */
 	run(func: ModalSubmitCallback): this {
 		this.__exec = func;
+		return this;
+	}
+
+	waitFor(func: ModalSubmitCallback, timeout: number): this {
+		this.run(
+			interaction =>
+				new Promise(resolve => {
+					const timer = setTimeout(() => {
+						resolve(null);
+					}, timeout);
+					func(interaction).then((data: ModalSubmitInteraction) => {
+						clearTimeout(timer);
+						resolve(data);
+					});
+				}),
+		);
 		return this;
 	}
 

--- a/src/commands/applications/entrycontext.ts
+++ b/src/commands/applications/entrycontext.ts
@@ -12,10 +12,11 @@ import type {
 	MakeRequired,
 	MessageWebhookCreateBodyRequest,
 	ModalCreateBodyRequest,
+	ModalCreateOptions,
 	UnionToTuple,
 	When,
 } from '../../common';
-import type { AllChannels, EntryPointInteraction } from '../../structures';
+import type { AllChannels, EntryPointInteraction, ModalSubmitInteraction } from '../../structures';
 import { MessageFlags, type RESTGetAPIGuildQuery } from '../../types';
 import { BaseContext } from '../basecontext';
 import type { RegisteredMiddlewares } from '../decorators';
@@ -52,8 +53,11 @@ export class EntryPointContext<M extends keyof RegisteredMiddlewares = never> ex
 		return this.interaction.write<WR>(body, withResponse);
 	}
 
-	modal(body: ModalCreateBodyRequest) {
-		return this.interaction.modal(body);
+	modal(body: ModalCreateBodyRequest, options?: undefined): Promise<undefined>;
+	modal(body: ModalCreateBodyRequest, options: ModalCreateOptions): Promise<ModalSubmitInteraction | null>;
+	modal(body: ModalCreateBodyRequest, options?: ModalCreateOptions | undefined) {
+		if (options === undefined) return this.interaction.modal(body);
+		return this.interaction.modal(body, options);
 	}
 
 	deferReply<WR extends boolean = false>(

--- a/src/commands/applications/menucontext.ts
+++ b/src/commands/applications/menucontext.ts
@@ -8,16 +8,22 @@ import {
 	type WebhookMessageStructure,
 } from '../../client/transformers';
 import {
-	type InteractionCreateBodyRequest,
-	type InteractionMessageUpdateBodyRequest,
-	type MakeRequired,
-	type MessageWebhookCreateBodyRequest,
-	type ModalCreateBodyRequest,
+	InteractionCreateBodyRequest,
+	InteractionMessageUpdateBodyRequest,
+	MakeRequired,
+	MessageWebhookCreateBodyRequest,
+	ModalCreateBodyRequest,
+	ModalCreateOptions,
 	toSnakeCase,
-	type UnionToTuple,
-	type When,
+	UnionToTuple,
+	When,
 } from '../../common';
-import type { AllChannels, MessageCommandInteraction, UserCommandInteraction } from '../../structures';
+import {
+	AllChannels,
+	MessageCommandInteraction,
+	ModalSubmitInteraction,
+	UserCommandInteraction,
+} from '../../structures';
 import { type APIMessage, ApplicationCommandType, MessageFlags, type RESTGetAPIGuildQuery } from '../../types';
 import { BaseContext } from '../basecontext';
 import type { RegisteredMiddlewares } from '../decorators';
@@ -75,8 +81,11 @@ export class MenuCommandContext<
 		return this.interaction.write<WR>(body, withResponse);
 	}
 
-	modal(body: ModalCreateBodyRequest) {
-		return this.interaction.modal(body);
+	modal(body: ModalCreateBodyRequest, options?: undefined): Promise<undefined>;
+	modal(body: ModalCreateBodyRequest, options: ModalCreateOptions): Promise<ModalSubmitInteraction | null>;
+	modal(body: ModalCreateBodyRequest, options?: ModalCreateOptions | undefined) {
+		if (options === undefined) return this.interaction.modal(body);
+		return this.interaction.modal(body, options);
 	}
 
 	deferReply<WR extends boolean = false>(

--- a/src/common/types/write.ts
+++ b/src/common/types/write.ts
@@ -70,3 +70,7 @@ export type InteractionCreateBodyRequest = OmitInsert<
 >;
 
 export type ModalCreateBodyRequest = APIModalInteractionResponse['data'] | Modal;
+
+export interface ModalCreateOptions {
+	waitFor?: number;
+}

--- a/src/components/componentcontext.ts
+++ b/src/components/componentcontext.ts
@@ -18,16 +18,18 @@ import type {
 } from '../client/transformers';
 import type { CommandMetadata, ExtendContext, GlobalMetadata, RegisteredMiddlewares, UsingClient } from '../commands';
 import { BaseContext } from '../commands/basecontext';
-import type {
+import {
 	ComponentInteractionMessageUpdate,
 	InteractionCreateBodyRequest,
 	InteractionMessageUpdateBodyRequest,
 	MakeRequired,
 	MessageWebhookCreateBodyRequest,
 	ModalCreateBodyRequest,
+	ModalCreateOptions,
 	UnionToTuple,
 	When,
 } from '../common';
+import { ModalSubmitInteraction } from '../structures';
 import { ComponentType, MessageFlags, type RESTGetAPIGuildQuery } from '../types';
 
 export interface ComponentContext<
@@ -150,8 +152,11 @@ export class ComponentContext<
 		return this.interaction.deleteResponse();
 	}
 
-	modal(body: ModalCreateBodyRequest) {
-		return this.interaction.modal(body);
+	modal(body: ModalCreateBodyRequest, options?: undefined): Promise<undefined>;
+	modal(body: ModalCreateBodyRequest, options: ModalCreateOptions): Promise<ModalSubmitInteraction | null>;
+	modal(body: ModalCreateBodyRequest, options?: ModalCreateOptions | undefined) {
+		if (options === undefined) return this.interaction.modal(body);
+		return this.interaction.modal(body, options);
 	}
 
 	/**

--- a/src/components/modalcontext.ts
+++ b/src/components/modalcontext.ts
@@ -1,4 +1,4 @@
-import type { AllChannels, Interaction, ModalCommand, ModalSubmitInteraction, ReturnCache } from '..';
+import type { AllChannels, ModalCommand, ModalSubmitInteraction, ReturnCache } from '..';
 import type {
 	GuildMemberStructure,
 	GuildStructure,
@@ -8,12 +8,13 @@ import type {
 } from '../client/transformers';
 import type { CommandMetadata, ExtendContext, GlobalMetadata, RegisteredMiddlewares, UsingClient } from '../commands';
 import { BaseContext } from '../commands/basecontext';
-import type {
+import {
 	InteractionCreateBodyRequest,
 	InteractionMessageUpdateBodyRequest,
 	MakeRequired,
 	MessageWebhookCreateBodyRequest,
 	ModalCreateBodyRequest,
+	ModalCreateOptions,
 	UnionToTuple,
 	When,
 } from '../common';
@@ -119,9 +120,11 @@ export class ModalContext<M extends keyof RegisteredMiddlewares = never> extends
 		return this.interaction.deleteResponse();
 	}
 
-	modal(body: ModalCreateBodyRequest): ReturnType<Interaction['modal']> {
-		//@ts-expect-error
-		return this.interaction.modal(body);
+	modal(body: ModalCreateBodyRequest, options?: undefined): Promise<undefined>;
+	modal(body: ModalCreateBodyRequest, options: ModalCreateOptions): Promise<ModalSubmitInteraction | null>;
+	modal(body: ModalCreateBodyRequest, options?: ModalCreateOptions | undefined) {
+		// @ts-expect-error
+		return this.interaction.modal(body, options);
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces a new `ModalCreateOptions` interface to enhance the functionality of the `modal` method across various contexts. It allows developers to specify options such as a timeout for waiting on modal submissions.