### PR TITLE
fix: stabilize ApiHandler retries and timeouts

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -57,6 +57,7 @@ export class ApiHandler {
 		this.options = {
 			baseUrl: 'api/v10',
 			domain: BASE_HOST,
+			requestTimeout: 15_000,
 			type: 'Bot',
 			...options,
 			userAgent: DefaultUserAgent,
@@ -169,8 +170,9 @@ export class ApiHandler {
 				requestOptions: { auth, ...request },
 			});
 		}
-		const route = request.route || this.routefy(url, method);
-		let attempts = 0;
+		const requestOptions = { auth, ...request };
+		const route = requestOptions.route || this.routefy(url, method);
+		const retryCount = request.retryCount ?? 0;
 
 		const callback = async (next: () => void, resolve: (data: any) => void, reject: (err: unknown) => void) => {
 			const headers = {
@@ -180,25 +182,27 @@ export class ApiHandler {
 			const { data, finalUrl } = this.parseRequest({
 				url,
 				headers,
-				request: { ...request, auth },
+				request: requestOptions,
 			});
 
 			let response: Response;
 
 			try {
+				const signal = this.options.requestTimeout > 0 ? AbortSignal.timeout(this.options.requestTimeout) : undefined;
 				const requestUrl = `${this.options.domain}/${this.options.baseUrl}${finalUrl}`;
 				this.debugger?.debug(`Sending, Method: ${method} | Url: [${finalUrl}](${route}) | Auth: ${auth}`);
 				response = await fetch(requestUrl, {
 					method,
 					headers,
 					body: data,
+					signal,
 				});
 				this.debugger?.debug(`Received response: ${response.statusText}(${response.status})`);
 			} catch (err) {
 				this.debugger?.debug('Fetch error', err);
-				await this.notifyFailRequest(method, finalUrl, err);
 				next();
 				reject(err);
+				void this.notifyFailRequest(method, finalUrl, err);
 				return;
 			}
 
@@ -212,14 +216,28 @@ export class ApiHandler {
 
 			if (response.status >= 300) {
 				if (response.status === 429) {
-					const result429 = await this.handle429(route, method, url, request, response, result, next, reject, now);
+					const result429 = await this.handle429(
+						route,
+						method,
+						url,
+						requestOptions,
+						response,
+						result,
+						next,
+						reject,
+						now,
+					);
 					if (result429 !== false) return resolve(result429);
-					await this.notifyFailRequest(method, finalUrl, result, response.status);
+					void this.notifyFailRequest(method, finalUrl, result, response.status);
 					return this.clearResetInterval(route);
 				}
-				if ([502, 503].includes(response.status) && ++attempts < 4) {
+				if ([502, 503].includes(response.status) && retryCount < 3) {
 					this.clearResetInterval(route);
-					return this.handle50X(method, url, request, next);
+					void this.handle50X(method, url, { ...requestOptions, retryCount: retryCount + 1 }, next).then(
+						resolve,
+						reject,
+					);
+					return;
 				}
 				this.clearResetInterval(route);
 				next();
@@ -229,16 +247,16 @@ export class ApiHandler {
 							result = JSON.parse(result);
 						} catch (err) {
 							this.debugger?.warn('SeyfertError parsing result error (', result, ')', err);
-							await this.notifyFailRequest(method, finalUrl, err, response.status);
 							reject(err);
+							void this.notifyFailRequest(method, finalUrl, err, response.status);
 							return;
 						}
 					}
 				}
 				const parsedError = this.parseError(method, route, response, result, originTrace);
 				this.debugger?.warn(parsedError.message);
-				await this.notifyFailRequest(method, finalUrl, parsedError, response.status);
 				reject(parsedError);
+				void this.notifyFailRequest(method, finalUrl, parsedError, response.status);
 				return;
 			}
 
@@ -248,17 +266,18 @@ export class ApiHandler {
 						result = JSON.parse(result);
 					} catch (err) {
 						this.debugger?.warn('Failed parsing result (', result, ')', err);
-						await this.notifyFailRequest(method, finalUrl, err, response.status);
 						next();
 						reject(err);
+						void this.notifyFailRequest(method, finalUrl, err, response.status);
 						return;
 					}
 				}
 			}
 
-			await this.notifySuccessRequest(method, finalUrl, response);
 			next();
-			return resolve(result || undefined);
+			resolve(result || undefined);
+			void this.notifySuccessRequest(method, finalUrl, response);
+			return;
 		};
 
 		return new Promise((resolve, reject) => {
@@ -353,13 +372,7 @@ export class ApiHandler {
 		this.debugger?.warn(`Handling a 50X status, retrying in ${wait}ms`);
 		next();
 		await delay(wait);
-		return this.request(method, url, {
-			body: request.body,
-			auth: request.auth,
-			reason: request.reason,
-			route: request.route,
-			unshift: true,
-		});
+		return this.request(method, url, { ...request, unshift: true });
 	}
 
 	async handle429(
@@ -412,22 +425,10 @@ export class ApiHandler {
 		if (retryAfter) {
 			await delay(retryAfter);
 			next();
-			return this.request(method, url, {
-				body: request.body,
-				auth: request.auth,
-				reason: request.reason,
-				route: request.route,
-				unshift: true,
-			});
+			return this.request(method, url, { ...request, unshift: true });
 		}
 		next();
-		return this.request(method, url, {
-			body: request.body,
-			auth: request.auth,
-			reason: request.reason,
-			route: request.route,
-			unshift: true,
-		});
+		return this.request(method, url, { ...request, unshift: true });
 	}
 
 	clearResetInterval(route: string) {

--- a/src/api/shared.ts
+++ b/src/api/shared.ts
@@ -11,6 +11,7 @@ export interface ApiHandlerOptions {
 	token: string;
 	debug?: boolean;
 	agent?: string;
+	requestTimeout?: number;
 	smartBucket?: boolean;
 	workerProxy?: boolean;
 	type?: 'Bearer' | 'Bot';
@@ -18,6 +19,7 @@ export interface ApiHandlerOptions {
 
 export interface ApiHandlerInternalOptions extends MakeRequired<ApiHandlerOptions, 'baseUrl' | 'domain' | 'type'> {
 	userAgent: string;
+	requestTimeout: number;
 }
 
 export interface RawFile {
@@ -37,6 +39,8 @@ export interface ApiRequestOptions {
 	unshift?: boolean;
 	appendToFormData?: boolean;
 	token?: string;
+	/** @internal */
+	retryCount?: number;
 }
 
 export type HttpMethods = 'GET' | 'DELETE' | 'PUT' | 'POST' | 'PATCH';

--- a/tests/api.test.mts
+++ b/tests/api.test.mts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiHandler } from '../src/api/api';
+
+type PromiseOutcome<T> =
+	| { status: 'resolved'; value: T }
+	| { status: 'rejected'; error: unknown }
+	| { status: 'pending' };
+
+const ratelimitHeaders = {
+	'content-type': 'application/json',
+	'x-ratelimit-limit': '1',
+	'x-ratelimit-remaining': '1',
+};
+
+function createJsonResponse(status: number, body: unknown) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: ratelimitHeaders,
+	});
+}
+
+function createTextResponse(status: number, body: string) {
+	return new Response(body, {
+		status,
+		headers: {
+			...ratelimitHeaders,
+			'content-type': 'text/plain',
+		},
+	});
+}
+
+async function observeWithin<T>(promise: Promise<T>, ms: number): Promise<PromiseOutcome<T>> {
+	const tracked = promise.then<PromiseOutcome<T>>(
+		value => ({ status: 'resolved', value }),
+		error => ({ status: 'rejected', error }),
+	);
+	const pending = new Promise<PromiseOutcome<T>>(resolve => {
+		setTimeout(() => resolve({ status: 'pending' }), ms);
+	});
+
+	const outcome = Promise.race([tracked, pending]);
+	await vi.advanceTimersByTimeAsync(ms);
+	return outcome;
+}
+
+function observeWithinReal<T>(promise: Promise<T>, ms: number): Promise<PromiseOutcome<T>> {
+	const tracked = promise.then<PromiseOutcome<T>>(
+		value => ({ status: 'resolved', value }),
+		error => ({ status: 'rejected', error }),
+	);
+	const pending = new Promise<PromiseOutcome<T>>(resolve => {
+		setTimeout(() => resolve({ status: 'pending' }), ms);
+	});
+
+	return Promise.race([tracked, pending]);
+}
+
+describe('ApiHandler', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('recovers the route bucket after a timed out fetch', async () => {
+		vi.useRealTimers();
+
+		let calls = 0;
+		const fetchMock = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+			calls++;
+			if (calls === 1) {
+				return new Promise<Response>((_resolve, reject) => {
+					const signal = init?.signal;
+					if (!signal) return;
+
+					if (signal.aborted) {
+						reject(signal.reason);
+						return;
+					}
+
+					signal.addEventListener(
+						'abort',
+						() => reject(signal.reason ?? new DOMException('Request timed out', 'TimeoutError')),
+						{ once: true },
+					);
+				});
+			}
+
+			return Promise.resolve(createJsonResponse(200, { ok: true }));
+		});
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		const api = new ApiHandler({
+			token: 'token',
+			requestTimeout: 50,
+		});
+
+		void api.request('POST', '/interactions/1/token/callback').catch(() => undefined);
+		const secondRequest = api.request('POST', '/interactions/1/token/callback');
+
+		await expect(observeWithinReal(secondRequest, 80)).resolves.toEqual({
+			status: 'resolved',
+			value: { ok: true },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('resolves the original request after 50X retries succeed', async () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createTextResponse(502, 'bad gateway'))
+			.mockResolvedValueOnce(createTextResponse(503, 'service unavailable'))
+			.mockResolvedValueOnce(createJsonResponse(200, { ok: true }));
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		const api = new ApiHandler({ token: 'token' });
+		const request = api.request('POST', '/channels/123/messages', {
+			body: { content: 'hello' },
+		});
+
+		await expect(observeWithin(request, 250)).resolves.toEqual({
+			status: 'resolved',
+			value: { ok: true },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it('rejects after the maximum number of 50X retries and unblocks the bucket', async () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createTextResponse(502, 'bad gateway'))
+			.mockResolvedValueOnce(createTextResponse(502, 'bad gateway'))
+			.mockResolvedValueOnce(createTextResponse(503, 'service unavailable'))
+			.mockResolvedValueOnce(createTextResponse(502, 'still bad'))
+			.mockResolvedValueOnce(createJsonResponse(200, { ok: true }));
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		const api = new ApiHandler({ token: 'token' });
+		const failedRequest = api.request('POST', '/channels/123/messages', {
+			body: { content: 'retry me' },
+		});
+
+		await expect(observeWithin(failedRequest, 350)).resolves.toMatchObject({
+			status: 'rejected',
+		});
+		const followUpRequest = api.request('POST', '/channels/123/messages', {
+			body: { content: 'next' },
+		});
+		await expect(observeWithin(followUpRequest, 10)).resolves.toEqual({
+			status: 'resolved',
+			value: { ok: true },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(5);
+	});
+
+	it('does not block the bucket while onFailRequest is still running', async () => {
+		const fetchMock = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('socket hang up'))
+			.mockResolvedValueOnce(createJsonResponse(200, { ok: true }));
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		const api = new ApiHandler({ token: 'token' });
+		api.onFailRequest = () => new Promise(resolve => setTimeout(resolve, 500));
+
+		void api.request('GET', '/channels/123').catch(() => undefined);
+		const secondRequest = api.request('GET', '/channels/123');
+
+		await expect(observeWithin(secondRequest, 10)).resolves.toEqual({
+			status: 'resolved',
+			value: { ok: true },
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
This PR stabilizes the ApiHandler by introducing explicit fetch() timeouts via AbortSignal.timeout and fixing broken retry logic for 502/503 errors. It also ensures that onFailRequest and onSuccessRequest callbacks do not block the request bucket. These changes prevent interaction stalls and "hanging" requests, especially under Bun, by ensuring faster recovery and proper bucket slot release during network failures.