### PR TITLE
feat(cache): add default limits for LimitedMemoryAdapter resources

### DIFF
--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { ApiHandler } from '../api';
 import { isBufferLike } from '../api/utils/utils';
 import type { Adapter, DisabledCache } from '../cache';
-import { Cache, MemoryAdapter } from '../cache';
+import { Cache, LimitedMemoryAdapter } from '../cache';
 import type {
 	Command,
 	CommandContext,
@@ -24,6 +24,7 @@ import {
 	ApplicationShorter,
 	assertString,
 	ChannelShorter,
+	defaultCacheSettings,
 	EmojiShorter,
 	filterSplit,
 	GuildShorter,
@@ -65,7 +66,7 @@ import type { MessageStructure } from './transformers';
 
 export class BaseClient {
 	rest = new ApiHandler({ token: 'INVALID' });
-	cache = new Cache(0, new MemoryAdapter(), {}, this);
+	cache = new Cache(0, new LimitedMemoryAdapter(defaultCacheSettings), {}, this);
 
 	applications = new ApplicationShorter(this);
 	users = new UsersShorter(this);

--- a/src/common/it/constants.ts
+++ b/src/common/it/constants.ts
@@ -1,3 +1,5 @@
+import type { LimitedMemoryAdapterOptions } from '../..';
+
 export enum EmbedColors {
 	Default = 0x000000,
 	White = 0xffffff,
@@ -40,3 +42,39 @@ export const BASE_URL = `${BASE_HOST}/api`;
 export const CDN_URL = 'https://cdn.discordapp.com';
 
 export const INTEGER_OPTION_VALUE_LIMIT = 2 ** 53;
+
+export const defaultCacheSettings: LimitedMemoryAdapterOptions<any> = {
+	ban: {
+		limit: 100,
+	},
+	member: {
+		limit: 200,
+	},
+	voice_state: {
+		limit: 50,
+	},
+	channel: {
+		limit: 200,
+	},
+	emoji: {
+		limit: 500,
+	},
+	presence: {
+		limit: 100,
+	},
+	role: {
+		limit: 200,
+	},
+	stage_instance: {
+		limit: 10,
+	},
+	sticker: {
+		limit: 60,
+	},
+	overwrite: {
+		limit: 100,
+	},
+	message: {
+		limit: 50,
+	},
+};


### PR DESCRIPTION
## Summary

- Add `defaultCacheSettings` with sensible per-resource limits for `LimitedMemoryAdapter`
- Limits are scoped per guild/channel depending on the resource (e.g. messages are per channel, members per guild)
- Accounts for boost-scaled resources (emojis: 500, stickers: 60)