### PR TITLE
fix(client): support extending Client<true> without constructor conflicts

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -280,6 +280,10 @@ type ClientReadyOf<
 > = TPluginsOrReady extends boolean ? TPluginsOrReady : Ready;
 type ClientAmbientExtensionOf<TPluginsOrReady extends readonly AnySeyfertPlugin[] | boolean> =
 	TPluginsOrReady extends readonly AnySeyfertPlugin[] ? {} : RegisteredPluginExtension;
+type ClientOptionsOf<TPluginsOrReady extends readonly AnySeyfertPlugin[] | boolean> =
+	TPluginsOrReady extends readonly AnySeyfertPlugin[]
+		? ClientOptions<TPluginsOrReady>
+		: ClientOptions<RegisteredPlugins>;
 type Materialize<T> = {
 	[K in keyof T]: T[K];
 };
@@ -291,12 +295,17 @@ export type Client<
 	ClientAmbientExtensionOf<TPluginsOrReady> &
 	Materialize<ExtendOf<ClientPluginsOf<TPluginsOrReady>>>;
 
-export interface ClientConstructor {
-	new <Ready extends boolean = boolean>(options?: ClientOptions<RegisteredPlugins>): Client<Ready>;
-	new <const TPlugins extends readonly AnySeyfertPlugin[] = RegisteredPlugins>(
-		options?: ClientOptions<TPlugins>,
-	): Client<TPlugins>;
-}
+type ClientBaseStatics = Omit<typeof ClientBase, 'prototype'>;
+
+export type ClientConstructor = ClientBaseStatics & {
+	new <
+		TPluginsOrReady extends readonly AnySeyfertPlugin[] | boolean = RegisteredPlugins,
+		Ready extends boolean = boolean,
+	>(
+		options?: ClientOptionsOf<TPluginsOrReady>,
+	): Client<TPluginsOrReady, Ready>;
+	prototype: Client;
+};
 
 export const Client = ClientBase as unknown as ClientConstructor;
 


### PR DESCRIPTION
## Root Cause
`Client` was exposed with constructor typing that effectively introduced incompatible constructor signatures when used as a base class. This allowed `Client<true>` as an annotation but failed on `extends Client<true>` with TS2510/constraint errors.

## Description
Refactored `ClientConstructor` typing to use a single generic constructor signature and separated class statics from constructor/prototype typing, preventing constructor return-type conflicts while preserving the existing `Client` generic behavior for ready/plugins typing.