### PR TITLE
feat: add context to vague loader/shard warnings

### DIFF
--- a/src/client/workerclient.ts
+++ b/src/client/workerclient.ts
@@ -227,7 +227,7 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				{
 					const shard = this.shards.get(data.shardId);
 					if (!shard) {
-						this.logger.fatal('Worker trying send payload by non-existent shard');
+						this.logger.fatal(`Worker trying to send payload by non-existent shard (#${data.shardId})`);
 						return;
 					}
 
@@ -250,7 +250,7 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				{
 					const shard = this.resharding.get(data.shardId);
 					if (!shard) {
-						this.logger.fatal('Worker trying reshard non-existent shard');
+						this.logger.fatal(`Worker trying to reshard non-existent shard (#${data.shardId})`);
 						return;
 					}
 					shard.options.presence = data.presence;
@@ -261,7 +261,7 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				{
 					const shard = this.shards.get(data.shardId);
 					if (!shard) {
-						this.logger.fatal('Worker trying connect non-existent shard');
+						this.logger.fatal(`Worker trying to connect non-existent shard (#${data.shardId})`);
 						return;
 					}
 					shard.options.presence = data.presence;
@@ -333,7 +333,7 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				{
 					const shard = this.shards.get(data.shardId);
 					if (!shard) {
-						this.logger.fatal('Worker trying get non-existent shard');
+						this.logger.fatal(`Worker trying to get non-existent shard (#${data.shardId})`);
 						return;
 					}
 

--- a/src/commands/applications/chat.ts
+++ b/src/commands/applications/chat.ts
@@ -37,7 +37,6 @@ import type {
 	ExtraProps,
 	IgnoreCommand,
 	OnOptionsReturnObject,
-	PassFunction,
 	SeyfertChannelMap,
 	StopFunction,
 	UsingClient,
@@ -96,13 +95,13 @@ type ContextOptionsAuxInternal<
 	: NonNullable<T['value']> extends (...args: any) => any
 		? Parameters<Parameters<NonNullable<T['value']>>[1]>[0] extends never
 			? T extends { channel_types?: infer C }
-				? C extends any[]
+				? C extends readonly any[]
 					? C[number] extends keyof SeyfertChannelMap
 						? SeyfertChannelMap[C[number]]
 						: never
 					: never
 				: T extends { choices?: infer C }
-					? C extends SeyfertChoice<string | number>[]
+					? C extends readonly SeyfertChoice<string | number>[]
 						? C[number]['value']
 						: never
 					: never
@@ -222,13 +221,6 @@ export class BaseCommand {
 
 		return new Promise((res, rej) => {
 			let running = true;
-			const pass: PassFunction = () => {
-				if (!running) {
-					return;
-				}
-				running = false;
-				return res({ pass: true });
-			};
 			function next(...args: unknown[]) {
 				if (!running) {
 					return;
@@ -253,6 +245,13 @@ export class BaseCommand {
 				});
 			};
 			const stop: StopFunction = err => {
+				if (err == null) {
+					if (!running) {
+						return;
+					}
+					running = false;
+					return res({ pass: true });
+				}
 				return deny(err, activeMiddlewares[index]);
 			};
 			const rejectRunner = (err: unknown) => {
@@ -265,7 +264,7 @@ export class BaseCommand {
 			function invoke(middleware: keyof ResolvedRegisteredMiddlewares) {
 				let result: unknown;
 				try {
-					result = context.client.middlewares![middleware]({ context, next, stop, pass });
+					result = context.client.middlewares![middleware]({ context, next, stop });
 				} catch (err) {
 					rejectRunner(err);
 					return;

--- a/src/commands/applications/options.ts
+++ b/src/commands/applications/options.ts
@@ -36,7 +36,7 @@ export interface SeyfertBasicOption<T extends keyof ReturnOptionsTypes, R = true
 
 export interface SeyfertBaseChoiceableOption<
 	T extends keyof ReturnOptionsTypes,
-	C = T extends ChoiceableTypes ? SeyfertChoice<ChoiceableValues[T]>[] : never,
+	C = T extends ChoiceableTypes ? readonly SeyfertChoice<ChoiceableValues[T]>[] : never,
 	R = true | false,
 	VC = never,
 > {
@@ -76,13 +76,13 @@ export interface ChoiceableValues {
 
 export type ValueCallback<
 	T extends keyof ReturnOptionsTypes,
-	C = T extends ChoiceableTypes ? SeyfertChoice<ChoiceableValues[T]>[] : keyof SeyfertChannelMap,
+	C = T extends ChoiceableTypes ? readonly SeyfertChoice<ChoiceableValues[T]>[] : keyof SeyfertChannelMap,
 	I = any,
 > = (
 	data: {
 		context: CommandContext;
 		value: T extends ChoiceableTypes
-			? C extends SeyfertChoice<ChoiceableValues[T]>[]
+			? C extends readonly SeyfertChoice<ChoiceableValues[T]>[]
 				? C[number]['value'] extends ReturnOptionsTypes[T]
 					? C[number]['value']
 					: never
@@ -95,34 +95,31 @@ export type ValueCallback<
 	fail: StopFunction,
 ) => Awaitable<void>;
 
-export type SeyfertStringOption<T = SeyfertChoice<string>[], R = boolean, VC = never> = SeyfertBaseChoiceableOption<
-	ApplicationCommandOptionType.String,
-	T,
-	R,
-	VC
-> & {
+export type SeyfertStringOption<
+	T = readonly SeyfertChoice<string>[],
+	R = boolean,
+	VC = never,
+> = SeyfertBaseChoiceableOption<ApplicationCommandOptionType.String, T, R, VC> & {
 	autocomplete?: AutocompleteCallback<string>;
 	onAutocompleteError?: OnAutocompleteErrorCallback<string>;
 	min_length?: number;
 	max_length?: number;
 };
-export type SeyfertIntegerOption<T = SeyfertChoice<number>[], R = boolean, VC = never> = SeyfertBaseChoiceableOption<
-	ApplicationCommandOptionType.Integer,
-	T,
-	R,
-	VC
-> & {
+export type SeyfertIntegerOption<
+	T = readonly SeyfertChoice<number>[],
+	R = boolean,
+	VC = never,
+> = SeyfertBaseChoiceableOption<ApplicationCommandOptionType.Integer, T, R, VC> & {
 	autocomplete?: AutocompleteCallback<number>;
 	onAutocompleteError?: OnAutocompleteErrorCallback<number>;
 	min_value?: number;
 	max_value?: number;
 };
-export type SeyfertNumberOption<T = SeyfertChoice<number>[], R = boolean, VC = never> = SeyfertBaseChoiceableOption<
-	ApplicationCommandOptionType.Number,
-	T,
-	R,
-	VC
-> & {
+export type SeyfertNumberOption<
+	T = readonly SeyfertChoice<number>[],
+	R = boolean,
+	VC = never,
+> = SeyfertBaseChoiceableOption<ApplicationCommandOptionType.Number, T, R, VC> & {
 	autocomplete?: AutocompleteCallback<number>;
 	onAutocompleteError?: OnAutocompleteErrorCallback<number>;
 	min_value?: number;
@@ -140,7 +137,7 @@ export type SeyfertChannelOption<C = keyof SeyfertChannelMap, R = true | false, 
 		name?: FlatObjectKeys<DefaultLocale>;
 		description?: FlatObjectKeys<DefaultLocale>;
 	};
-	channel_types?: C[];
+	channel_types?: readonly C[];
 };
 export type SeyfertRoleOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Role, R>;
 export type SeyfertMentionableOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Mentionable, R>;
@@ -148,7 +145,7 @@ export type SeyfertAttachmentOption<R = boolean> = SeyfertBasicOption<Applicatio
 
 export function createStringOption<
 	R extends boolean,
-	C extends SeyfertChoice<string>[] = SeyfertChoice<string>[],
+	C extends readonly SeyfertChoice<string>[] = readonly SeyfertChoice<string>[],
 	VC = never,
 >(data: SeyfertStringOption<C, R, VC>) {
 	return { ...data, type: ApplicationCommandOptionType.String } as const;
@@ -156,7 +153,7 @@ export function createStringOption<
 
 export function createIntegerOption<
 	R extends boolean,
-	C extends SeyfertChoice<number>[] = SeyfertChoice<number>[],
+	C extends readonly SeyfertChoice<number>[] = readonly SeyfertChoice<number>[],
 	VC = never,
 >(data: SeyfertIntegerOption<C, R, VC>) {
 	return { ...data, type: ApplicationCommandOptionType.Integer } as const;
@@ -164,7 +161,7 @@ export function createIntegerOption<
 
 export function createNumberOption<
 	R extends boolean,
-	C extends SeyfertChoice<number>[] = SeyfertChoice<number>[],
+	C extends readonly SeyfertChoice<number>[] = readonly SeyfertChoice<number>[],
 	VC = never,
 >(data: SeyfertNumberOption<C, R, VC>) {
 	return { ...data, type: ApplicationCommandOptionType.Number } as const;

--- a/src/commands/applications/shared.ts
+++ b/src/commands/applications/shared.ts
@@ -17,9 +17,8 @@ import type { ChannelType } from '../../types';
 import type { ResolvedRegisteredMiddlewares } from '../decorators';
 
 export type OKFunction<T> = (value: T) => void;
-export type StopFunction = (error: string) => void;
+export type StopFunction = (error?: string | null) => void;
 export type NextFunction<T = unknown> = IsStrictlyUndefined<T> extends true ? () => void : (data: T) => void;
-export type PassFunction = () => void;
 
 export type InferWithPrefix = InternalOptions extends { withPrefix: infer P } ? P : false;
 
@@ -57,14 +56,8 @@ export type MiddlewareContext<T = any, C = any> = (context: {
 	context: C;
 	next: NextFunction<T>;
 	stop: StopFunction;
-	pass: PassFunction;
 }) => any;
-export type AnyMiddlewareContext = (context: {
-	context: any;
-	next: any;
-	stop: StopFunction;
-	pass: PassFunction;
-}) => any;
+export type AnyMiddlewareContext = (context: { context: any; next: any; stop: StopFunction }) => any;
 export type MetadataMiddleware<T extends AnyMiddlewareContext> = T extends (context: infer Payload) => any
 	? Payload extends { next: (...args: infer Args) => unknown }
 		? IsStrictlyUndefined<Args[0]> extends true
@@ -111,7 +104,7 @@ export type CommandMetadata<
 			: {};
 
 export type MessageCommandOptionErrors =
-	| ['CHANNEL_TYPES', type: ChannelType[]]
+	| ['CHANNEL_TYPES', type: readonly ChannelType[]]
 	| ['STRING_MIN_LENGTH', min: number]
 	| ['STRING_MAX_LENGTH', max: number]
 	| ['STRING_INVALID_CHOICE', choices: readonly { name: string; value: string }[]]

--- a/src/commands/applications/shared.ts
+++ b/src/commands/applications/shared.ts
@@ -27,14 +27,26 @@ export interface GlobalMetadata {}
 export type DefaultLocale = SeyfertRegistry extends { langs: infer L extends Record<string, any> } ? L : {};
 export interface ExtendContext extends RegisteredPluginContext {}
 export interface ExtraProps {}
-export type UsingClient = BaseClient &
-	RegisteredPluginExtension &
-	(SeyfertRegistry extends { client: infer C } ? C : unknown);
+declare const __seyfertClientType: unique symbol;
+type RegisteredClient = SeyfertRegistry extends { client: infer C }
+	? [C] extends [{ readonly [__seyfertClientType]?: infer T }]
+		? [T] extends [never]
+			? BaseClient
+			: unknown extends T
+				? C extends BaseClient
+					? C
+					: BaseClient
+				: T
+		: C extends BaseClient
+			? C
+			: BaseClient
+	: BaseClient;
+export type UsingClient = BaseClient & RegisteredPluginExtension & RegisteredClient;
 export interface CustomWorkerClientEvents {}
 export interface CustomWorkerManagerEvents {}
 export interface ExtendedRC {}
 export interface ExtendedRCLocations {}
-export type ParseClient<T extends BaseClient> = T;
+export type ParseClient<T extends BaseClient> = T & { readonly [__seyfertClientType]?: T };
 export type ParseGlobalMiddlewares<T extends Record<string, AnyMiddlewareContext>> = {
 	[K in keyof T]: MetadataMiddleware<T[K]>;
 };

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -316,7 +316,7 @@ export class CommandHandler extends BaseHandler {
 				commandInstance = this.onCommand(command, options.create);
 				if (!commandInstance) continue;
 			} catch (e) {
-				this.logger.warn(`${command.name} ins't a resolvable command`);
+				this.logger.warn(`${command.name} isn't a resolvable command`);
 				this.logger.error(e);
 				continue;
 			}

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -374,9 +374,12 @@ export class CommandHandler extends BaseHandler {
 								continue;
 							}
 							try {
+								const relativePath = option.split(process.cwd()).slice(1).join(process.cwd());
 								const fileSubCommands = this.onFile(result.find(x => x.path === option)!.file);
 								if (!fileSubCommands) {
-									this.logger.warn(`SubCommand returned (${fileSubCommands}) ignoring.`);
+									this.logger.warn(
+										`Command "${commandInstance.name}": no default export found in "${relativePath}", ignoring it as a SubCommand.`,
+									);
 									continue;
 								}
 								for (const fileSubCommand of fileSubCommands) {
@@ -385,7 +388,10 @@ export class CommandHandler extends BaseHandler {
 										subCommand.__filePath = option;
 										commandInstance.options!.push(subCommand);
 									} else {
-										this.logger.warn(subCommand ? 'SubCommand expected' : 'Invalid SubCommand', subCommand);
+										this.logger.warn(
+											`Command "${commandInstance.name}": expected a SubCommand from "${relativePath}", got (${subCommand}); ignoring it.`,
+											subCommand,
+										);
 									}
 								}
 							} catch {

--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -256,7 +256,7 @@ export class EventHandler extends CustomEventHandler {
 			const instance = this.callback(event);
 			if (!instance) continue;
 			if (typeof instance?.run !== 'function') {
-				this.logger.warn('Missing event run function');
+				this.logger.warn(`Event "${instance.data?.name ?? 'unknown'}" is missing a 'run' function, ignoring it.`);
 				continue;
 			}
 			this.values[normalizeEventName(instance.data.name) as CustomEventsKeys | GatewayEvents] = instance as EventValue;

--- a/src/langs/router.ts
+++ b/src/langs/router.ts
@@ -2,10 +2,7 @@ import type { DefaultLocale } from '../commands';
 import { SeyfertError } from '../common';
 
 export const LangRouter = (userLocale: string, defaultLang: string, langs: Partial<Record<string, any>>) => {
-	function createProxy(
-		route = [] as string[],
-		args: any[] = [],
-	): __InternalParseLocale<DefaultLocale> & { get(locale?: string): DefaultLocale } {
+	function createProxy(route = [] as string[], args: any[] = []): SeyfertLocale {
 		const noop = () => {
 			return;
 		};
@@ -53,6 +50,14 @@ export type __InternalParseLocale<T extends Record<string, any>> = {
 					? __InternalParseLocale<T[K]> & { get(locale?: string): T[K] }
 					: never;
 };
+
+/**
+ * The `ctx.t` / `client.t(...)` accessor type. Kept as a named alias so that inferred return
+ * types (BaseClient.t, the context `t` getters, ...) emit a reference to `DefaultLocale` instead
+ * of eagerly baking it to `{}` at build time (where `SeyfertRegistry` has no `langs`), which left
+ * consumers with an untyped `ctx.t`.
+ */
+export type SeyfertLocale = __InternalParseLocale<DefaultLocale> & { get(locale?: string): DefaultLocale };
 
 export type ParseLocales<T extends Record<string, any>> = T;
 /**Idea inspiration from: FreeAoi | Fixed by: Drylozu */

--- a/src/structures/channels.ts
+++ b/src/structures/channels.ts
@@ -157,6 +157,14 @@ export class BaseNoEditableChannel<T extends ChannelType> extends DiscordBase<AP
 		return !this.isDM() && this.isTextable();
 	}
 
+	isNamed(): this is AllNamedChannels {
+		return typeof (this as { name?: unknown }).name === 'string';
+	}
+
+	isGuild(): this is AllGuildChannels | BaseGuildChannelStructure {
+		return !this.isDM();
+	}
+
 	isThreadOnly(): this is ForumChannel | MediaChannel {
 		return this.isForum() || this.isMedia();
 	}
@@ -679,6 +687,11 @@ export class NewsChannel extends BaseGuildChannel {
 	}
 }
 
+export interface DirectoryChannel
+	extends ObjectToLower<Omit<APIGuildChannel<ChannelType.GuildDirectory>, 'permission_overwrites' | 'guild_id'>> {
+	guildId: string;
+}
+
 export class DirectoryChannel extends BaseChannel<ChannelType.GuildDirectory> {}
 
 export type AllGuildChannels =
@@ -704,6 +717,7 @@ export type AllGuildTextableChannels =
 	| NewsChannelStructure
 	| ThreadChannelStructure;
 export type AllGuildVoiceChannels = VoiceChannelStructure | StageChannelStructure;
+export type AllNamedChannels = AllGuildChannels | BaseGuildChannelStructure | (BaseChannelStructure & { name: string });
 
 export type AllChannels =
 	| BaseChannelStructure

--- a/src/structures/channels.ts
+++ b/src/structures/channels.ts
@@ -101,8 +101,8 @@ export class BaseNoEditableChannel<T extends ChannelType> extends DiscordBase<AP
 		}
 	}
 
-	delete(reason?: string): Promise<AllChannels> {
-		return this.client.channels.delete(this.id, { reason });
+	delete(reason?: string): Promise<this> {
+		return this.client.channels.delete(this.id, { reason }) as unknown as Promise<this>;
 	}
 
 	toString() {
@@ -594,7 +594,7 @@ export class MediaChannel extends BaseGuildChannel {
 
 export interface ForumChannel
 	extends ObjectToLower<Omit<APIGuildForumChannel, 'permission_overwrites' | 'guild_id'>>,
-		Omit<ThreadOnlyMethods, 'type' | 'edit'>,
+		Omit<ThreadOnlyMethods, 'type' | 'edit' | 'delete'>,
 		WebhookChannelMethods {}
 @mix(ThreadOnlyMethods, WebhookChannelMethods)
 export class ForumChannel extends BaseGuildChannel {
@@ -603,7 +603,7 @@ export class ForumChannel extends BaseGuildChannel {
 
 export interface ThreadChannel
 	extends ObjectToLower<Omit<APIThreadChannel, 'permission_overwrites' | 'guild_id'>>,
-		Omit<TextBaseGuildChannel, 'edit' | 'parentId'> {
+		Omit<TextBaseGuildChannel, 'edit' | 'parentId' | 'delete'> {
 	parentId: string;
 }
 @mix(TextBaseGuildChannel)

--- a/src/websocket/discord/shard.ts
+++ b/src/websocket/discord/shard.ts
@@ -311,7 +311,7 @@ export class Shard {
 			case GatewayOpcodes.InvalidSession: {
 				if (packet.d) {
 					if (!this.resumable) {
-						return this.logger.fatal('This is a completely unexpected error message.');
+						return this.logger.fatal(`Shard #${this.id} received a non-resumable InvalidSession, cannot resume.`);
 					}
 					return this.resume();
 				}
@@ -490,7 +490,7 @@ export class Shard {
 		clearInterval(this.heart.nodeInterval);
 		clearTimeout(this.heart.ackTimeout);
 		this.logger.warn(
-			`${ShardSocketCloseCodes[close.code] ?? GatewayCloseCodes[close.code] ?? close.code} (${close.code})`,
+			`Shard #${this.id} closed: ${ShardSocketCloseCodes[close.code] ?? GatewayCloseCodes[close.code] ?? close.code} (${close.code})`,
 			close.reason,
 		);
 
@@ -534,11 +534,11 @@ export class Shard {
 				case GatewayCloseCodes.InvalidIntents:
 				case GatewayCloseCodes.InvalidShard:
 				case GatewayCloseCodes.ShardingRequired:
-					this.logger.fatal('Cannot reconnect');
+					this.logger.fatal(`Shard #${this.id} cannot reconnect`);
 					break;
 				default:
 					{
-						this.logger.warn('Unknown close code, trying to reconnect anyways');
+						this.logger.warn(`Shard #${this.id} unknown close code (${close.code}), trying to reconnect anyways`);
 						await this.reconnect();
 					}
 					break;

--- a/src/websocket/discord/shard.ts
+++ b/src/websocket/discord/shard.ts
@@ -158,7 +158,7 @@ export class Shard {
 
 		this.websocket.onclose = (event: { code: number; reason: string }) => this.handleClosed(event);
 
-		this.websocket.onerror = (event: ErrorEvent) => this.logger.error(event);
+		this.websocket.onerror = (event: ErrorEvent) => this.logger.error(`Shard #${this.id}`, event);
 
 		this.websocket.onopen = () => {
 			this.isConnecting = false;

--- a/tests/command-context-client-type.test.mts
+++ b/tests/command-context-client-type.test.mts
@@ -24,6 +24,9 @@ const writeConsumerFixture = (root: string) => {
 import { middlewares } from "./middlewares";
 
 export let client: Client<true>;
+declare const typedClient: Client<true>;
+const parsedClient: ParseClient<Client<true>> = typedClient;
+void parsedClient;
 
 declare module "seyfert" {
 	interface SeyfertRegistry {
@@ -59,6 +62,117 @@ const options = {
 
 declare const ctx: GuildCommandContext<typeof options>;
 ctx.client.messages.write(ctx.channelId, { content: "ok" });
+`,
+	);
+};
+
+const writeInvalidClientFixture = (root: string) => {
+	mkdirSync(join(root, 'src'), { recursive: true });
+	mkdirSync(join(root, 'node_modules'), { recursive: true });
+	symlinkSync(process.cwd(), join(root, 'node_modules', 'seyfert'), 'dir');
+
+	writeFileSync(
+		join(root, 'src', 'start.ts'),
+		`import type { BaseClient } from "seyfert/lib/client/base";
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: Pick<BaseClient, "messages" | "rest" | "logger"> & { fake: 1 };
+	}
+}
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'command.ts'),
+		`import "./start";
+import type { CommandContext } from "seyfert";
+
+declare const ctx: CommandContext;
+ctx.client.messages.write("123", { content: "ok" });
+ctx.client.fake;
+`,
+	);
+};
+
+const writeDirectClientFixture = (root: string) => {
+	mkdirSync(join(root, 'src'), { recursive: true });
+	mkdirSync(join(root, 'node_modules'), { recursive: true });
+	symlinkSync(process.cwd(), join(root, 'node_modules', 'seyfert'), 'dir');
+
+	writeFileSync(
+		join(root, 'src', 'start.ts'),
+		`import type { Client } from "seyfert";
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: Client<true>;
+	}
+}
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'command.ts'),
+		`import "./start";
+import type { CommandContext } from "seyfert";
+
+declare const ctx: CommandContext;
+ctx.client.gateway.values();
+ctx.client.events.load("events");
+ctx.client.messages.write("123", { content: "ok" });
+`,
+	);
+};
+
+const writeDocumentedClientVariantFixture = (root: string) => {
+	mkdirSync(join(root, 'src'), { recursive: true });
+	mkdirSync(join(root, 'node_modules'), { recursive: true });
+	symlinkSync(process.cwd(), join(root, 'node_modules', 'seyfert'), 'dir');
+
+	writeFileSync(
+		join(root, 'src', 'gateway.ts'),
+		`import type { Client, CommandContext, ParseClient } from "seyfert";
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: ParseClient<Client<true>>;
+	}
+}
+
+declare const ctx: CommandContext;
+ctx.client.gateway.values();
+ctx.client.events.load("events");
+ctx.client.messages.write("123", { content: "ok" });
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'http.ts'),
+		`import type { CommandContext, HttpClient, ParseClient } from "seyfert";
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: ParseClient<HttpClient>;
+	}
+}
+
+declare const ctx: CommandContext;
+ctx.client.messages.write("123", { content: "ok" });
+ctx.client.rest;
+ctx.client.logger;
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'worker.ts'),
+		`import type { CommandContext, ParseClient, WorkerClient } from "seyfert";
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: ParseClient<WorkerClient<true>>;
+	}
+}
+
+declare const ctx: CommandContext;
+ctx.client.events.load("events");
+ctx.client.messages.write("123", { content: "ok" });
 `,
 	);
 };
@@ -111,6 +225,87 @@ describe('command context client type', () => {
 			expect(clientTypes).toHaveLength(1);
 			expect(clientTypes[0]?.text).toBe('UsingClient');
 			expect(clientTypes[0]?.isAny).toBe(false);
+			expect(program.getSemanticDiagnostics()).toHaveLength(0);
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	test('ignores arbitrary client registry types not created with ParseClient', () => {
+		const root = mkdtempSync(join(tmpdir(), 'seyfert-invalid-client-'));
+
+		try {
+			writeInvalidClientFixture(root);
+
+			const commandFile = join(root, 'src', 'command.ts');
+			const program = ts.createProgram([commandFile], {
+				esModuleInterop: true,
+				module: ts.ModuleKind.CommonJS,
+				moduleResolution: ts.ModuleResolutionKind.Node10,
+				noEmit: true,
+				skipLibCheck: true,
+				strict: true,
+				target: ts.ScriptTarget.ESNext,
+				types: ['node'],
+			});
+			const diagnostics = program.getSemanticDiagnostics();
+
+			expect(
+				diagnostics.some(
+					(diagnostic) =>
+						diagnostic.code === 2339 &&
+						ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n').includes('fake'),
+				),
+			).toBe(true);
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	test('keeps direct Client registry types compatible', () => {
+		const root = mkdtempSync(join(tmpdir(), 'seyfert-direct-client-'));
+
+		try {
+			writeDirectClientFixture(root);
+
+			const commandFile = join(root, 'src', 'command.ts');
+			const program = ts.createProgram([commandFile], {
+				esModuleInterop: true,
+				module: ts.ModuleKind.CommonJS,
+				moduleResolution: ts.ModuleResolutionKind.Node10,
+				noEmit: true,
+				skipLibCheck: true,
+				strict: true,
+				target: ts.ScriptTarget.ESNext,
+				types: ['node'],
+			});
+
+			expect(program.getSemanticDiagnostics()).toHaveLength(0);
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
+	});
+
+	test('keeps documented ParseClient variants compatible', () => {
+		const root = mkdtempSync(join(tmpdir(), 'seyfert-client-variants-'));
+
+		try {
+			writeDocumentedClientVariantFixture(root);
+
+			for (const filename of ['gateway.ts', 'http.ts', 'worker.ts']) {
+				const program = ts.createProgram([join(root, 'src', filename)], {
+					esModuleInterop: true,
+					module: ts.ModuleKind.CommonJS,
+					moduleResolution: ts.ModuleResolutionKind.Node10,
+					noEmit: true,
+					skipLibCheck: true,
+					strict: true,
+					target: ts.ScriptTarget.ESNext,
+					types: ['node'],
+				});
+
+				expect(program.getSemanticDiagnostics()).toHaveLength(0);
+			}
 		} finally {
 			rmSync(root, { force: true, recursive: true });
 		}

--- a/tests/command-context-client-type.test.mts
+++ b/tests/command-context-client-type.test.mts
@@ -311,3 +311,124 @@ describe('command context client type', () => {
 		}
 	});
 });
+
+const writeLocaleFixture = (root: string) => {
+	mkdirSync(join(root, 'src', 'langs'), { recursive: true });
+	mkdirSync(join(root, 'node_modules'), { recursive: true });
+	symlinkSync(process.cwd(), join(root, 'node_modules', 'seyfert'), 'dir');
+
+	writeFileSync(join(root, 'src', 'index.ts'), 'export * from "./start";\n');
+	writeFileSync(join(root, 'src', 'middlewares.ts'), 'export const middlewares = {};\n');
+	writeFileSync(
+		join(root, 'src', 'langs', 'en.ts'),
+		`export default {
+	commands: {
+		ping: { content: "Pong" },
+	},
+	greeting: (name: string) => "Hi " + name,
+};
+`,
+	);
+	// Mirrors a real consumer entrypoint: a single SeyfertRegistry augmentation that registers a
+	// self-referential client AND langs, resolved through a circular module graph (index -> start,
+	// client-utils -> index, command -> client-utils). The self-referential client field is what
+	// previously made the constrained `infer L extends Record<string, any>` in DefaultLocale collapse
+	// to `{}`, leaving `ctx.t` untyped.
+	writeFileSync(
+		join(root, 'src', 'start.ts'),
+		`import { Client, type ParseClient, type ParseLocales } from "seyfert";
+import { middlewares } from "./middlewares";
+
+export let client: Client<true>;
+
+declare module "seyfert" {
+	interface SeyfertRegistry {
+		client: ParseClient<Client<true>>;
+		middlewares: typeof middlewares;
+		langs: ParseLocales<typeof import("./langs/en")["default"]>;
+	}
+}
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'client-utils.ts'),
+		`import { client } from "./index";
+
+export async function helper() {
+	await client.messages.write("123", { content: "ok" });
+}
+`,
+	);
+	writeFileSync(
+		join(root, 'src', 'command.ts'),
+		`import type { CommandContext } from "seyfert";
+import { helper } from "./client-utils";
+
+void helper;
+declare const ctx: CommandContext;
+const reply = ctx.t.commands.ping.content.get();
+const greeting = ctx.t.greeting("world").get();
+void reply;
+void greeting;
+`,
+	);
+};
+
+const getLocaleTypesBeforeDiagnostics = (sourceFile: ts.SourceFile, checker: ts.TypeChecker) => {
+	const localeTypes: TypeSnapshot[] = [];
+
+	const visit = (node: ts.Node) => {
+		if (ts.isPropertyAccessExpression(node) && node.name.text === 't') {
+			const type = checker.getTypeAtLocation(node);
+			localeTypes.push({
+				isAny: isAnyType(type),
+				text: checker.typeToString(type),
+			});
+		}
+
+		ts.forEachChild(node, visit);
+	};
+
+	visit(sourceFile);
+	return localeTypes;
+};
+
+describe('command context locale type', () => {
+	test('keeps ctx.t typed while resolving circular consumer module augmentation', () => {
+		const root = mkdtempSync(join(tmpdir(), 'seyfert-context-locale-'));
+
+		try {
+			writeLocaleFixture(root);
+
+			const commandFile = join(root, 'src', 'command.ts');
+			const program = ts.createProgram([commandFile], {
+				esModuleInterop: true,
+				module: ts.ModuleKind.CommonJS,
+				moduleResolution: ts.ModuleResolutionKind.Node10,
+				noEmit: true,
+				skipLibCheck: true,
+				strict: true,
+				target: ts.ScriptTarget.ESNext,
+				types: ['node'],
+			});
+			const checker = program.getTypeChecker();
+			const sourceFile = program.getSourceFile(commandFile);
+
+			expect(sourceFile).toBeDefined();
+			if (!sourceFile) throw new Error('Fixture command source was not loaded');
+
+			const localeTypes = getLocaleTypesBeforeDiagnostics(sourceFile, checker);
+
+			// ctx.t must resolve to the registered locale proxy, not collapse to `{}` (untyped).
+			expect(localeTypes.length).toBeGreaterThanOrEqual(1);
+			for (const localeType of localeTypes) {
+				expect(localeType.isAny).toBe(false);
+				expect(localeType.text).not.toBe('{}');
+			}
+			// Accessing ctx.t.commands.ping.content.get() and ctx.t.greeting(...).get() must typecheck.
+			expect(program.getSemanticDiagnostics()).toHaveLength(0);
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
+	});
+});

--- a/tests/command-options-contract.ts
+++ b/tests/command-options-contract.ts
@@ -1,0 +1,282 @@
+// Compile-time contract for command option inference.
+// Locks the readonly fix for `choices` and `channel_types`, plus the documented inference
+// across ALL create*Option helpers (with and without a `value`+`ok` callback) so it can't
+// silently regress. Checked by `pnpm test:types` against the built `./lib/index.d.ts`.
+//
+// `choices`/`channel_types` are covered in BOTH forms:
+//   • CON `as const` → the fix accepts it and infers the literal value union. Declared as a
+//     *separate* const on purpose: the readonly bug only reproduces with a separate
+//     `const ... as const` (an inline one is inferred contextually and compiles even without
+//     the fix), so these are the cases that turn red if the fix is reverted. Do not inline them.
+//   • SIN `as const` → behaves exactly as before the fix: the value type is widened.
+import {
+	type Attachment,
+	ChannelType,
+	type CommandContext,
+	createAttachmentOption,
+	createBooleanOption,
+	createChannelOption,
+	createIntegerOption,
+	createMentionableOption,
+	createNumberOption,
+	createRoleOption,
+	createStringOption,
+	createUserOption,
+	type GuildMemberStructure,
+	type GuildRoleStructure,
+	type InteractionGuildMemberStructure,
+	type OKFunction,
+	type TextGuildChannelStructure,
+	type UserStructure,
+	type VoiceChannelStructure,
+} from 'seyfert';
+
+declare function expectType<T>(value: T): void;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+	? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+		? true
+		: false
+	: false;
+
+// Distinct marker type so "the `ok` type flows to ctx.options" is unambiguous for every helper.
+interface Resolved {
+	rid: string;
+}
+
+// ───────────────────────────── choices: con / sin const ─────────────────────────────
+const numberChoices = [
+	{ name: 'S0', value: 0 },
+	{ name: 'S1', value: 1 },
+	{ name: 'S1.5', value: 1.5 },
+] as const;
+const stringChoices = [
+	{ name: 'Solo', value: 'solo' },
+	{ name: 'Duo', value: 'duo' },
+] as const;
+const integerChoices = [
+	{ name: 'D6', value: 6 },
+	{ name: 'D20', value: 20 },
+] as const;
+const abChoices = [
+	{ name: 'A', value: 'a' },
+	{ name: 'B', value: 'b' },
+] as const;
+
+const choiceOptions = {
+	numberConst: createNumberOption({ description: 'n', required: true, choices: numberChoices }),
+	numberMutable: createNumberOption({
+		description: 'n',
+		required: true,
+		choices: [
+			{ name: 'S0', value: 0 },
+			{ name: 'S1', value: 1 },
+			{ name: 'S1.5', value: 1.5 },
+		],
+	}),
+	numberConstOptional: createNumberOption({ description: 'n', choices: numberChoices }),
+	stringConst: createStringOption({ description: 's', required: true, choices: stringChoices }),
+	stringMutable: createStringOption({
+		description: 's',
+		required: true,
+		choices: [
+			{ name: 'Solo', value: 'solo' },
+			{ name: 'Duo', value: 'duo' },
+		],
+	}),
+	integerConst: createIntegerOption({ description: 'i', required: true, choices: integerChoices }),
+	integerMutable: createIntegerOption({
+		description: 'i',
+		required: true,
+		choices: [
+			{ name: 'D6', value: 6 },
+			{ name: 'D20', value: 20 },
+		],
+	}),
+	// value callback: `data.value` from choices (CON const: literal | SIN const: widened),
+	// `ctx.options` from `ok`.
+	resolvedConst: createStringOption({
+		description: 'r',
+		required: true,
+		choices: abChoices,
+		value(data, ok: OKFunction<number>) {
+			expectType<true>(true as Equal<typeof data.value, 'a' | 'b'>);
+			ok(1);
+		},
+	}),
+	resolvedMutable: createStringOption({
+		description: 'r',
+		required: true,
+		choices: [
+			{ name: 'A', value: 'a' },
+			{ name: 'B', value: 'b' },
+		],
+		value(data, ok: OKFunction<number>) {
+			expectType<true>(true as Equal<typeof data.value, string>);
+			ok(1);
+		},
+	}),
+} as const;
+
+declare const choiceCtx: CommandContext<typeof choiceOptions>;
+expectType<true>(true as Equal<typeof choiceCtx.options.numberConst, 0 | 1 | 1.5>);
+expectType<true>(true as Equal<typeof choiceCtx.options.numberMutable, number>);
+expectType<true>(true as Equal<typeof choiceCtx.options.numberConstOptional, 0 | 1 | 1.5 | undefined>);
+expectType<true>(true as Equal<typeof choiceCtx.options.stringConst, 'solo' | 'duo'>);
+expectType<true>(true as Equal<typeof choiceCtx.options.stringMutable, string>);
+expectType<true>(true as Equal<typeof choiceCtx.options.integerConst, 6 | 20>);
+expectType<true>(true as Equal<typeof choiceCtx.options.integerMutable, number>);
+expectType<true>(true as Equal<typeof choiceCtx.options.resolvedConst, number>);
+expectType<true>(true as Equal<typeof choiceCtx.options.resolvedMutable, number>);
+
+// @ts-expect-error a number option rejects string choice values
+createNumberOption({ description: 'x', choices: [{ name: 'a', value: 'not-a-number' }] });
+// @ts-expect-error a string option rejects numeric choice values
+createStringOption({ description: 'x', choices: [{ name: 'a', value: 1 }] });
+
+// ─────────────────────────── channel_types: con / sin const ───────────────────────────
+const channelTypesOne = [ChannelType.GuildText] as const;
+const channelTypesMany = [ChannelType.GuildText, ChannelType.GuildVoice] as const;
+
+const channelOptions = {
+	constOne: createChannelOption({ description: 'c', required: true, channel_types: channelTypesOne }),
+	constMany: createChannelOption({ description: 'c', required: true, channel_types: channelTypesMany }),
+	mutableOne: createChannelOption({ description: 'c', required: true, channel_types: [ChannelType.GuildText] }),
+	mutableMany: createChannelOption({
+		description: 'c',
+		required: true,
+		channel_types: [ChannelType.GuildText, ChannelType.GuildVoice],
+	}),
+} as const;
+
+declare const channelCtx: CommandContext<typeof channelOptions>;
+expectType<true>(true as Equal<typeof channelCtx.options.constOne, TextGuildChannelStructure>);
+expectType<true>(
+	true as Equal<typeof channelCtx.options.constMany, TextGuildChannelStructure | VoiceChannelStructure>,
+);
+expectType<true>(true as Equal<typeof channelCtx.options.mutableOne, TextGuildChannelStructure>);
+expectType<true>(
+	true as Equal<typeof channelCtx.options.mutableMany, TextGuildChannelStructure | VoiceChannelStructure>,
+);
+
+// ───────────── every create*Option — SIN callback (tipo base) ─────────────
+const withoutCallback = {
+	string: createStringOption({ description: 'x', required: true }),
+	integer: createIntegerOption({ description: 'x', required: true }),
+	number: createNumberOption({ description: 'x', required: true }),
+	boolean: createBooleanOption({ description: 'x', required: true }),
+	user: createUserOption({ description: 'x', required: true }),
+	role: createRoleOption({ description: 'x', required: true }),
+	mentionable: createMentionableOption({ description: 'x', required: true }),
+	attachment: createAttachmentOption({ description: 'x', required: true }),
+	channel: createChannelOption({ description: 'x', required: true, channel_types: [ChannelType.GuildText] }),
+} as const;
+
+declare const baseCtx: CommandContext<typeof withoutCallback>;
+expectType<true>(true as Equal<typeof baseCtx.options.string, string>);
+expectType<true>(true as Equal<typeof baseCtx.options.integer, number>);
+expectType<true>(true as Equal<typeof baseCtx.options.number, number>);
+expectType<true>(true as Equal<typeof baseCtx.options.boolean, boolean>);
+expectType<true>(true as Equal<typeof baseCtx.options.user, InteractionGuildMemberStructure | UserStructure>);
+expectType<true>(true as Equal<typeof baseCtx.options.role, GuildRoleStructure>);
+expectType<true>(
+	true as Equal<
+		typeof baseCtx.options.mentionable,
+		GuildRoleStructure | InteractionGuildMemberStructure | GuildMemberStructure | UserStructure
+	>,
+);
+expectType<true>(true as Equal<typeof baseCtx.options.attachment, Attachment>);
+expectType<true>(true as Equal<typeof baseCtx.options.channel, TextGuildChannelStructure>);
+
+// ───────────── every create*Option — CON callback `value` + `ok` ─────────────
+// `data.value` receives the option's input type; `ok: OKFunction<Resolved>` makes ctx.options `Resolved`.
+const withCallback = {
+	string: createStringOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, string>);
+			ok({ rid: '1' });
+		},
+	}),
+	integer: createIntegerOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, number>);
+			ok({ rid: '1' });
+		},
+	}),
+	number: createNumberOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, number>);
+			ok({ rid: '1' });
+		},
+	}),
+	boolean: createBooleanOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, boolean>);
+			ok({ rid: '1' });
+		},
+	}),
+	user: createUserOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, InteractionGuildMemberStructure | UserStructure>);
+			ok({ rid: '1' });
+		},
+	}),
+	role: createRoleOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, GuildRoleStructure>);
+			ok({ rid: '1' });
+		},
+	}),
+	mentionable: createMentionableOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(
+				true as Equal<
+					typeof data.value,
+					GuildRoleStructure | InteractionGuildMemberStructure | GuildMemberStructure | UserStructure
+				>,
+			);
+			ok({ rid: '1' });
+		},
+	}),
+	attachment: createAttachmentOption({
+		description: 'x',
+		required: true,
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, Attachment>);
+			ok({ rid: '1' });
+		},
+	}),
+	channel: createChannelOption({
+		description: 'x',
+		required: true,
+		channel_types: [ChannelType.GuildText],
+		value(data, ok: OKFunction<Resolved>) {
+			expectType<true>(true as Equal<typeof data.value, TextGuildChannelStructure>);
+			ok({ rid: '1' });
+		},
+	}),
+} as const;
+
+declare const cbCtx: CommandContext<typeof withCallback>;
+expectType<true>(true as Equal<typeof cbCtx.options.string, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.integer, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.number, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.boolean, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.user, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.role, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.mentionable, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.attachment, Resolved>);
+expectType<true>(true as Equal<typeof cbCtx.options.channel, Resolved>);

--- a/tests/plugin-api.test.mts
+++ b/tests/plugin-api.test.mts
@@ -1139,7 +1139,7 @@ describe('plugin api v3', () => {
 	});
 
 	test('registers plugin middleware and global middleware option', () => {
-		const audit: MiddlewareContext = ({ pass }) => pass();
+		const audit: MiddlewareContext = ({ stop }) => stop();
 		const plugin = createPlugin({
 			name: 'middleware',
 			register(api) {
@@ -1195,6 +1195,31 @@ describe('plugin api v3', () => {
 		await expect(BaseCommand.__runMiddlewares(context, ['stopCommand' as never], false)).resolves.toEqual({
 			error: 'command denied',
 			metadata: { middleware: 'stopCommand', scope: 'command' },
+		});
+	});
+
+	test('treats stop() / stop(null) / stop(undefined) as pass', async () => {
+		const passNoArg = createMiddleware<void>(({ stop }) => stop());
+		const passNull = createMiddleware<void>(({ stop }) => stop(null));
+		const passUndefined = createMiddleware<void>(({ stop }) => stop(undefined));
+		const context = {
+			client: {
+				middlewares: { passNoArg, passNull, passUndefined },
+				logger: { warn: vi.fn() },
+			},
+			command: { name: 'secure' },
+			globalMetadata: {},
+			metadata: {},
+		} as never;
+
+		await expect(BaseCommand.__runMiddlewares(context, ['passNoArg' as never], false)).resolves.toEqual({
+			pass: true,
+		});
+		await expect(BaseCommand.__runMiddlewares(context, ['passNull' as never], false)).resolves.toEqual({
+			pass: true,
+		});
+		await expect(BaseCommand.__runMiddlewares(context, ['passUndefined' as never], false)).resolves.toEqual({
+			pass: true,
 		});
 	});
 

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -120,6 +120,7 @@ import {
 	type CallbackEventHandler,
 	type ClientOptions,
 	type ClientEvent,
+	type ParseClient,
 	type RestArgumentsRequiredQuery,
 	type StringSelectMenuInteraction,
 	type Collection,
@@ -1300,7 +1301,7 @@ const emptyPlugins = definePlugins();
 declare module 'seyfert' {
 	interface SeyfertRegistry {
 		plugins: typeof plugins;
-		client: Client<true>;
+		client: ParseClient<Client<true>>;
 		middlewares: { localAudit: typeof combinedAudit };
 		langs: {
 			commands: {

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -3,6 +3,7 @@ import {
 	ApplicationCommandType,
 	type AllChannels,
 	type AllGuildChannels,
+	type AllNamedChannels,
 	type Attachment,
 	type AutocompleteCallback,
 	type AutocompleteInteraction,
@@ -34,6 +35,7 @@ import {
 	Declare,
 	definePlugins,
 	type DMChannelStructure,
+	type DirectoryChannelStructure,
 	GatewayIntentBits,
 	GatewayOpcodes,
 	type GatewayDispatchPayload,
@@ -1433,10 +1435,29 @@ expectType<Promise<GuildMemberStructure | undefined>>(commandContext().fetchMemb
 expectType<ReturnCache<GuildMemberStructure | undefined>>(commandContext().fetchMember('cache'));
 
 type GuildCommandChannel = AllGuildChannels | BaseGuildChannelStructure;
+type NamedChannel = GuildCommandChannel | (BaseChannelStructure & { name: string });
+expectType<true>(true as Equal<AllNamedChannels, NamedChannel>);
 expectType<true>(true as Equal<AllGuildChannels extends GuildCommandChannel ? true : false, true>);
 expectType<true>(true as Equal<BaseGuildChannelStructure extends GuildCommandChannel ? true : false, true>);
 expectType<true>(true as Equal<DMChannelStructure extends GuildCommandChannel ? true : false, false>);
 expectType<true>(true as Equal<BaseChannelStructure extends GuildCommandChannel ? true : false, false>);
+// @ts-expect-error AllEditableChannels duplicates the guild-channel contract and should not be exported.
+type NoEditableChannelsAlias = import('seyfert').AllEditableChannels;
+expectType<string>(undefined as never as DirectoryChannelStructure['name']);
+expectType<string>(undefined as never as DirectoryChannelStructure['guildId']);
+
+const maybeChannel = undefined as never as AllChannels;
+// @ts-expect-error Use isNamed() for named channels or isGuild() for guild channels.
+maybeChannel.isEditable();
+
+if (maybeChannel.isNamed()) {
+	expectType<AllNamedChannels>(maybeChannel);
+	expectType<string>(maybeChannel.name);
+}
+
+if (maybeChannel.isGuild()) {
+	expectType<GuildCommandChannel>(maybeChannel);
+}
 
 const guildCommandContext = commandContext();
 if (guildCommandContext.inGuild()) {

--- a/tests/plugin-authoring-tsconfig.json
+++ b/tests/plugin-authoring-tsconfig.json
@@ -1,16 +1,24 @@
 {
 	"compilerOptions": {
 		"baseUrl": "..",
-		"lib": ["ESNext"],
+		"lib": [
+			"ESNext"
+		],
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"noEmit": true,
 		"paths": {
-			"seyfert": ["./lib/index.d.ts"]
+			"seyfert": [
+				"./lib/index.d.ts"
+			]
 		},
 		"skipLibCheck": true,
 		"strict": true,
 		"target": "ESNext"
 	},
-	"files": ["./plugin-authoring-contract.ts", "./root-export-contract.ts"]
+	"files": [
+		"./plugin-authoring-contract.ts",
+		"./root-export-contract.ts",
+		"./command-options-contract.ts"
+	]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./plugin-authoring-tsconfig.json"
+}


### PR DESCRIPTION
## What

Several warnings logged a generic message without telling you *which* command, event, file, or shard triggered them. The clearest offender:

\`\`\`
WARN [Seyfert] > SubCommand returned (undefined) ignoring.
\`\`\`

No way to know which subcommand/file caused it. This PR surfaces the missing identifier in that warning and the others that shared the same problem.

## Changes

- **commands/handler.ts** — autoload SubCommand warnings now include the parent command name and the offending file path:
  - `Command "name": no default export found in "path", ignoring it as a SubCommand.`
  - `Command "name": expected a SubCommand from "path", got (x); ignoring it.`
- **events/handler.ts** — `Missing event run function` → `Event "name" is missing a 'run' function, ignoring it.`
- **client/workerclient.ts** — the four `non-existent shard` fatals now include the shard id (`(#id)`).
- **websocket/discord/shard.ts** — close-code / reconnect warnings and the InvalidSession fatal now prefix the shard id, and the placeholder `This is a completely unexpected error message.` is replaced with what actually happened.

Log-message changes only — no behavior change. Typecheck and lint pass.