### PR TITLE
feat(client): add context scopes for plugins

### DIFF
--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -33,7 +33,6 @@ import {
 	LogLevels,
 	type MakeRequired,
 	MemberShorter,
-	MergeOptions,
 	MessageShorter,
 	magicImport,
 	ReactionShorter,
@@ -61,6 +60,7 @@ import type {
 	UserCommandInteraction,
 } from '../structures';
 import type { APIInteraction, APIInteractionResponse, LocaleString, RESTPostAPIChannelMessageJSONBody } from '../types';
+import { resolveClientPlugins, type SeyfertPlugin, type SeyfertPluginClient, setupClientPlugins } from './plugins';
 import type { MessageStructure } from './transformers';
 
 export class BaseClient {
@@ -104,73 +104,72 @@ export class BaseClient {
 		return Buffer.from(token.split('.')[0], 'base64').toString('ascii');
 	}
 
+	readonly plugins: readonly SeyfertPlugin[] = [];
+	private pluginsStarted = false;
 	options: BaseClientOptions;
 
 	/**@internal */
 	static _seyfertCfWorkerConfig?: InternalRuntimeConfigHTTP | InternalRuntimeConfig;
 
 	constructor(options?: BaseClientOptions) {
-		this.options = MergeOptions(
-			{
-				commands: {
-					defaults: {
-						onRunError(context, error): any {
-							context.client.logger.fatal(`${context.command.name}.<onRunError>`, context.author.id, error);
-						},
-						onOptionsError(context, metadata): any {
-							context.client.logger.fatal(`${context.command.name}.<onOptionsError>`, context.author.id, metadata);
-						},
-						onMiddlewaresError(context, error: string): any {
-							context.client.logger.fatal(`${context.command.name}.<onMiddlewaresError>`, context.author.id, error);
-						},
-						onBotPermissionsFail(context, permissions): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onBotPermissionsFail>`,
-								context.author.id,
-								permissions,
-							);
-						},
-						onPermissionsFail(context, permissions): any {
-							context.client.logger.fatal(
-								`${context.command.name}.<onPermissionsFail>`,
-								context.author.id,
-								permissions,
-							);
-						},
-						onInternalError(client: UsingClient, command, error: unknown): any {
-							client.logger.fatal(`${command.name}.<onInternalError>`, error);
-						},
+		const defaults = {
+			commands: {
+				defaults: {
+					onRunError(context, error): any {
+						context.client.logger.fatal(`${context.command.name}.<onRunError>`, context.author.id, error);
+					},
+					onOptionsError(context, metadata): any {
+						context.client.logger.fatal(`${context.command.name}.<onOptionsError>`, context.author.id, metadata);
+					},
+					onMiddlewaresError(context, error: string): any {
+						context.client.logger.fatal(`${context.command.name}.<onMiddlewaresError>`, context.author.id, error);
+					},
+					onBotPermissionsFail(context, permissions): any {
+						context.client.logger.fatal(
+							`${context.command.name}.<onBotPermissionsFail>`,
+							context.author.id,
+							permissions,
+						);
+					},
+					onPermissionsFail(context, permissions): any {
+						context.client.logger.fatal(`${context.command.name}.<onPermissionsFail>`, context.author.id, permissions);
+					},
+					onInternalError(client: UsingClient, command, error: unknown): any {
+						client.logger.fatal(`${command.name}.<onInternalError>`, error);
 					},
 				},
-				components: {
-					defaults: {
-						onRunError(context: ComponentContext, error: unknown): any {
-							context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
-						},
-						onMiddlewaresError(context: ComponentContext, error: string): any {
-							context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
-						},
-						onInternalError(client: UsingClient, error: unknown): any {
-							client.logger.fatal(error);
-						},
+			},
+			components: {
+				defaults: {
+					onRunError(context: ComponentContext, error: unknown): any {
+						context.client.logger.fatal('ComponentCommand.<onRunError>', context.author.id, error);
+					},
+					onMiddlewaresError(context: ComponentContext, error: string): any {
+						context.client.logger.fatal('ComponentCommand.<onMiddlewaresError>', context.author.id, error);
+					},
+					onInternalError(client: UsingClient, error: unknown): any {
+						client.logger.fatal(error);
 					},
 				},
-				modals: {
-					defaults: {
-						onRunError(context: ModalContext, error: unknown): any {
-							context.client.logger.fatal('ModalCommand.<onRunError>', context.author.id, error);
-						},
-						onMiddlewaresError(context: ModalContext, error: string): any {
-							context.client.logger.fatal('ModalCommand.<onMiddlewaresError>', context.author.id, error);
-						},
-						onInternalError(client: UsingClient, error: unknown): any {
-							client.logger.fatal(error);
-						},
+			},
+			modals: {
+				defaults: {
+					onRunError(context: ModalContext, error: unknown): any {
+						context.client.logger.fatal('ModalCommand.<onRunError>', context.author.id, error);
+					},
+					onMiddlewaresError(context: ModalContext, error: string): any {
+						context.client.logger.fatal('ModalCommand.<onMiddlewaresError>', context.author.id, error);
+					},
+					onInternalError(client: UsingClient, error: unknown): any {
+						client.logger.fatal(error);
 					},
 				},
-			} satisfies BaseClientOptions,
-			options,
-		);
+			},
+		} satisfies BaseClientOptions;
+		const resolved = resolveClientPlugins(defaults, options);
+
+		this.options = resolved.options;
+		this.plugins = resolved.plugins;
 	}
 
 	get proxy() {
@@ -277,6 +276,10 @@ export class BaseClient {
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
+		if (!this.pluginsStarted) {
+			await setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+			this.pluginsStarted = true;
+		}
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {
@@ -476,6 +479,7 @@ export class BaseClient {
 }
 
 export interface BaseClientOptions {
+	plugins?: readonly SeyfertPlugin[];
 	context?: (
 		interaction:
 			| ChatInputCommandInteraction<boolean>

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -63,6 +63,8 @@ import type { APIInteraction, APIInteractionResponse, LocaleString, RESTPostAPIC
 import { resolveClientPlugins, type SeyfertPlugin, type SeyfertPluginClient, setupClientPlugins } from './plugins';
 import type { MessageStructure } from './transformers';
 
+export type ContextScope = <T>(context: unknown, run: () => Awaitable<T>) => Awaitable<T>;
+
 export class BaseClient {
 	rest = new ApiHandler({ token: 'INVALID' });
 	cache = new Cache(0, new MemoryAdapter(), {}, this);
@@ -489,6 +491,7 @@ export class BaseClient {
 
 export interface BaseClientOptions {
 	plugins?: readonly SeyfertPlugin[];
+	contextScopes?: readonly ContextScope[];
 	context?: (
 		interaction:
 			| ChatInputCommandInteraction<boolean>

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -105,7 +105,7 @@ export class BaseClient {
 	}
 
 	readonly plugins: readonly SeyfertPlugin[] = [];
-	private pluginsStarted = false;
+	private pluginsSetupPromise?: Promise<void>;
 	options: BaseClientOptions;
 
 	/**@internal */
@@ -276,10 +276,8 @@ export class BaseClient {
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
-		if (!this.pluginsStarted) {
-			await setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-			this.pluginsStarted = true;
-		}
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+		await this.pluginsSetupPromise;
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -269,8 +269,7 @@ export class BaseClient {
 
 		if (!this.handleCommand) this.handleCommand = new HandleCommand(this);
 
-		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-		await this.pluginsSetupPromise;
+		await this.setupPlugins();
 
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
@@ -279,6 +278,17 @@ export class BaseClient {
 		await this.loadLangs(options.langsDir);
 		await this.loadCommands(options.commandsDir);
 		await this.loadComponents(options.componentsDir);
+	}
+
+	private async setupPlugins() {
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+
+		try {
+			await this.pluginsSetupPromise;
+		} catch (error) {
+			this.pluginsSetupPromise = undefined;
+			throw error;
+		}
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -260,10 +260,6 @@ export class BaseClient {
 			'langsDir' | 'commandsDir' | 'connection' | 'token' | 'componentsDir'
 		> = {},
 	) {
-		await this.loadLangs(options.langsDir);
-		await this.loadCommands(options.commandsDir);
-		await this.loadComponents(options.componentsDir);
-
 		const { token: tokenRC, debug } = await this.getRC();
 		const token = options.token ?? tokenRC;
 		assertString(token, 'token is not a string');
@@ -273,11 +269,16 @@ export class BaseClient {
 
 		if (!this.handleCommand) this.handleCommand = new HandleCommand(this);
 
+		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
+		await this.pluginsSetupPromise;
+
 		// The reason of this method is so for adapters that need to connect somewhere, have time to connect.
 		// Or maybe clear cache?
 		await this.cache.adapter.start();
-		this.pluginsSetupPromise ??= setupClientPlugins(this as SeyfertPluginClient, this.plugins);
-		await this.pluginsSetupPromise;
+
+		await this.loadLangs(options.langsDir);
+		await this.loadCommands(options.commandsDir);
+		await this.loadComponents(options.componentsDir);
 	}
 
 	protected async onPacket(..._packet: unknown[]): Promise<any> {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,6 @@
 export type { RuntimeConfig, RuntimeConfigHTTP } from './base';
 export * from './client';
 export * from './httpclient';
+export * from './plugins';
 export * from './transformers';
 export * from './workerclient';

--- a/src/client/plugins.ts
+++ b/src/client/plugins.ts
@@ -1,0 +1,163 @@
+import type { UsingClient } from '../commands';
+import { MergeOptions } from '../common';
+import type { Awaitable } from '../common/types/util';
+import type { BaseClientOptions } from './base';
+
+type ClientOptionsFragment = Partial<Omit<BaseClientOptions, 'plugins'>>;
+type CommandDefaults = NonNullable<NonNullable<BaseClientOptions['commands']>['defaults']>;
+type ComponentDefaults = NonNullable<NonNullable<BaseClientOptions['components']>['defaults']>;
+type ModalDefaults = NonNullable<NonNullable<BaseClientOptions['modals']>['defaults']>;
+type AnyFunction = (...args: unknown[]) => unknown;
+
+export type SeyfertPluginClient = UsingClient & {
+	plugins: readonly SeyfertPlugin[];
+};
+
+export interface SeyfertPlugin {
+	name: string;
+	options?(current: Readonly<BaseClientOptions>): ClientOptionsFragment;
+	setup?(client: SeyfertPluginClient): Awaitable<void>;
+}
+
+export interface ResolvedClientPlugins {
+	plugins: readonly SeyfertPlugin[];
+	options: BaseClientOptions;
+}
+
+const commandHookKeys = [
+	'onBeforeMiddlewares',
+	'onBeforeOptions',
+	'onRunError',
+	'onPermissionsFail',
+	'onBotPermissionsFail',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onOptionsError',
+	'onAfterRun',
+] as const satisfies readonly (keyof CommandDefaults)[];
+
+const componentHookKeys = [
+	'onBeforeMiddlewares',
+	'onRunError',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onAfterRun',
+] as const satisfies readonly (keyof ComponentDefaults)[];
+
+const modalHookKeys = [
+	'onBeforeMiddlewares',
+	'onRunError',
+	'onInternalError',
+	'onMiddlewaresError',
+	'onAfterRun',
+] as const satisfies readonly (keyof ModalDefaults)[];
+
+export function resolveClientPlugins(
+	defaults: BaseClientOptions,
+	options: BaseClientOptions = {},
+): ResolvedClientPlugins {
+	const plugins = options.plugins ?? [];
+	const userOptions = omitPlugins(options);
+	const pluginOptions: ClientOptionsFragment[] = [];
+
+	for (const plugin of plugins) {
+		const current = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
+		const fragment = plugin.options?.(current);
+		if (fragment) pluginOptions.push(fragment);
+	}
+
+	const merged = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
+	merged.plugins = plugins;
+
+	composeContext(merged, pluginOptions, userOptions);
+	composeGlobalMiddlewares(merged, pluginOptions, userOptions);
+	composeDefaults(
+		merged.commands?.defaults,
+		defaults.commands?.defaults,
+		pluginOptions.map(fragment => fragment.commands?.defaults),
+		userOptions.commands?.defaults,
+		commandHookKeys,
+	);
+	composeDefaults(
+		merged.components?.defaults,
+		defaults.components?.defaults,
+		pluginOptions.map(fragment => fragment.components?.defaults),
+		userOptions.components?.defaults,
+		componentHookKeys,
+	);
+	composeDefaults(
+		merged.modals?.defaults,
+		defaults.modals?.defaults,
+		pluginOptions.map(fragment => fragment.modals?.defaults),
+		userOptions.modals?.defaults,
+		modalHookKeys,
+	);
+
+	return { plugins, options: merged };
+}
+
+export async function setupClientPlugins(client: SeyfertPluginClient, plugins: readonly SeyfertPlugin[]) {
+	for (const plugin of plugins) await plugin.setup?.(client);
+}
+
+function omitPlugins(options: BaseClientOptions): ClientOptionsFragment {
+	const { plugins: _plugins, ...rest } = options;
+	return rest;
+}
+
+function composeContext(
+	target: BaseClientOptions,
+	pluginOptions: readonly ClientOptionsFragment[],
+	userOptions: ClientOptionsFragment,
+) {
+	const callbacks = pluginOptions
+		.map(fragment => fragment.context)
+		.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function');
+	if (userOptions.context) callbacks.push(userOptions.context);
+	if (!callbacks.length) return;
+
+	target.context = interaction =>
+		callbacks.reduce<Record<string, unknown>>((context, callback) => Object.assign(context, callback(interaction)), {});
+}
+
+function composeGlobalMiddlewares(
+	target: BaseClientOptions,
+	pluginOptions: readonly ClientOptionsFragment[],
+	userOptions: ClientOptionsFragment,
+) {
+	const middlewares = pluginOptions.flatMap(fragment => [...(fragment.globalMiddlewares ?? [])]);
+	middlewares.push(...(userOptions.globalMiddlewares ?? []));
+	if (middlewares.length) target.globalMiddlewares = middlewares;
+}
+
+function composeDefaults<TDefaults extends object, TKey extends keyof TDefaults>(
+	target: TDefaults | undefined,
+	defaults: TDefaults | undefined,
+	pluginDefaults: readonly (TDefaults | undefined)[],
+	userDefaults: TDefaults | undefined,
+	keys: readonly TKey[],
+) {
+	if (!target) return;
+
+	for (const key of keys) {
+		const pluginHooks: AnyFunction[] = pluginDefaults.map(defaults => defaults?.[key] as unknown).filter(isFunction);
+		const userHook = userDefaults?.[key] as unknown;
+		const fallbackHook = defaults?.[key] as unknown;
+
+		if (!pluginHooks.length && typeof userHook !== 'function') continue;
+
+		const tailHook = typeof userHook === 'function' ? userHook : fallbackHook;
+		const hooks = isFunction(tailHook) ? [...pluginHooks, tailHook] : pluginHooks;
+		target[key] = composeHooks(hooks) as TDefaults[TKey];
+	}
+}
+
+function composeHooks(hooks: readonly AnyFunction[]) {
+	return async (...args: unknown[]) => {
+		for (const hook of hooks) await hook(...args);
+	};
+}
+
+function isFunction(value: unknown): value is AnyFunction {
+	return typeof value === 'function';
+}

--- a/src/client/plugins.ts
+++ b/src/client/plugins.ts
@@ -1,7 +1,7 @@
 import type { UsingClient } from '../commands';
 import { MergeOptions } from '../common';
 import type { Awaitable } from '../common/types/util';
-import type { BaseClientOptions } from './base';
+import type { BaseClientOptions, ContextScope } from './base';
 
 type ClientOptionsFragment = Partial<Omit<BaseClientOptions, 'plugins'>>;
 type CommandDefaults = NonNullable<NonNullable<BaseClientOptions['commands']>['defaults']>;
@@ -70,6 +70,7 @@ export function resolveClientPlugins(
 	merged.plugins = plugins;
 
 	composeContext(merged, defaults, pluginOptions, userOptions);
+	composeContextScopes(merged, defaults, pluginOptions, userOptions);
 	composeGlobalMiddlewares(merged, defaults, pluginOptions, userOptions);
 	composeDefaults(
 		merged.commands?.defaults,
@@ -100,6 +101,17 @@ export async function setupClientPlugins(client: SeyfertPluginClient, plugins: r
 	for (const plugin of plugins) await plugin.setup?.(client);
 }
 
+export function runContextScopes<T>(
+	scopes: readonly ContextScope[] | undefined,
+	context: unknown,
+	run: () => Awaitable<T>,
+): Awaitable<T> {
+	if (!scopes?.length) return run();
+
+	const scopedRun = scopes.reduceRight<() => Awaitable<T>>((next, scope) => () => scope(context, next), run);
+	return scopedRun();
+}
+
 function omitPlugins(options: BaseClientOptions): ClientOptionsFragment {
 	const { plugins: _plugins, ...rest } = options;
 	return rest;
@@ -123,6 +135,20 @@ function composeContext(
 
 	target.context = interaction =>
 		callbacks.reduce<Record<string, unknown>>((context, callback) => Object.assign(context, callback(interaction)), {});
+}
+
+function composeContextScopes(
+	target: BaseClientOptions,
+	defaults: BaseClientOptions,
+	pluginOptions: readonly ClientOptionsFragment[],
+	userOptions: ClientOptionsFragment,
+) {
+	const scopes = [
+		...(defaults.contextScopes ?? []),
+		...pluginOptions.flatMap(fragment => fragment.contextScopes ?? []),
+		...(userOptions.contextScopes ?? []),
+	];
+	if (scopes.length) target.contextScopes = scopes;
 }
 
 function composeGlobalMiddlewares(

--- a/src/client/plugins.ts
+++ b/src/client/plugins.ts
@@ -69,8 +69,8 @@ export function resolveClientPlugins(
 	const merged = MergeOptions<BaseClientOptions>(defaults, ...pluginOptions, userOptions);
 	merged.plugins = plugins;
 
-	composeContext(merged, pluginOptions, userOptions);
-	composeGlobalMiddlewares(merged, pluginOptions, userOptions);
+	composeContext(merged, defaults, pluginOptions, userOptions);
+	composeGlobalMiddlewares(merged, defaults, pluginOptions, userOptions);
 	composeDefaults(
 		merged.commands?.defaults,
 		defaults.commands?.defaults,
@@ -107,13 +107,18 @@ function omitPlugins(options: BaseClientOptions): ClientOptionsFragment {
 
 function composeContext(
 	target: BaseClientOptions,
+	defaults: BaseClientOptions,
 	pluginOptions: readonly ClientOptionsFragment[],
 	userOptions: ClientOptionsFragment,
 ) {
-	const callbacks = pluginOptions
-		.map(fragment => fragment.context)
-		.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function');
-	if (userOptions.context) callbacks.push(userOptions.context);
+	const callbacks: NonNullable<BaseClientOptions['context']>[] = [];
+	if (typeof defaults.context === 'function') callbacks.push(defaults.context);
+	callbacks.push(
+		...pluginOptions
+			.map(fragment => fragment.context)
+			.filter((callback): callback is NonNullable<BaseClientOptions['context']> => typeof callback === 'function'),
+	);
+	if (typeof userOptions.context === 'function') callbacks.push(userOptions.context);
 	if (!callbacks.length) return;
 
 	target.context = interaction =>
@@ -122,10 +127,14 @@ function composeContext(
 
 function composeGlobalMiddlewares(
 	target: BaseClientOptions,
+	defaults: BaseClientOptions,
 	pluginOptions: readonly ClientOptionsFragment[],
 	userOptions: ClientOptionsFragment,
 ) {
-	const middlewares = pluginOptions.flatMap(fragment => [...(fragment.globalMiddlewares ?? [])]);
+	const middlewares = [
+		...(defaults.globalMiddlewares ?? []),
+		...pluginOptions.flatMap(fragment => fragment.globalMiddlewares ?? []),
+	];
 	middlewares.push(...(userOptions.globalMiddlewares ?? []));
 	if (middlewares.length) target.globalMiddlewares = middlewares;
 }

--- a/src/commands/handle.ts
+++ b/src/commands/handle.ts
@@ -1,4 +1,5 @@
 import type { Client, WorkerClient } from '../client';
+import { runContextScopes } from '../client/plugins';
 import { type MessageStructure, type OptionResolverStructure, Transformers } from '../client/transformers';
 import type { MakeRequired } from '../common';
 import { INTEGER_OPTION_VALUE_LIMIT } from '../common/it/constants';
@@ -100,32 +101,34 @@ export class HandleCommand {
 		interaction: MessageCommandInteraction | UserCommandInteraction,
 		context: MenuCommandContext<MessageCommandInteraction | UserCommandInteraction>,
 	) {
-		try {
-			if (context.guildId && command.botPermissions) {
-				const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
-				if (permissions) return await command.onBotPermissionsFail?.(context, permissions);
-			}
-
-			await command.onBeforeMiddlewares?.(context);
-			const resultGlobal = await this.runGlobalMiddlewares(command, context);
-			if (typeof resultGlobal === 'boolean') return;
-			const resultMiddle = await this.runMiddlewares(command, context);
-			if (typeof resultMiddle === 'boolean') return;
-
+		return runContextScopes(this.client.options.contextScopes, context, async () => {
 			try {
-				await command.run!(context);
-				await command.onAfterRun?.(context, undefined);
+				if (context.guildId && command.botPermissions) {
+					const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
+					if (permissions) return await command.onBotPermissionsFail?.(context, permissions);
+				}
+
+				await command.onBeforeMiddlewares?.(context);
+				const resultGlobal = await this.runGlobalMiddlewares(command, context);
+				if (typeof resultGlobal === 'boolean') return;
+				const resultMiddle = await this.runMiddlewares(command, context);
+				if (typeof resultMiddle === 'boolean') return;
+
+				try {
+					await command.run!(context);
+					await command.onAfterRun?.(context, undefined);
+				} catch (error) {
+					await command.onRunError?.(context, error);
+					await command.onAfterRun?.(context, error);
+				}
 			} catch (error) {
-				await command.onRunError?.(context, error);
-				await command.onAfterRun?.(context, error);
+				try {
+					await command.onInternalError?.(this.client, command, error);
+				} catch (err) {
+					this.client.logger.error(`[${command.name}] Internal error:`, err);
+				}
 			}
-		} catch (error) {
-			try {
-				await command.onInternalError?.(this.client, command, error);
-			} catch (err) {
-				this.client.logger.error(`[${command.name}] Internal error:`, err);
-			}
-		}
+		});
 	}
 
 	contextMenuMessage(
@@ -145,32 +148,34 @@ export class HandleCommand {
 	}
 
 	async entryPoint(command: EntryPointCommand, interaction: EntryPointInteraction, context: EntryPointContext) {
-		try {
-			if (context.guildId && command.botPermissions) {
-				const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
-				if (permissions) return await command.onBotPermissionsFail(context, permissions);
-			}
-
-			await command.onBeforeMiddlewares?.(context);
-			const resultGlobal = await this.runGlobalMiddlewares(command, context);
-			if (typeof resultGlobal === 'boolean') return;
-			const resultMiddle = await this.runMiddlewares(command, context);
-			if (typeof resultMiddle === 'boolean') return;
-
+		return runContextScopes(this.client.options.contextScopes, context, async () => {
 			try {
-				await command.run!(context);
-				await command.onAfterRun?.(context, undefined);
+				if (context.guildId && command.botPermissions) {
+					const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
+					if (permissions) return await command.onBotPermissionsFail(context, permissions);
+				}
+
+				await command.onBeforeMiddlewares?.(context);
+				const resultGlobal = await this.runGlobalMiddlewares(command, context);
+				if (typeof resultGlobal === 'boolean') return;
+				const resultMiddle = await this.runMiddlewares(command, context);
+				if (typeof resultMiddle === 'boolean') return;
+
+				try {
+					await command.run!(context);
+					await command.onAfterRun?.(context, undefined);
+				} catch (error) {
+					await command.onRunError(context, error);
+					await command.onAfterRun?.(context, error);
+				}
 			} catch (error) {
-				await command.onRunError(context, error);
-				await command.onAfterRun?.(context, error);
+				try {
+					await command.onInternalError(this.client, command, error);
+				} catch (err) {
+					this.client.logger.error(`[${command.name}] Internal error:`, err);
+				}
 			}
-		} catch (error) {
-			try {
-				await command.onInternalError(this.client, command, error);
-			} catch (err) {
-				this.client.logger.error(`[${command.name}] Internal error:`, err);
-			}
-		}
+		});
 	}
 
 	async chatInput(
@@ -179,42 +184,47 @@ export class HandleCommand {
 		resolver: OptionResolverStructure,
 		context: CommandContext,
 	) {
-		try {
-			if (context.guildId) {
-				if (command.botPermissions) {
-					const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
-					if (permissions) return await command.onBotPermissionsFail?.(context, permissions);
-				}
-
-				if (command.defaultMemberPermissions) {
-					const permissions = this.checkPermissions(interaction.member!.permissions, command.defaultMemberPermissions);
-					if (permissions) return await command.onPermissionsFail?.(context, permissions);
-				}
-			}
-
-			await command.onBeforeOptions?.(context);
-			if (!(await this.runOptions(command, context, resolver))) return;
-
-			await command.onBeforeMiddlewares?.(context);
-			const resultGlobal = await this.runGlobalMiddlewares(command, context);
-			if (typeof resultGlobal === 'boolean') return;
-			const resultMiddle = await this.runMiddlewares(command, context);
-			if (typeof resultMiddle === 'boolean') return;
-
+		return runContextScopes(this.client.options.contextScopes, context, async () => {
 			try {
-				await command.run!(context);
-				await command.onAfterRun?.(context, undefined);
+				if (context.guildId) {
+					if (command.botPermissions) {
+						const permissions = this.checkPermissions(interaction.appPermissions, command.botPermissions);
+						if (permissions) return await command.onBotPermissionsFail?.(context, permissions);
+					}
+
+					if (command.defaultMemberPermissions) {
+						const permissions = this.checkPermissions(
+							interaction.member!.permissions,
+							command.defaultMemberPermissions,
+						);
+						if (permissions) return await command.onPermissionsFail?.(context, permissions);
+					}
+				}
+
+				await command.onBeforeOptions?.(context);
+				if (!(await this.runOptions(command, context, resolver))) return;
+
+				await command.onBeforeMiddlewares?.(context);
+				const resultGlobal = await this.runGlobalMiddlewares(command, context);
+				if (typeof resultGlobal === 'boolean') return;
+				const resultMiddle = await this.runMiddlewares(command, context);
+				if (typeof resultMiddle === 'boolean') return;
+
+				try {
+					await command.run!(context);
+					await command.onAfterRun?.(context, undefined);
+				} catch (error) {
+					await command.onRunError?.(context, error);
+					await command.onAfterRun?.(context, error);
+				}
 			} catch (error) {
-				await command.onRunError?.(context, error);
-				await command.onAfterRun?.(context, error);
+				try {
+					await command.onInternalError?.(this.client, command, error);
+				} catch (err) {
+					this.client.logger.error(`[${command.name}] Internal error:`, err);
+				}
 			}
-		} catch (error) {
-			try {
-				await command.onInternalError?.(this.client, command, error);
-			} catch (err) {
-				this.client.logger.error(`[${command.name}] Internal error:`, err);
-			}
-		}
+		});
 	}
 
 	async modal(interaction: ModalSubmitInteraction) {
@@ -363,58 +373,60 @@ export class HandleCommand {
 			const extendContext = self.options?.context?.(message) ?? {};
 			Object.assign(context, extendContext);
 
-			if (errors.length) {
-				return await command.onOptionsError?.(
-					context,
-					Object.fromEntries(
-						errors.map(x => {
-							return [
-								x.name,
-								{
-									failed: true,
-									value: x.error,
-									parseError: x.fullError,
-								},
-							];
-						}),
-					),
-				);
-			}
+			return await runContextScopes(self.options.contextScopes, context, async () => {
+				if (errors.length) {
+					return await command.onOptionsError?.(
+						context,
+						Object.fromEntries(
+							errors.map(x => {
+								return [
+									x.name,
+									{
+										failed: true,
+										value: x.error,
+										parseError: x.fullError,
+									},
+								];
+							}),
+						),
+					);
+				}
 
-			if (rawMessage.guild_id) {
-				if (command.defaultMemberPermissions) {
-					const memberPermissions = await self.members.permissions(rawMessage.guild_id, rawMessage.author.id);
-					const permissions = this.checkPermissions(memberPermissions, command.defaultMemberPermissions);
-					const guild = await this.client.guilds.raw(rawMessage.guild_id);
-					if (permissions && guild.owner_id !== rawMessage.author.id) {
-						return await command.onPermissionsFail?.(context, memberPermissions.keys(permissions));
+				if (rawMessage.guild_id) {
+					if (command.defaultMemberPermissions) {
+						const memberPermissions = await self.members.permissions(rawMessage.guild_id, rawMessage.author.id);
+						const permissions = this.checkPermissions(memberPermissions, command.defaultMemberPermissions);
+						const guild = await this.client.guilds.raw(rawMessage.guild_id);
+						if (permissions && guild.owner_id !== rawMessage.author.id) {
+							return await command.onPermissionsFail?.(context, memberPermissions.keys(permissions));
+						}
+					}
+
+					if (command.botPermissions) {
+						const appPermissions = await self.members.permissions(rawMessage.guild_id, self.botId);
+						const permissions = this.checkPermissions(appPermissions, command.botPermissions);
+						if (permissions) {
+							return await command.onBotPermissionsFail?.(context, permissions);
+						}
 					}
 				}
 
-				if (command.botPermissions) {
-					const appPermissions = await self.members.permissions(rawMessage.guild_id, self.botId);
-					const permissions = this.checkPermissions(appPermissions, command.botPermissions);
-					if (permissions) {
-						return await command.onBotPermissionsFail?.(context, permissions);
-					}
+				await command.onBeforeOptions?.(context);
+				if (!(await this.runOptions(command, context, optionsResolver))) return;
+
+				await command.onBeforeMiddlewares?.(context);
+				const resultGlobal = await this.runGlobalMiddlewares(command, context);
+				if (typeof resultGlobal === 'boolean') return;
+				const resultMiddle = await this.runMiddlewares(command, context);
+				if (typeof resultMiddle === 'boolean') return;
+				try {
+					await command.run!(context);
+					await command.onAfterRun?.(context, undefined);
+				} catch (error) {
+					await command.onRunError?.(context, error);
+					await command.onAfterRun?.(context, error);
 				}
-			}
-
-			await command.onBeforeOptions?.(context);
-			if (!(await this.runOptions(command, context, optionsResolver))) return;
-
-			await command.onBeforeMiddlewares?.(context);
-			const resultGlobal = await this.runGlobalMiddlewares(command, context);
-			if (typeof resultGlobal === 'boolean') return;
-			const resultMiddle = await this.runMiddlewares(command, context);
-			if (typeof resultMiddle === 'boolean') return;
-			try {
-				await command.run!(context);
-				await command.onAfterRun?.(context, undefined);
-			} catch (error) {
-				await command.onRunError?.(context, error);
-				await command.onAfterRun?.(context, error);
-			}
+			});
 		} catch (error) {
 			try {
 				await command.onInternalError?.(this.client, command, error);

--- a/src/components/handler.ts
+++ b/src/components/handler.ts
@@ -6,6 +6,7 @@ import type {
 	ListenerOptions,
 	ModalSubmitCallback,
 } from '../builders/types';
+import { runContextScopes } from '../client/plugins';
 import { LimitedCollection } from '../collection';
 import { BaseCommand, type RegisteredMiddlewares, type UsingClient } from '../commands';
 import type { FileLoaded } from '../commands/handler';
@@ -318,42 +319,44 @@ export class ComponentHandler extends BaseHandler {
 	}
 
 	async execute(i: ComponentCommands, context: ComponentContext | ModalContext) {
-		try {
-			await i.onBeforeMiddlewares?.(context as never);
-			const resultRunGlobalMiddlewares = await BaseCommand.__runMiddlewares(
-				context,
-				(context.client.options?.globalMiddlewares ?? []) as keyof RegisteredMiddlewares,
-				true,
-			);
-			if (resultRunGlobalMiddlewares.pass) {
-				return;
-			}
-			if ('error' in resultRunGlobalMiddlewares) {
-				return await i.onMiddlewaresError?.(context as never, resultRunGlobalMiddlewares.error ?? 'Unknown error');
-			}
-
-			const resultRunMiddlewares = await BaseCommand.__runMiddlewares(context, i.middlewares, false);
-			if (resultRunMiddlewares.pass) {
-				return;
-			}
-			if ('error' in resultRunMiddlewares) {
-				return await i.onMiddlewaresError?.(context as never, resultRunMiddlewares.error ?? 'Unknown error');
-			}
-
+		return runContextScopes(context.client.options.contextScopes, context, async () => {
 			try {
-				await i.run(context as never);
-				await i.onAfterRun?.(context as never, undefined);
+				await i.onBeforeMiddlewares?.(context as never);
+				const resultRunGlobalMiddlewares = await BaseCommand.__runMiddlewares(
+					context,
+					(context.client.options?.globalMiddlewares ?? []) as keyof RegisteredMiddlewares,
+					true,
+				);
+				if (resultRunGlobalMiddlewares.pass) {
+					return;
+				}
+				if ('error' in resultRunGlobalMiddlewares) {
+					return await i.onMiddlewaresError?.(context as never, resultRunGlobalMiddlewares.error ?? 'Unknown error');
+				}
+
+				const resultRunMiddlewares = await BaseCommand.__runMiddlewares(context, i.middlewares, false);
+				if (resultRunMiddlewares.pass) {
+					return;
+				}
+				if ('error' in resultRunMiddlewares) {
+					return await i.onMiddlewaresError?.(context as never, resultRunMiddlewares.error ?? 'Unknown error');
+				}
+
+				try {
+					await i.run(context as never);
+					await i.onAfterRun?.(context as never, undefined);
+				} catch (error) {
+					await i.onRunError?.(context as never, error);
+					await i.onAfterRun?.(context as never, error);
+				}
 			} catch (error) {
-				await i.onRunError?.(context as never, error);
-				await i.onAfterRun?.(context as never, error);
+				try {
+					await i.onInternalError?.(this.client, error);
+				} catch (err) {
+					this.client.logger.error(`[${i.customId ?? 'Component/Modal command'}] Internal error:`, err);
+				}
 			}
-		} catch (error) {
-			try {
-				await i.onInternalError?.(this.client, error);
-			} catch (err) {
-				this.client.logger.error(`[${i.customId ?? 'Component/Modal command'}] Internal error:`, err);
-			}
-		}
+		});
 	}
 
 	async executeComponent(context: ComponentContext) {

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { Client, type ClientOptions } from '../src/client/client';
-import type { SeyfertPlugin } from '../src/client/plugins';
+import { resolveClientPlugins, type SeyfertPlugin } from '../src/client/plugins';
 
 function runtimeConfig() {
 	return {
@@ -46,6 +46,36 @@ describe('client plugins', () => {
 			shared: 'user',
 		});
 		expect(client.options.globalMiddlewares).toEqual(['pluginA', 'pluginB', 'user']);
+	});
+
+	test('preserves base context and global middlewares before plugin and user options', () => {
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			options: () => ({
+				context: () => ({ fromPlugin: true, shared: 'plugin' }),
+				globalMiddlewares: ['plugin' as never],
+			}),
+		};
+
+		const { options } = resolveClientPlugins(
+			{
+				context: () => ({ fromBase: true, shared: 'base' }),
+				globalMiddlewares: ['base' as never],
+			},
+			{
+				plugins: [plugin],
+				context: () => ({ fromUser: true, shared: 'user' }),
+				globalMiddlewares: ['user' as never],
+			},
+		);
+
+		expect(options.context?.({} as never)).toEqual({
+			fromBase: true,
+			fromPlugin: true,
+			fromUser: true,
+			shared: 'user',
+		});
+		expect(options.globalMiddlewares).toEqual(['base', 'plugin', 'user']);
 	});
 
 	test('runs plugin lifecycle hooks before user lifecycle hooks', async () => {
@@ -108,5 +138,38 @@ describe('client plugins', () => {
 		await client.start({ token: 'header.payload.signature' }, false);
 
 		expect(calls).toEqual(['plugin-a', 'plugin-b']);
+	});
+
+	test('shares setup work across concurrent starts', async () => {
+		const calls: string[] = [];
+		let releaseSetup = () => {};
+		const holdSetup = new Promise<void>(resolve => {
+			releaseSetup = resolve;
+		});
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: async () => {
+				calls.push('plugin');
+				await holdSetup;
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		const starts = [
+			client.start({ token: 'header.payload.signature' }, false),
+			client.start({ token: 'header.payload.signature' }, false),
+		];
+
+		try {
+			await new Promise(resolve => setTimeout(resolve, 0));
+			expect(calls).toEqual(['plugin']);
+		} finally {
+			releaseSetup();
+			await Promise.allSettled(starts);
+		}
+
+		expect(calls).toEqual(['plugin']);
 	});
 });

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -140,6 +140,35 @@ describe('client plugins', () => {
 		expect(calls).toEqual(['plugin-a', 'plugin-b']);
 	});
 
+	test('runs setup before cache start and command loading', async () => {
+		const calls: string[] = [];
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: () => {
+				calls.push('plugin');
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+		client.cache.adapter.start = async () => {
+			calls.push('cache');
+		};
+		client.loadLangs = async () => {
+			calls.push('langs');
+		};
+		client.loadCommands = async () => {
+			calls.push('commands');
+		};
+		client.loadComponents = async () => {
+			calls.push('components');
+		};
+
+		await client.start({ token: 'header.payload.signature' }, false);
+
+		expect(calls).toEqual(['plugin', 'cache', 'langs', 'commands', 'components']);
+	});
+
 	test('shares setup work across concurrent starts', async () => {
 		const calls: string[] = [];
 		let releaseSetup = () => {};

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { Client, type ClientOptions } from '../src/client/client';
-import { resolveClientPlugins, type SeyfertPlugin } from '../src/client/plugins';
+import { resolveClientPlugins, runContextScopes, type SeyfertPlugin } from '../src/client/plugins';
 
 function runtimeConfig() {
 	return {
@@ -113,6 +113,63 @@ describe('client plugins', () => {
 		await client.options.commands?.defaults?.onAfterRun?.({} as never, undefined);
 
 		expect(calls).toEqual(['plugin-a', 'plugin-b', 'user']);
+	});
+
+	test('composes context scopes in plugin order before user scopes', async () => {
+		const calls: string[] = [];
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			options: () => ({
+				contextScopes: [
+					async (_context, run) => {
+						calls.push('plugin-a before');
+						const result = await run();
+						calls.push('plugin-a after');
+						return result;
+					},
+				],
+			}),
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			options: () => ({
+				contextScopes: [
+					async (_context, run) => {
+						calls.push('plugin-b before');
+						const result = await run();
+						calls.push('plugin-b after');
+						return result;
+					},
+				],
+			}),
+		};
+		const client = createClient({
+			plugins: [pluginA, pluginB],
+			contextScopes: [
+				async (_context, run) => {
+					calls.push('user before');
+					const result = await run();
+					calls.push('user after');
+					return result;
+				},
+			],
+		});
+
+		const result = await runContextScopes(client.options.contextScopes, {}, async () => {
+			calls.push('handler');
+			return 'done';
+		});
+
+		expect(result).toBe('done');
+		expect(calls).toEqual([
+			'plugin-a before',
+			'plugin-b before',
+			'user before',
+			'handler',
+			'user after',
+			'plugin-b after',
+			'plugin-a after',
+		]);
 	});
 
 	test('runs setup once during start in plugin order', async () => {

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -201,4 +201,23 @@ describe('client plugins', () => {
 
 		expect(calls).toEqual(['plugin']);
 	});
+
+	test('retries setup after plugin setup fails', async () => {
+		const calls: string[] = [];
+		const plugin: SeyfertPlugin = {
+			name: 'plugin',
+			setup: () => {
+				calls.push('plugin');
+				if (calls.length === 1) throw new Error('setup failed');
+			},
+		};
+		const client = createClient({ plugins: [plugin] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		await expect(client.start({ token: 'header.payload.signature' }, false)).rejects.toThrow('setup failed');
+		await expect(client.start({ token: 'header.payload.signature' }, false)).resolves.toBeUndefined();
+
+		expect(calls).toEqual(['plugin', 'plugin']);
+	});
 });

--- a/tests/client-plugins.test.mts
+++ b/tests/client-plugins.test.mts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+import { Client, type ClientOptions } from '../src/client/client';
+import type { SeyfertPlugin } from '../src/client/plugins';
+
+function runtimeConfig() {
+	return {
+		token: 'header.payload.signature',
+		locations: { base: process.cwd() },
+	};
+}
+
+function createClient(options: ClientOptions = {}) {
+	return new Client({
+		getRC: async () => runtimeConfig(),
+		...options,
+	});
+}
+
+describe('client plugins', () => {
+	test('composes context callbacks and global middlewares in plugin order before user options', () => {
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			options: () => ({
+				context: () => ({ fromA: true, shared: 'plugin-a' }),
+				globalMiddlewares: ['pluginA' as never],
+			}),
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			options: () => ({
+				context: () => ({ fromB: true, shared: 'plugin-b' }),
+				globalMiddlewares: ['pluginB' as never],
+			}),
+		};
+
+		const client = createClient({
+			plugins: [pluginA, pluginB],
+			context: () => ({ fromUser: true, shared: 'user' }),
+			globalMiddlewares: ['user' as never],
+		});
+
+		expect(client.options.context?.({} as never)).toEqual({
+			fromA: true,
+			fromB: true,
+			fromUser: true,
+			shared: 'user',
+		});
+		expect(client.options.globalMiddlewares).toEqual(['pluginA', 'pluginB', 'user']);
+	});
+
+	test('runs plugin lifecycle hooks before user lifecycle hooks', async () => {
+		const calls: string[] = [];
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			options: () => ({
+				commands: {
+					defaults: {
+						onAfterRun: () => calls.push('plugin-a'),
+					},
+				},
+			}),
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			options: () => ({
+				commands: {
+					defaults: {
+						onAfterRun: () => calls.push('plugin-b'),
+					},
+				},
+			}),
+		};
+
+		const client = createClient({
+			plugins: [pluginA, pluginB],
+			commands: {
+				defaults: {
+					onAfterRun: () => calls.push('user'),
+				},
+			},
+		});
+
+		await client.options.commands?.defaults?.onAfterRun?.({} as never, undefined);
+
+		expect(calls).toEqual(['plugin-a', 'plugin-b', 'user']);
+	});
+
+	test('runs setup once during start in plugin order', async () => {
+		const calls: string[] = [];
+		const pluginA: SeyfertPlugin = {
+			name: 'plugin-a',
+			setup: client => {
+				expect(client.plugins.map(plugin => plugin.name)).toEqual(['plugin-a', 'plugin-b']);
+				calls.push('plugin-a');
+			},
+		};
+		const pluginB: SeyfertPlugin = {
+			name: 'plugin-b',
+			setup: () => {
+				calls.push('plugin-b');
+			},
+		};
+		const client = createClient({ plugins: [pluginA, pluginB] });
+
+		(client as unknown as { gateway: unknown }).gateway = {};
+
+		await client.start({ token: 'header.payload.signature' }, false);
+		await client.start({ token: 'header.payload.signature' }, false);
+
+		expect(calls).toEqual(['plugin-a', 'plugin-b']);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a generic `contextScopes` client option for plugin-provided async context wrappers.
- Composes context scopes in base, plugin, then user order and executes handlers inside nested scopes.
- Wraps chat input, context menu, entry point, prefix command, component, and modal execution so plugins can expose request/interaction-scoped helpers without passing `ctx` through service layers.

## Slipher PR Stack
- tiramisulabs/extra#11 — adds `@slipher/cooldown` 1.0.0; this PR enables `ctx.cooldown.context()` to use the current interaction scope.
- tiramisulabs/extra#16 — source Slipher package roadmap draft being split into focused PRs.
- tiramisulabs/extra#17 — adds `@slipher/testing` as runner-agnostic Seyfert fixtures.
- tiramisulabs/extra#18 — adds `@slipher/logger`; this PR enables its `useLogger()` current interaction scope.
- tiramisulabs/extra#19 — adds `@slipher/queues` with memory and BullMQ drivers.
- tiramisulabs/extra#20 — adds `@slipher/scheduler` with Croner and BullMQ-backed tasks.
- tiramisulabs/extra#21 — centralizes Biome formatting config.

## Verification
- `pnpm check`
- `pnpm build`
- `pnpm test`
