### PR TITLE
feat(client): add plugin lifecycle support

### DIFF
--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -33,7 +33,6 @@ import {
 	LogLevels,
 	type MakeRequired,
 	MemberShorter,
-	MergeOptions,
 	MessageShorter,
 	magicImport,
 	ReactionShorter,
@@ -61,6 +60,7 @@ import type {
 	UserCommandInteraction,
 } from '../structures';
 import type { APIInteraction, APIInteractionResponse, LocaleString, RESTPostAPIChannelMessageJSONBody } from '../types';
+import { resolveClientPlugins, type SeyfertPlugin, type SeyfertPluginClient, setupClientPlugins } from './plugins';
 import type { MessageStructure } from './transformers';
 
 export class BaseClient {
@@ -104,73 +104,72 @@ export class BaseClient {
 		return Buffer.from(token.split('.')[0], 'base64').toString('ascii');
 	}
 
+	readonly plugins: readonly SeyfertPlugin[] = [];
+	private pluginsStarted = false;
 	options: BaseClientOptions;
 
 	/**@internal */
 	static _seyfertCfWorkerConfig?: InternalRuntimeConfigHTTP | InternalRuntimeConfig;
 
 	constructor(options?: BaseClientOptions) {
-		this.options = MergeOptions(
-			{
-				commands: {
-					defaults: {
-						onRunError(context, error): any {
-							context.client.logger.fatal(`${context.command.name}.<onRunError>`, context.author.id, error);
-						},
-						onOptionsError(context, metadata): any {
-							context.client.logger.fatal(`${context.command.name}.<onOptionsError>`, context.author.id, metadata);
-						},
-						onMiddlewaresError(context, error: string): any {
-							context.client.logger.fatal(`${context.command.name}.<onMiddlewaresError>`, context.author.id, error);
-						},
-						onBotPermissionsFail(context, permissions): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onBotPermissionsFail>`,
-								context.author.id,
-								permissions,
-							);
-						},
-						onPermissionsFail(context, permissions): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onPermissionsFail>`,
-								context.author.id,
-								permissions,
-							);
-						},
-						onInternalError(client: UsingClient, command, error: unknown): any {
-							client.logger.fatal(`${command.name}.<onInternalError>`, error);
-						},
+		const defaults = {
+			commands: {
+				defaults: {
+					onRunError(context, error): any {
+						context.client.logger.fatal(`${context.command.name}.<onRunError>`, context.author.id, error);
+					},
+					onOptionsError(context, metadata): any {
+						context.client.logger.fatal(`${context.command.name}.<onOptionsError>`, context.author.id, metadata);
+					},
+					onMiddlewaresError(context, error: string): any {
+						context.client.logger.fatal(`${context.command.name}.<onMiddlewaresError>`, context.author.id, error);
+					},
+					onBotPermissionsFail(context, permissions): any {
+						context.client.logger.fatal(
+							`${context.command.name}.<onBotPermissionsFail>`,
+							context.author.id,
+							permissions,
+						);
+					},
+					onPermissionsFail(context, permissions): any {
+						context.client.logger.fatal(`${context.command.name}.<onPermissionsFail>`, context.author.id, permissions);
+					},
+					onInternalError(client: UsingClient, command, error: unknown): any {
+						client.logger.fatal(`${command.name}.<onInternalError>`, error);
 					},
 				},
-				components: {
-					defaults: {
-						onRunError(context: ComponentContext, error: unknown): any {
-							context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
-						},
-						onMiddlewaresError(context: ComponentContext, error: string): any {
-							context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
-						},
-						onInternalError(client: UsingClient, error: unknown): any {
-							client.logger.fatal(error);
-						},
+			},
+			components: {
+				defaults: {
+					onRunError(context: ComponentContext, error: unknown): any {
+						context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
+					},
+					onMiddlewaresError(context: ComponentContext, error: string): any {
+						context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
+					},
+					onInternalError(client: UsingClient, error: unknown): any {
+						client.logger.fatal(error);
 					},
 				},
-				modals: {
-					defaults: {
-						onRunError(context: ModalContext, error: unknown): any {
-							context.client.logger.fatal('ModalCommand.<onRunError>', context.author.id, error);
-						},
-						onMiddlewaresError(context: ModalContext, error: string): any {
-							context.client.logger.fatal('ModalCommand.<onMiddlewaresError>', context.author.id, error);
-						},
-						onInternalError(client: UsingClient, error: unknown): any {
-							client.logger.fatal(error);
-						},
+			},
+			modals: {
+				defaults: {
+					onRunError(context: ModalContext, error: unknown): any {
+						context.client.logger.fatal('ModalCommand.<onRunError>', context.author.id, error);
+					},
+					onMiddlewaresError(context: ModalContext, error: string): any {
+						context.client.logger.fatal('ModalCommand.<onMiddlewaresError>', context.author.id, error);
+					},
+					onInternalError(client: UsingClient, error: unknown): any {
+						client.logger.fatal(error);
 					},
 				},
-			} satisfies BaseClientOptions,
-			options,
-		);
+			},
+		} satisfies BaseClientOptions;
+		const resolved = resolveClientPlugins(defaults, options);
+
+		this.options = resolved.options;
+		this.plugins = resolved.plugins;
 	}
 
 	get proxy() {
@@ -277,6 +276,10 @@ export class BaseClient {
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
+		if (!this.pluginsStarted) {
+			await setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+			this.pluginsStarted = true;
+		}
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {
@@ -476,6 +479,7 @@ export class BaseClient {
 }
 
 export interface BaseClientOptions {
+	plugins?: readonly SeyfertPlugin[];
 	context?: (
 		interaction:
 			| ChatInputCommandInteraction<boolean>

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -105,7 +105,7 @@ export class BaseClient {
 	}
 
 	readonly plugins: readonly SeyfertPlugin[] = [];
-	private pluginsStarted = false;
+	private pluginsSetupPromise?: Promise<void>;
 	options: BaseClientOptions;
 
 	/**@internal */
@@ -276,10 +276,8 @@ export class BaseClient {
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
-		if (!this.pluginsStarted) {
-			await setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-			this.pluginsStarted = true;
-		}
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+		await this.pluginsSetupPromise;
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -269,8 +269,7 @@ export class BaseClient {
 
 		if (!this.handleCommand) this.handleCommand = new HandleCommand(this);
 
-		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-		await this.pluginsSetupPromise;
+		await this.setupPlugins();
 
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
@@ -279,6 +278,17 @@ export class BaseClient {
 		await this.loadLangs(options.langsDir);
 		await this.loadCommands(options.commandsDir);
 		await this.loadComponents(options.componentsDir);
+	}
+
+	private async setupPlugins() {
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+
+		try {
+			await this.pluginsSetupPromise;
+		} catch (error) {
+			this.pluginsSetupPromise = undefined;
+			throw error;
+		}
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -260,10 +260,6 @@ export class BaseClient {
 			'langsDir' | 'commandsDir' | 'connection' | 'token' | 'componentsDir'
 		> = {},
 	) {
-		await this.loadLangs(options.langsDir);
-		await this.loadCommands(options.commandsDir);
-		await this.loadComponents(options.componentsDir);
-
 		const { token: tokenRC, debug } = await this.getRC();
 		const token = options.token ?? tokenRC;
 		assertString(token, 'token is not a string');
@@ -273,11 +269,16 @@ export class BaseClient {
 
 		if (!this.handleCommand) this.handleCommand = new HandleCommand(this);
 
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+		await this.pluginsSetupPromise;
+
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
-		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-		await this.pluginsSetupPromise;
+
+		await this.loadLangs(options.langsDir);
+		await this.loadCommands(options.commandsDir);
+		await this.loadComponents(options.componentsDir);
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,6 @@
 export type { RuntimeConfig, RuntimeConfigHTTP } from './base';
 export * from './client';
 export * from './httpclient';
+export * from './plugins';
 export * from './transformers';
 export * from './workerclient';

--- a/src/client/plugins.ts
+++ b/src/client/plugins.ts
@@ -1,0 +1,163 @@
+import type { UsingClient } from '../commands';
+import { MergeOptions } from '../common';
+import type { Awaitable } from '../common/types/util';
+import type { BaseClientOptions } from './base';
+
+type ClientOptionsFragment = Partial<Omit<BaseClientOptions, 'plugins'>>;
+type CommandDefaults = NonNullable<NonNullable<BaseClientOptions['commands']>['defaults']>;
+type ComponentDefaults = NonNullable<NonNullable<BaseClientOptions['components']>['defaults']>;
+type ModalDefaults = NonNullable<NonNullable<BaseClientOptions['modals']>['defaults']>;
+type AnyFunction = (...args: unknown[]) => unknown;
+
+export type SeyfertPluginClient = UsingClient & {
+	plugins: readonly SeyfertPlugin[];
+};
+
+export interface SeyfertPlugin {
+	name: string;
+	options?(current: Readonly<BaseClientOptions>): ClientOptionsFragment;
+	setup?(client: SeyfertPluginClient): Awaitable<void>;
+}
+
+export interface ResolvedClientPlugins {
+	plugins: readonly SeyfertPlugin[];
+	options: BaseClientOptions;
+}
+
+const commandHookKeys = [
+	'onBeforeMiddlewares',
+	'onBeforeOptions',
+	'onRunError',
+	'onPermissionsFail',
+	'onBotPermissionsFail',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onOptionsError',
+	'onAfterRun',
+] as const satisfies readonly (keyof CommandDefaults)[];
+
+const componentHookKeys = [
+	'onBeforeMiddlewares',
+	'onRunError',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onAfterRun',
+] as const satisfies readonly (keyof ComponentDefaults)[];
+
+const modalHookKeys = [
+	'onBeforeMiddlewares',
+	'onRunError',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onAfterRun',
+] as const satisfies readonly (keyof ModalDefaults)[];
+
+export function resolveClientPlugins(
+	defaults: BaseClientOptions,
+	options: BaseClientOptions = {},
+): ResolvedClientPlugins {
+	const plugins = options.plugins ?? [];
+	const userOptions = omitPlugins(options);
+	const pluginOptions: ClientOptionsFragment[] = [];
+
+	for (const plugin of plugins) {
+		const current = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
+		const fragment = plugin.options?.(current);
+		if (fragment) pluginOptions.push(fragment);
+	}
+
+	const merged = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
+	merged.plugins = plugins;
+
+	composeContext(merged, pluginOptions, userOptions);
+	composeGlobalMiddlewares(merged, pluginOptions, userOptions);
+	composeDefaults(
+		merged.commands?.defaults,
+		defaults.commands?.defaults,
+		pluginOptions.map(fragment => fragment.commands?.defaults),
+		userOptions.commands?.defaults,
+		commandHookKeys,
+	);
+	composeDefaults(
+		merged.components?.defaults,
+		defaults.components?.defaults,
+		pluginOptions.map(fragment => fragment.components?.defaults),
+		userOptions.components?.defaults,
+		componentHookKeys,
+	);
+	composeDefaults(
+		merged.modals?.defaults,
+		defaults.modals?.defaults,
+		pluginOptions.map(fragment => fragment.modals?.defaults),
+		userOptions.modals?.defaults,
+		modalHookKeys,
+	);
+
+	return { plugins, options: merged };
+}
+
+export async function setupClientPlugins(client: SeyfertPluginClient, plugins: readonly SeyfertPlugin[]) {
+	for (const plugin of plugins) await plugin.setup?.(client);
+}
+
+function omitPlugins(options: BaseClientOptions): ClientOptionsFragment {
+	const { plugins: _plugins, ...rest } = options;
+	return rest;
+}
+
+function composeContext(
+	target: BaseClientOptions,
+	pluginOptions: readonly ClientOptionsFragment[],
+	userOptions: ClientOptionsFragment,
+) {
+	const callbacks = pluginOptions
+		.map(fragment => fragment.context)
+		.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function');
+	if (userOptions.context) callbacks.push(userOptions.context);
+	if (!callbacks.length) return;
+
+	target.context = interaction =>
+		callbacks.reduce<Record<string, unknown>>((context, callback) => Object.assign(context, callback(interaction)), {});
+}
+
+function composeGlobalMiddlewares(
+	target: BaseClientOptions,
+	pluginOptions: readonly ClientOptionsFragment[],
+	userOptions: ClientOptionsFragment,
+) {
+	const middlewares = pluginOptions.flatMap(fragment => [...(fragment.globalMiddlewares ?? [])]);
+	middlewares.push(...(userOptions.globalMiddlewares ?? []));
+	if (middlewares.length) target.globalMiddlewares = middlewares;
+}
+
+function composeDefaults<TDefaults extends object, TKey extends keyof TDefaults>(
+	target: TDefaults | undefined,
+	defaults: TDefaults | undefined,
+	pluginDefaults: readonly (TDefaults | undefined)[],
+	userDefaults: TDefaults | undefined,
+	keys: readonly TKey[],
+) {
+	if (!target) return;
+
+	for (const key of keys) {
+		const pluginHooks: AnyFunction[] = pluginDefaults.map(defaults => defaults?.[key] as unknown).filter(isFunction);
+		const userHook = userDefaults?.[key] as unknown;
+		const fallbackHook = defaults?.[key] as unknown;
+
+		if (!pluginHooks.length && typeof userHook !== 'function') continue;
+
+		const tailHook = typeof userHook === 'function' ? userHook : fallbackHook;
+		const hooks = isFunction(tailHook) ? [...pluginHooks, tailHook] : pluginHooks;
+		target[key] = composeHooks(hooks) as TDefaults[TKey];
+	}
+}
+
+function composeHooks(hooks: readonly AnyFunction[]) {
+	return async (...args: unknown[]) => {
+		for (const hook of hooks) await hook(...args);
+	};
+}
+
+function isFunction(value: unknown): value is AnyFunction {
+	return typeof value === 'function';
+}

--- a/src/client/plugins.ts
+++ b/src/client/plugins.ts
@@ -69,8 +69,8 @@ export function resolveClientPlugins(
 	const merged = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
 	merged.plugins = plugins;
 
-	composeContext(merged, pluginOptions, userOptions);
-	composeGlobalMiddlewares(merged, pluginOptions, userOptions);
+	composeContext(merged, defaults, pluginOptions, userOptions);
+	composeGlobalMiddlewares(merged, defaults, pluginOptions, userOptions);
 	composeDefaults(
 		merged.commands?.defaults,
 		defaults.commands?.defaults,
@@ -107,13 +107,18 @@ function omitPlugins(options: BaseClientOptions): ClientOptionsFragment {
 
 function composeContext(
 	target: BaseClientOptions,
+	defaults: BaseClientOptions,
 	pluginOptions: readonly ClientOptionsFragment[],
 	userOptions: ClientOptionsFragment,
 ) {
-	const callbacks = pluginOptions
-		.map(fragment => fragment.context)
-		.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function');
-	if (userOptions.context) callbacks.push(userOptions.context);
+	const callbacks: NonNullable<BaseClientOptions['context']>[] = [];
+	if (typeof defaults.context === 'function') callbacks.push(defaults.context);
+	callbacks.push(
+		...pluginOptions
+			.map(fragment => fragment.context)
+			.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function'),
+	);
+	if (typeof userOptions.context === 'function') callbacks.push(userOptions.context);
 	if (!callbacks.length) return;
 
 	target.context = interaction =>
@@ -122,10 +127,14 @@ function composeContext(
 
 function composeGlobalMiddlewares(
 	target: BaseClientOptions,
+	defaults: BaseClientOptions,
 	pluginOptions: readonly ClientOptionsFragment[],
 	userOptions: ClientOptionsFragment,
 ) {
-	const middlewares = pluginOptions.flatMap(fragment => [...(fragment.globalMiddlewares ?? [])]);
+	const middlewares = [
+		...(defaults.globalMiddlewares ?? []),
+		...pluginOptions.flatMap(fragment => fragment.globalMiddlewares ?? []),
+	];
 	middlewares.push(...(userOptions.globalMiddlewares ?? []));
 	if (middlewares.length) target.globalMiddlewares = middlewares;
 }

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { Client, type ClientOptions } from '../src/client/client';
-import type { SeyfertPlugin } from '../src/client/plugins';
+import { resolveClientPlugins, type SeyfertPlugin } from '../src/client/plugins';
 
 function runtimeConfig() {
 	return {
@@ -46,6 +46,36 @@ describe('client plugins', () => {
 			shared: 'user',
 		});
 		expect(client.options.globalMiddlewares).toEqual(['pluginA', 'pluginB', 'user']);
+	});
+
+	test('preserves base context and global middlewares before plugin and user options', () => {
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			options: () => ({
+				context: () => ({ fromPlugin: true, shared: 'plugin' }),
+				globalMiddlewares: ['plugin' as never],
+			}),
+		};
+
+		const { options } = resolveClientPlugins(
+			{
+				context: () => ({ fromBase: true, shared: 'base' }),
+				globalMiddlewares: ['base' as never],
+			},
+			{
+				plugins: [plugin],
+				context: () => ({ fromUser: true, shared: 'user' }),
+				globalMiddlewares: ['user' as never],
+			},
+		);
+
+		expect(options.context?.({} as never)).toEqual({
+			fromBase: true,
+			fromPlugin: true,
+			fromUser: true,
+			shared: 'user',
+		});
+		expect(options.globalMiddlewares).toEqual(['base', 'plugin', 'user']);
 	});
 
 	test('runs plugin lifecycle hooks before user lifecycle hooks', async () => {
@@ -108,5 +138,38 @@ describe('client plugins', () => {
 		await client.start({ token: 'header.payload.signature' }, false);
 
 		expect(calls).toEqual(['plugin-a', 'plugin-b']);
+	});
+
+	test('shares setup work across concurrent starts', async () => {
+		const calls: string[] = [];
+		let releaseSetup = () => {};
+		const holdSetup = new Promise<void>(resolve => {
+			releaseSetup = resolve;
+		});
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: async () => {
+				calls.push('plugin');
+				await holdSetup;
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		const starts = [
+			client.start({ token: 'header.payload.signature' }, false),
+			client.start({ token: 'header.payload.signature' }, false),
+		];
+
+		try {
+			await new Promise(resolve => setTimeout(resolve, 0));
+			expect(calls).toEqual(['plugin']);
+		} finally {
+			releaseSetup();
+			await Promise.allSettled(starts);
+		}
+
+		expect(calls).toEqual(['plugin']);
 	});
 });

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -140,6 +140,35 @@ describe('client plugins', () => {
 		expect(calls).toEqual(['plugin-a', 'plugin-b']);
 	});
 
+	test('runs setup before cache start and command loading', async () => {
+		const calls: string[] = [];
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: () => {
+				calls.push('plugin');
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+		client.cache.adapter.start = async () => {
+			calls.push('cache');
+		};
+		client.loadLangs = async () => {
+			calls.push('langs');
+		};
+		client.loadCommands = async () => {
+			calls.push('commands');
+		};
+		client.loadComponents = async () => {
+			calls.push('components');
+		};
+
+		await client.start({ token: 'header.payload.signature' }, false);
+
+		expect(calls).toEqual(['plugin', 'cache', 'langs', 'commands', 'components']);
+	});
+
 	test('shares setup work across concurrent starts', async () => {
 		const calls: string[] = [];
 		let releaseSetup = () => {};

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -201,4 +201,23 @@ describe('client plugins', () => {
 
 		expect(calls).toEqual(['plugin']);
 	});
+
+	test('retries setup after plugin setup fails', async () => {
+		const calls: string[] = [];
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: () => {
+				calls.push('plugin');
+				if (calls.length === 1) throw new Error('setup failed');
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		await expect(client.start({ token: 'header.payload.signature' }, false)).rejects.toThrow('setup failed');
+		await expect(client.start({ token: 'header.payload.signature' }, false)).resolves.toBeUndefined();
+
+		expect(calls).toEqual(['plugin', 'plugin']);
+	});
 });

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import { Client, type ClientOptions } from '../src/client/client';
+import type { SeyfertPlugin } from '../src/client/plugins';
+
+function runtimeConfig() {
+	return {
+		token: 'header.payload.signature',
+		locations: { base: process.cwd() },
+	};
+}
+
+function createClient(options: ClientOptions = {}) {
+	return new Client({
+		getRC: async () => runtimeConfig(),
+		...options,
+	});
+}
+
+describe('client plugins', () => {
+	test('composes context callbacks and global middlewares in plugin order before user options', () => {
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			options: () => ({
+				context: () => ({ fromA: true, shared: 'plugin-a' }),
+				globalMiddlewares: ['pluginA' as never],
+			}),
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			options: () => ({
+				context: () => ({ fromB: true, shared: 'plugin-b' }),
+				globalMiddlewares: ['pluginB' as never],
+			}),
+		};
+
+		const client = createClient({
+			plugins: [pluginA, pluginB],
+			context: () => ({ fromUser: true, shared: 'user' }),
+			globalMiddlewares: ['user' as never],
+		});
+
+		expect(client.options.context?.({} as never)).toEqual({
+			fromA: true,
+			fromB: true,
+			fromUser: true,
+			shared: 'user',
+		});
+		expect(client.options.globalMiddlewares).toEqual(['pluginA', 'pluginB', 'user']);
+	});
+
+	test('runs plugin lifecycle hooks before user lifecycle hooks', async () => {
+		const calls: string[] = [];
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			options: () => ({
+				commands: {
+					defaults: {
+						onAfterRun: () => calls.push('plugin-a'),
+					},
+				},
+			}),
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			options: () => ({
+				commands: {
+					defaults: {
+						onAfterRun: () => calls.push('plugin-b'),
+					},
+				},
+			}),
+		};
+
+		const client = createClient({
+			plugins: [pluginA, pluginB],
+			commands: {
+				defaults: {
+					onAfterRun: () => calls.push('user'),
+				},
+			},
+		});
+
+		await client.options.commands?.defaults?.onAfterRun?.({} as never, undefined);
+
+		expect(calls).toEqual(['plugin-a', 'plugin-b', 'user']);
+	});
+
+	test('runs setup once during start in plugin order', async () => {
+		const calls: string[] = [];
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			setup: client => {
+				expect(client.plugins.map(plugin => plugin.name)).toEqual(['plugin-a', 'plugin-b']);
+				calls.push('plugin-a');
+			},
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			setup: () => {
+				calls.push('plugin-b');
+			},
+		};
+		const client = createClient({ plugins: [pluginA, pluginB] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		await client.start({ token: 'header.payload.signature' }, false);
+		await client.start({ token: 'header.payload.signature' }, false);
+
+		expect(calls).toEqual(['plugin-a', 'plugin-b']);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a `plugins: []` client option for Seyfert integrations.
- Lets plugins contribute option fragments, context, global middlewares, lifecycle defaults, and async setup.
- Composes plugin hooks in array order before user hooks without requiring manual wiring.

## Slipher PR Stack
- tiramisulabs/extra#16 — source Slipher package roadmap draft being split into focused PRs.
- tiramisulabs/extra#17 — adds `@slipher/testing` as runner-agnostic Seyfert fixtures; first recovered package PR.
- tiramisulabs/extra#18 — adds `@slipher/logger` as a Seyfert plugin with wide-event interaction logging and root logger setup.
- tiramisulabs/extra#19 — adds `@slipher/queues` with `memory()` and BullMQ-backed `persistent()` drivers, `ctx.queues`, processors, events, and producers.
- tiramisulabs/extra#20 — adds `@slipher/scheduler` with Croner-backed `memory()`, BullMQ-backed `persistent()`, `ctx.scheduler`, and task decorators.
- tiramisulabs/extra#21 — centralizes Biome formatting config so feature PRs do not carry package-local `biome.json` files.
- Future Slipher package PRs will be appended here as they open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class client plugin system: supply plugins at construction, access resolved plugin list, and have plugins contribute config fragments, context, global middleware, and lifecycle hooks in declared order.
  * Plugin setup is run automatically during client startup, initialized once per instance (serialized across concurrent starts), and runs before cache and other loading steps.

* **Tests**
  * Added tests verifying plugin composition, ordering, startup single-run semantics, failure retry, and concurrent-start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


