### PR TITLE
fix: modal input value

### DIFF
--- a/src/structures/Interaction.ts
+++ b/src/structures/Interaction.ts
@@ -864,13 +864,11 @@ export class ModalSubmitInteraction<FromGuild extends boolean = boolean> extends
 	getInputValue(customId: string, required?: false): string | string[] | undefined;
 	getInputValue(customId: string, required?: boolean): string | string[] | undefined {
 		let value: string | string[] | undefined;
-		for (const { components } of this.components) {
-			const get = components.find(x => x.customId === customId);
-			if (get) {
-				value = get.value ?? get.values;
-				break;
-			}
+		const get = this.components.find(x => x.component.customId === customId);
+		if (get) {
+			value = get.component.value ?? get.component.values;
 		}
+
 		if ((!value || value.length === 0) && required) throw new Error(`${customId} component doesn't have a value`);
 		return value;
 	}

--- a/src/types/payloads/_interactions/modalSubmit.ts
+++ b/src/types/payloads/_interactions/modalSubmit.ts
@@ -17,7 +17,7 @@ export interface ModalSubmitComponent {
 
 export interface ModalSubmitActionRowComponent
 	extends Omit<APIActionRowComponent<APIModalActionRowComponent>, 'components'> {
-	components: ModalSubmitComponent[];
+	component: ModalSubmitComponent;
 }
 
 /**


### PR DESCRIPTION
The discord api docs say one thing:

<img width="1212" height="216" alt="image" src="https://github.com/user-attachments/assets/e85167b0-547b-486a-89e2-ec765a4f16f6" />
<img width="1224" height="275" alt="image" src="https://github.com/user-attachments/assets/f9e8ef58-c23e-412f-8854-5881fae8cb6b" />

But the api returns other thing:
<img width="559" height="171" alt="image" src="https://github.com/user-attachments/assets/47d3de50-db2b-4862-9997-25d5b45cd1da" />
<img width="836" height="398" alt="image" src="https://github.com/user-attachments/assets/5d97e497-a761-4752-a311-7baa26630d8f" />

