### PR TITLE
ci: run test suite on Node, Bun, and Deno

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,17 +42,90 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
 
-      - name: Test suites
-        run: pnpm test
-  
       - name: Run Bot
         id: bot-up
         if: env.BOT_TOKEN != ''
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: node ./tests/bot.js
-        
 
       - name: Publish in pkg.pr.new
         run: pnpx pkg-pr-new publish
         if: github.repository == 'tiramisulabs/seyfert'
+
+  test:
+    name: Test (${{ matrix.runtime }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [node, bun, deno]
+
+    steps:
+      - name: check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      # --- Node (pnpm) ---
+      - name: Install Node
+        if: matrix.runtime == 'node'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Install pnpm
+        if: matrix.runtime == 'node'
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies (Node)
+        if: matrix.runtime == 'node'
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        if: matrix.runtime == 'node'
+        run: pnpm run test:types
+
+      - name: Test suites (Node)
+        if: matrix.runtime == 'node'
+        run: pnpm exec vitest run --config ./tests/vitest.config.mts ./tests/
+
+      # --- Bun ---
+      - name: Install Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun install --ignore-scripts
+        env:
+          HUSKY: 0
+
+      - name: Build (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun run build
+
+      - name: Test suites (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun --bun ./node_modules/vitest/vitest.mjs run --config ./tests/vitest.config.mts ./tests/
+
+      # --- Deno ---
+      - name: Install Deno
+        if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install dependencies (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno install
+        env:
+          HUSKY: 0
+
+      - name: Build (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno run -A npm:typescript/tsc --outDir ./lib
+
+      - name: Test suites (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno run -A npm:vitest run --config ./tests/vitest.config.mts ./tests/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,9 +3,14 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   linter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: check out code
@@ -56,6 +61,8 @@ jobs:
   test:
     name: Test (${{ matrix.runtime }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Split the test suite out of the linter job into a dedicated `test` matrix (`node`, `bun`, `deno`).
- Each runtime installs and builds with its own toolchain (`pnpm` / `bun` / `deno`) instead of always using Node package manager.
- Node still runs typecheck (`pnpm run test:types`); Bun and Deno install natively, build, and run vitest.