### PR TITLE
Improve cache adapters, message/user caching and overwrite handling; refactor shorters

### DIFF
--- a/src/cache/adapters/default.ts
+++ b/src/cache/adapters/default.ts
@@ -89,7 +89,7 @@ export class MemoryAdapter<T> implements Adapter {
 		for (const key of data) {
 			const content = this.get(key);
 
-			if (content) {
+			if (content !== undefined && content !== null) {
 				array.push(content);
 			}
 		}

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -1,7 +1,18 @@
 import { LimitedCollection } from '../..';
 import { type MakeRequired, MergeOptions } from '../../common';
 import type { Adapter } from './types';
-//TODO: optimizar esto
+
+const namespaceIndexedResources = new Set([
+	'channel',
+	'emoji',
+	'presence',
+	'role',
+	'stage_instance',
+	'sticker',
+	'overwrite',
+	'message',
+]);
+const scopeDerivedResources = new Set(['ban', 'member', 'voice_state']);
 export interface ResourceLimitedMemoryAdapter {
 	expire?: number;
 	limit?: number;
@@ -108,19 +119,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	private _supportsNamespaceIndex(resource: string) {
-		switch (resource) {
-			case 'channel':
-			case 'emoji':
-			case 'presence':
-			case 'role':
-			case 'stage_instance':
-			case 'sticker':
-			case 'overwrite':
-			case 'message':
-				return true;
-			default:
-				return false;
-		}
+		return namespaceIndexedResources.has(resource);
 	}
 
 	private _setIndexedStorage(resource: string, key: string, storageEntry: LimitedCollection<string, T>) {
@@ -145,14 +144,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	private _getDerivedNamespace(resource: string, scope: string) {
-		switch (resource) {
-			case 'ban':
-			case 'member':
-			case 'voice_state':
-				return scope ? `${resource}.${scope}` : resource;
-			default:
-				return resource;
-		}
+		return scope && scopeDerivedResources.has(resource) ? `${resource}.${scope}` : resource;
 	}
 
 	private _isResourceNamespace(resource: string, namespace: string) {
@@ -342,15 +334,20 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	keys(to: string) {
+		const relationship = this._getRelationshipSet(to);
+		if (!relationship) {
+			return [];
+		}
+
 		const result: string[] = [];
-		for (const id of this._getRelationshipSet(to)) {
+		for (const id of relationship) {
 			result.push(`${to}.${id}`);
 		}
 		return result;
 	}
 
 	count(to: string) {
-		return this._getRelationshipSet(to).size;
+		return this._getRelationshipSet(to)?.size ?? 0;
 	}
 
 	bulkRemove(keys: string[]) {
@@ -382,7 +379,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	contains(to: string, keys: string): boolean {
-		return this._getRelationshipSet(to).has(keys);
+		return this._getRelationshipSet(to)?.has(keys) ?? false;
 	}
 
 	private _getRelationshipData(to: string) {
@@ -392,16 +389,28 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 	private _getRelationshipSet(to: string) {
 		const { key, subrelationKey } = this._getRelationshipData(to);
-		if (!this.relationships.has(key)) this.relationships.set(key, new Map<string, Set<string>>());
-		const relation = this.relationships.get(key)!;
-		if (!relation.has(subrelationKey)) {
-			relation.set(subrelationKey, new Set<string>());
+		return this.relationships.get(key)?.get(subrelationKey);
+	}
+
+	private _ensureRelationshipSet(to: string) {
+		const { key, subrelationKey } = this._getRelationshipData(to);
+		let relation = this.relationships.get(key);
+		if (!relation) {
+			relation = new Map<string, Set<string>>();
+			this.relationships.set(key, relation);
 		}
-		return relation.get(subrelationKey)!;
+
+		let values = relation.get(subrelationKey);
+		if (!values) {
+			values = new Set<string>();
+			relation.set(subrelationKey, values);
+		}
+
+		return values;
 	}
 
 	getToRelationship(to: string): string[] {
-		return [...this._getRelationshipSet(to)];
+		return [...(this._getRelationshipSet(to) ?? [])];
 	}
 
 	bulkAddToRelationShip(data: Record<string, string[]>) {
@@ -411,7 +420,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	addToRelationship(to: string, keys: string | string[]) {
-		const data = this._getRelationshipSet(to);
+		const data = this._ensureRelationshipSet(to);
 
 		for (const key of Array.isArray(keys) ? keys : [keys]) {
 			data.add(key);
@@ -420,8 +429,19 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 	removeToRelationship(to: string, keys: string | string[]) {
 		const data = this._getRelationshipSet(to);
+		if (!data) {
+			return;
+		}
+
 		for (const key of Array.isArray(keys) ? keys : [keys]) {
 			data.delete(key);
+		}
+
+		if (!data.size) {
+			const { key, subrelationKey } = this._getRelationshipData(to);
+			const relation = this.relationships.get(key);
+			relation?.delete(subrelationKey);
+			if (relation && !relation.size) this.relationships.delete(key);
 		}
 	}
 

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -340,6 +340,14 @@ export class Cache {
 						if (type !== 'overwrites' && type !== 'messages') {
 							data.guild_id = guildId;
 						}
+						if (type === 'messages' && data?.author?.id && this.users?.filter(data.author, data.author.id, from)) {
+							const userHashId = this.users.namespace;
+							if (!(userHashId in relationshipsData)) {
+								relationshipsData[userHashId] = [];
+							}
+							relationshipsData[userHashId].push(data.author.id);
+							allData.push([this.users.hashId(data.author.id), data.author]);
+						}
 						allData.push([this[type]!.hashId(id), this[type]!.parse(data, id, guildId!)]);
 					}
 					break;
@@ -431,6 +439,14 @@ export class Cache {
 						relationshipsData[hashId].push(id);
 						if (type !== 'overwrites' && type !== 'messages') {
 							data.guild_id = guildId;
+						}
+						if (type === 'messages' && data?.author?.id && this.users?.filter(data.author, data.author.id, from)) {
+							const userHashId = this.users.namespace;
+							if (!(userHashId in relationshipsData)) {
+								relationshipsData[userHashId] = [];
+							}
+							relationshipsData[userHashId].push(data.author.id);
+							allData.push([this.users.hashId(data.author.id), data.author]);
 						}
 						allData.push([this[type]!.hashId(id), this[type]!.parse(data, id, guildId!)]);
 					}

--- a/src/cache/resources/messages.ts
+++ b/src/cache/resources/messages.ts
@@ -36,19 +36,21 @@ export class Messages extends GuildRelatedResource<any, APIMessage> {
 	}
 
 	override bulk(ids: string[]): ReturnCache<MessageStructure[]> {
-		return fakePromise(super.bulk(ids) as APIMessageResource[]).then(messages =>
-			messages
-				.map(rawMessage => {
-					return this.cache.users && rawMessage?.user_id
-						? fakePromise(
-								this.cache.adapter.get(this.cache.users.hashId(rawMessage.user_id)) as APIUser | undefined,
-							).then(user => {
-								return user ? Transformers.Message(this.client, { ...rawMessage, author: user }) : undefined;
-							})
-						: undefined;
-				})
-				.filter(x => x !== undefined),
-		);
+		return fakePromise(super.bulk(ids) as APIMessageResource[]).then(messages => {
+			const userHashes = this.cache.users
+				? messages.flatMap(message => (message.user_id ? [this.cache.users!.hashId(message.user_id)] : []))
+				: [];
+
+			return fakePromise(this.cache.adapter.bulkGet(userHashes) as APIUser[]).then(users => {
+				const usersById = new Map(users.map(user => [user.id, user]));
+				return messages
+					.map(message => {
+						const user = message.user_id ? usersById.get(message.user_id) : undefined;
+						return user ? Transformers.Message(this.client, { ...message, author: user }) : undefined;
+					})
+					.filter((message): message is MessageStructure => message !== undefined);
+			});
+		});
 	}
 
 	bulkRaw(ids: string[]): ReturnCache<APIMessageResource[]> {
@@ -61,12 +63,13 @@ export class Messages extends GuildRelatedResource<any, APIMessage> {
 				? messages.map(x => (x.user_id ? this.cache.users?.hashId(x.user_id) : undefined))
 				: [];
 			return fakePromise(this.cache.adapter.bulkGet(hashes.filter(x => x !== undefined)) as APIUser[]).then(users => {
+				const usersById = new Map(users.map(user => [user.id, user]));
 				return messages
 					.map(message => {
-						const user = users.find(user => user.id === message.user_id);
+						const user = message.user_id ? usersById.get(message.user_id) : undefined;
 						return user ? Transformers.Message(this.client, { ...message, author: user }) : undefined;
 					})
-					.filter(x => x !== undefined);
+					.filter((message): message is MessageStructure => message !== undefined);
 			});
 		});
 	}
@@ -77,6 +80,24 @@ export class Messages extends GuildRelatedResource<any, APIMessage> {
 
 	keys(channel: string) {
 		return super.keys(channel);
+	}
+
+	private _buildCacheEntries(from: CacheFrom, keys: [string, any][], channelId: string) {
+		return keys.map(([id, value]) => [from, 'messages', value, id, channelId] as const);
+	}
+
+	override async set(from: CacheFrom, messageId: string, channelId: string, data: any): Promise<void>;
+	override async set(from: CacheFrom, messageDataArray: [string, any][], channelId: string): Promise<void>;
+	override async set(from: CacheFrom, __keys: string | [string, any][], channelId: string, data?: any) {
+		const keys: [string, any][] = Array.isArray(__keys) ? __keys : [[__keys, data]];
+		await this.cache.bulkSet(this._buildCacheEntries(from, keys, channelId));
+	}
+
+	override async patch(from: CacheFrom, messageId: string, channelId: string, data: any): Promise<void>;
+	override async patch(from: CacheFrom, messageDataArray: [string, any][], channelId: string): Promise<void>;
+	override async patch(from: CacheFrom, __keys: string | [string, any][], channelId: string, data?: any) {
+		const keys: [string, any][] = Array.isArray(__keys) ? __keys : [[__keys, data]];
+		await this.cache.bulkPatch(this._buildCacheEntries(from, keys, channelId));
 	}
 }
 

--- a/src/cache/resources/overwrites.ts
+++ b/src/cache/resources/overwrites.ts
@@ -13,10 +13,7 @@ export class Overwrites extends GuildRelatedResource<any, APIOverwrite[]> {
 	}
 
 	parse(data: any[], _id: string, guild_id: string) {
-		data.forEach(x => {
-			x.guild_id = guild_id;
-		});
-		return data;
+		return data.map(x => ({ ...x, guild_id }));
 	}
 
 	raw(id: string): ReturnCache<(APIOverwrite & { guild_id: string })[] | undefined> {

--- a/src/common/shorters/application.ts
+++ b/src/common/shorters/application.ts
@@ -80,8 +80,9 @@ export class ApplicationShorter extends BaseShorter {
 	 * Deletes an emoji for the application.
 	 * @param emojiId The ID of the emoji.
 	 */
-	deleteEmoji(emojiId: string) {
-		return this.client.proxy.applications(this.client.applicationId).emojis(emojiId).delete();
+	async deleteEmoji(emojiId: string) {
+		await this.client.proxy.applications(this.client.applicationId).emojis(emojiId).delete();
+		await this.client.cache.emojis?.remove(emojiId, this.client.applicationId);
 	}
 
 	/**

--- a/src/common/shorters/channels.ts
+++ b/src/common/shorters/channels.ts
@@ -5,14 +5,13 @@ import { type AllChannels, BaseChannel, channelFrom, type GuildMember, type Guil
 import { PermissionsBitField } from '../../structures/extra/Permissions';
 import type {
 	APIChannel,
-	APIGuildChannel,
 	APIOverwrite,
 	RESTGetAPIChannelMessagesPinsQuery,
 	RESTGetAPIChannelMessagesQuery,
 	RESTPatchAPIChannelJSONBody,
 	RESTPutAPIChannelPermissionJSONBody,
 } from '../../types';
-import { type ChannelType, PermissionFlagsBits } from '../../types';
+import { PermissionFlagsBits } from '../../types';
 import { MergeOptions } from '../it/utils';
 import type { MakeRequired, OmitInsert, PermissionStrings } from '../types/util';
 import type { ThreadCreateBodyRequest } from '../types/write';
@@ -34,8 +33,9 @@ export class ChannelShorter extends BaseShorter {
 			const channel = await this.client.cache.channels?.raw(id);
 			if (channel) {
 				const overwrites = await this.client.cache.overwrites?.raw(id);
-				if (overwrites) (channel as APIGuildChannel<ChannelType>).permission_overwrites = overwrites;
-				return channel as APIChannel;
+				return overwrites
+					? ({ ...channel, permission_overwrites: overwrites } as unknown as APIChannel)
+					: (channel as APIChannel);
 			}
 		}
 

--- a/src/common/shorters/emojis.ts
+++ b/src/common/shorters/emojis.ts
@@ -60,6 +60,7 @@ export class EmojiShorter extends BaseShorter {
 			if (emoji) return emoji;
 		}
 		const emoji = await this.client.proxy.guilds(guildId).emojis(emojiId).get();
+		await this.client.cache.emojis?.set(CacheFrom.Rest, emoji.id!, guildId, emoji);
 		return Transformers.GuildEmoji(this.client, emoji, guildId);
 	}
 

--- a/src/common/shorters/guilds.ts
+++ b/src/common/shorters/guilds.ts
@@ -1,6 +1,5 @@
 import { resolveFiles } from '../../builders';
 import { CacheFrom } from '../../cache';
-import type { Channels } from '../../cache/resources/channels';
 import {
 	type AnonymousGuildStructure,
 	type AutoModerationRuleStructure,
@@ -20,7 +19,6 @@ import {
 } from '../../structures';
 import type {
 	APIChannel,
-	APISticker,
 	GuildWidgetStyle,
 	RESTGetAPICurrentUserGuildsQuery,
 	RESTGetAPIGuildMessagesSearch,
@@ -33,6 +31,7 @@ import type {
 	RESTPatchAPIGuildJSONBody,
 	RESTPatchAPIGuildStickerJSONBody,
 	RESTPostAPIAutoModerationRuleJSONBody,
+	RESTPostAPIChannelFollowersResult,
 	RESTPostAPIGuildChannelJSONBody,
 } from '../../types';
 import type { APITextChannel } from '../../types/payloads/channel';
@@ -169,14 +168,14 @@ export class GuildShorter extends BaseShorter {
 		 * @returns A Promise that resolves to an array of channels.
 		 */
 		list: async (guildId: string, force = false): Promise<AllChannels[]> => {
-			let channels: ReturnType<Channels['values']> | APIChannel[];
 			if (!force) {
-				channels = (await this.client.cache.channels?.values(guildId)) ?? [];
-				if (channels.length) {
-					return channels;
+				const cachedChannels = (await this.client.cache.channels?.values(guildId)) ?? [];
+				if (cachedChannels.length) {
+					return cachedChannels;
 				}
 			}
-			channels = await this.client.proxy.guilds(guildId).channels.get();
+
+			const channels = await this.client.proxy.guilds(guildId).channels.get();
 			await this.client.cache.channels?.set(
 				CacheFrom.Rest,
 				channels.map<[string, APIChannel]>(x => [x.id, x]),
@@ -207,19 +206,8 @@ export class GuildShorter extends BaseShorter {
 		 * @param force Whether to force fetching the channel from the API even if it exists in the cache.
 		 * @returns A Promise that resolves to the fetched channel.
 		 */
-		fetch: async (guildId: string, channelId: string, force?: boolean) => {
-			let channel: APIChannel | ReturnType<Channels['get']>;
-			if (!force) {
-				channel = await this.client.cache.channels?.get(channelId);
-				if (channel) return channel as ReturnType<typeof channelFrom>;
-			}
-
-			channel = await this.client.proxy.channels(channelId).get();
-			await this.client.cache.channels?.patch(CacheFrom.Rest, channelId, guildId, channel);
-			if ('permission_overwrites' in channel && channel.permission_overwrites) {
-				await this.client.cache.overwrites?.set(CacheFrom.Rest, channelId, guildId, channel.permission_overwrites);
-			}
-			return channelFrom(channel, this.client);
+		fetch: async (_guildId: string, channelId: string, force?: boolean) => {
+			return this.client.channels.fetch(channelId, force);
 		},
 
 		/**
@@ -245,29 +233,19 @@ export class GuildShorter extends BaseShorter {
 		 * @returns A Promise that resolves to the deleted channel.
 		 */
 		delete: async (guildId: string, channelId: string, reason?: string) => {
-			const res = await this.client.proxy.channels(channelId).delete({ reason });
-			await this.client.cache.channels?.removeIfNI(BaseChannel.__intent__(guildId), res.id, guildId);
-			return channelFrom(res, this.client);
+			return this.client.channels.delete(channelId, { guildId, reason });
 		},
 
 		/**
 		 * Edits a channel in the guild.
-		 * @param guildchannelId The ID of the guild.
+		 * @param guildId The ID of the guild.
 		 * @param channelId The ID of the channel to edit.
 		 * @param body The data to update the channel with.
 		 * @param reason The reason for editing the channel.
 		 * @returns A Promise that resolves to the edited channel.
 		 */
-		edit: async (guildchannelId: string, channelId: string, body: RESTPatchAPIChannelJSONBody, reason?: string) => {
-			const res = await this.client.proxy.channels(channelId).patch({ body, reason });
-			await this.client.cache.channels?.setIfNI(
-				CacheFrom.Rest,
-				BaseChannel.__intent__(guildchannelId),
-				res.id,
-				guildchannelId,
-				res,
-			);
-			return channelFrom(res, this.client);
+		edit: async (guildId: string, channelId: string, body: RESTPatchAPIChannelJSONBody, reason?: string) => {
+			return this.client.channels.edit(channelId, body, { guildId, reason });
 		},
 
 		/**
@@ -278,7 +256,11 @@ export class GuildShorter extends BaseShorter {
 		editPositions: (guildId: string, body: RESTPatchAPIGuildChannelPositionsJSONBody) =>
 			this.client.proxy.guilds(guildId).channels.patch({ body }),
 
-		addFollower: async (channelId: string, webhook_channel_id: string, reason?: string) => {
+		addFollower: async (
+			channelId: string,
+			webhook_channel_id: string,
+			reason?: string,
+		): Promise<RESTPostAPIChannelFollowersResult> => {
 			return this.client.proxy.channels(channelId).followers.post({
 				body: {
 					webhook_channel_id,
@@ -428,12 +410,12 @@ export class GuildShorter extends BaseShorter {
 		 * @returns A Promise that resolves to the fetched sticker.
 		 */
 		fetch: async (guildId: string, stickerId: string, force = false): Promise<StickerStructure> => {
-			let sticker: APISticker | StickerStructure | undefined;
 			if (!force) {
-				sticker = await this.client.cache.stickers?.get(stickerId);
-				if (sticker) return sticker;
+				const cachedSticker = await this.client.cache.stickers?.get(stickerId);
+				if (cachedSticker) return cachedSticker;
 			}
-			sticker = await this.client.proxy.guilds(guildId).stickers(stickerId).get();
+
+			const sticker = await this.client.proxy.guilds(guildId).stickers(stickerId).get();
 			await this.client.cache.stickers?.patch(CacheFrom.Rest, stickerId, guildId, sticker);
 			return Transformers.Sticker(this.client, sticker);
 		},

--- a/src/common/shorters/members.ts
+++ b/src/common/shorters/members.ts
@@ -178,12 +178,12 @@ export class MemberShorter extends BaseShorter {
 	 * @returns A Promise that resolves to an array of listed members.
 	 */
 	async list(guildId: string, query?: RESTGetAPIGuildMembersQuery, force = false): Promise<GuildMemberStructure[]> {
-		let members: APIGuildMember[] | GuildMemberStructure[];
 		if (!force) {
-			members = (await this.client.cache.members?.values(guildId)) ?? [];
-			if (members.length) return members;
+			const cachedMembers = (await this.client.cache.members?.values(guildId)) ?? [];
+			if (cachedMembers.length) return cachedMembers;
 		}
-		members = await this.client.proxy.guilds(guildId).members.get({
+
+		const members = await this.client.proxy.guilds(guildId).members.get({
 			query,
 		});
 		await this.client.cache.members?.set(

--- a/tests/bitfield.test.mts
+++ b/tests/bitfield.test.mts
@@ -1,7 +1,7 @@
 import { assert, describe, test } from 'vitest';
-import { BitField } from '../lib/structures/extra/BitField';
-import { PermissionsBitField } from '../lib/structures/extra/Permissions';
-import { PermissionFlagsBits } from '../lib/types';
+import { BitField } from '../src/structures/extra/BitField';
+import { PermissionsBitField } from '../src/structures/extra/Permissions';
+import { PermissionFlagsBits } from '../src/types';
 
 describe('PermissionsBitField', () => {
 	test('constructor', () => {

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -1,5 +1,5 @@
 import { assert, describe, test } from 'vitest';
-import { Client, LimitedMemoryAdapter, MemoryAdapter } from '../lib/index';
+import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter } from '../src/index';
 
 // all intents
 const intents = 53608447;
@@ -127,4 +127,54 @@ describe('test limited memory cache adapter indexing', () => {
 			false,
 		);
 	});
+	test('relationship reads do not allocate empty buckets', () => {
+		const adapter = new LimitedMemoryAdapter();
+		const relationships = (adapter as LimitedMemoryAdapter<unknown> & { relationships: Map<string, unknown> }).relationships;
+
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.deepEqual(adapter.getToRelationship('message.channel-1'), []);
+		assert.deepEqual(adapter.keys('message.channel-1'), []);
+		assert.equal(adapter.count('message.channel-1'), 0);
+		assert.equal(relationships.size, 0);
+
+		adapter.addToRelationship('message.channel-1', 'message-1');
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+
+		adapter.removeToRelationship('message.channel-1', 'message-1');
+		assert.equal(relationships.size, 0);
+	});
+
+	test('message cache stores authors so transformed messages can be read back', async () => {
+		const client: any = {};
+		const cache = new Cache(0, new MemoryAdapter(), {}, client);
+		client.cache = cache;
+		const message = {
+			attachments: [],
+			author: { avatar: null, discriminator: '0001', id: 'user-1', username: 'socram' },
+			channel_id: 'channel-1',
+			components: [],
+			content: 'hello',
+			edited_timestamp: null,
+			embeds: [],
+			flags: 0,
+			id: 'message-1',
+			mention_everyone: false,
+			mention_roles: [],
+			mentions: [],
+			pinned: false,
+			timestamp: new Date(0).toISOString(),
+			tts: false,
+			type: 0,
+		};
+
+		await cache.messages?.set(CacheFrom.Rest, message.id, message.channel_id, message);
+
+		const cachedMessage = await cache.messages?.get(message.id);
+		const rawMessage = await cache.messages?.raw(message.id);
+
+		assert.equal(cachedMessage?.author.id, message.author.id);
+		assert.equal(rawMessage?.user_id, message.author.id);
+		assert.equal(await cache.users?.raw(message.author.id), message.author);
+	});
+
 });

--- a/tests/channel-overwrites.test.mts
+++ b/tests/channel-overwrites.test.mts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
-import { Cache, MemoryAdapter } from '../lib';
-import { ChannelShorter } from '../lib/common/shorters/channels';
-import { OverwriteType } from '../lib/types';
+import { Cache, CacheFrom, MemoryAdapter } from '../src';
+import { ChannelShorter } from '../src/common/shorters/channels';
+import { OverwriteType } from '../src/types';
 
 describe('channel overwrites endpoint', () => {
 	const channelId = '123';
@@ -58,4 +58,24 @@ describe('channel overwrites endpoint', () => {
 		expect(afterDelete ?? undefined).toBeUndefined();
 		expect(del).toHaveBeenCalledWith({ reason: 'remove overwrite' });
 	});
+	test('raw channel rehydrates overwrites without mutating cached channel data', async () => {
+		const client: any = {};
+		client.cache = new Cache(0, new MemoryAdapter(), {}, client);
+		client.proxy = {
+			channels: vi.fn(),
+		};
+		const channelShorter = new ChannelShorter(client);
+		const channel = { guild_id: guildId, id: channelId, name: 'general', type: 0 };
+		const overwrites = [{ allow: '2', deny: '4', id: overwriteId, type: OverwriteType.Member }];
+
+		await client.cache.channels?.set(CacheFrom.Rest, channelId, guildId, channel);
+		await client.cache.overwrites?.set(CacheFrom.Rest, channelId, guildId, overwrites);
+
+		const raw = await channelShorter.raw(channelId);
+		const cachedRaw = await client.cache.channels?.raw(channelId);
+
+		expect(raw).toMatchObject({ permission_overwrites: [{ guild_id: guildId, id: overwriteId }] });
+		expect(cachedRaw).not.toHaveProperty('permission_overwrites');
+	});
+
 });

--- a/tests/mixer.test.mts
+++ b/tests/mixer.test.mts
@@ -1,6 +1,6 @@
 // test written by claude 🩻
 import { describe, expect, it } from 'vitest';
-import { mix } from '../lib/deps/mixer';
+import { mix } from '../src/deps/mixer';
 
 describe('mix decorator', () => {
 	// Helper classes for testing


### PR DESCRIPTION
### Motivation

- Fix null/undefined handling and relationship bookkeeping in memory cache adapters to avoid accidental allocations and stale indices. 
- Ensure message authors are persisted to the cache so transformed `MessageStructure` instances can be reconstructed. 
- Avoid mutating cached channel objects when rehydrating permission overwrites and consolidate shorter methods to reuse channel-level flows.

### Description

- Strengthen `MemoryAdapter` and `LimitedMemoryAdapter` checks to treat `null`/`undefined` consistently and avoid creating empty relationship buckets by adding `_ensureRelationshipSet` and cleaning up relations on remove. 
- Add `namespaceIndexedResources` and `scopeDerivedResources` sets and simplify namespace logic in `LimitedMemoryAdapter`, plus support for `keyToStorage` indexing and safe `keys`/`count`/`contains` behaviors. 
- Persist message authors into the global cache when storing messages in `cache/index.ts` and wire message author caching into message bulk/values lookups using batch `adapter.bulkGet` for performance in `src/cache/resources/messages.ts`. 
- Add `Messages.set`/`patch` overloads that forward to `cache.bulkSet`/`bulkPatch` with channel context and a helper `_buildCacheEntries`. 
- Make `Overwrites.parse` non-mutating by returning mapped objects with `guild_id` and adjust channel shorter to rehydrate overwrites into returned `raw` channel without mutating cached channel data. 
- Minor shorters refactors: cache the emoji on fetch in `emojis.ts`, delegate channel operations in `guilds.ts` to unified `channels` APIs, and update `application.deleteEmoji` to remove from cache. 
- Update tests and imports to reference `src` modules and add tests verifying relationship non-allocation, message author persistence, and non-mutating overwrites rehydration.

### Testing

- Ran unit tests with `vitest` covering `tests/bitfield.test.mts`, `tests/cache.test.mts`, `tests/channel-overwrites.test.mts`, and `tests/mixer.test.mts` after updates. 
- Added assertions for relationship allocations and message author caching in `tests/cache.test.mts`, and a rehydration test in `tests/channel-overwrites.test.mts`. 
- All updated and new tests completed successfully (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1921f73494832da0dc50f808f31504)