### PR TITLE
docs: add hierarchical agent development guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Developing Seyfert
+
+Hierarchical `AGENTS.md` files split ownership: this root owns universal
+workflow, routing, review, Git, and completion; nested guides own source, tests,
+and subsystems. For consumer recipes use public docs, verified against this
+checkout; this is not a bot tutorial.
+
+## Required instruction routing
+
+Codex auto-loads one guide per directory from project root to cwd, under its
+default 32 KiB combined cap. A root-started agent may not receive nested guides.
+**Before editing, read this guide plus every guide routed below for every
+affected path, whether auto-loaded or not.** Subsystem guides add to, never
+replace, `src/AGENTS.md`.
+
+| Path or change | Additional guide(s) to read | Ownership |
+| --- | --- | --- |
+| Repository configuration, workflows, or root files | None | Universal workflow and repository boundaries in this file |
+| `src/**` | `src/AGENTS.md` | Public API, type system, source style, async behavior, diagnostics, compatibility |
+| `src/client/**` | `src/client/AGENTS.md` | Client lifecycle, packet dispatch, transformers, collectors, plugins |
+| `src/commands/**` | `src/commands/AGENTS.md` | Declarations, options, contexts, loading, application and prefix dispatch |
+| `src/components/**` | `src/components/AGENTS.md` | Components, modals, interaction contexts, component collectors |
+| `src/events/**` | `src/events/AGENTS.md` | Gateway/custom events, hooks, cache ordering, reload behavior |
+| `src/api/**` | `src/api/AGENTS.md` | REST transport, route proxy, retries, rate limits, route types |
+| `src/common/shorters/**` | `src/api/AGENTS.md` and `src/common/shorters/AGENTS.md` | REST-layer boundary plus high-level resource operations |
+| `src/cache/**` | `src/cache/AGENTS.md` | Cache facade, adapters, resources, intents, packet updates |
+| `src/structures/**` | `src/structures/AGENTS.md` | Transformed structures, methods, guards, declaration merging |
+| `src/websocket/**` | `src/websocket/AGENTS.md` | Shards, sockets, reconnects, sharding, workers, managers |
+| `tests/**` | `tests/AGENTS.md` | Test ownership, compiler contracts, commands, portability, test style |
+| Any build, typecheck, test, formatter, or portability verification | `tests/AGENTS.md` | Command selection, mutating-script warnings, verification ladder, runtime parity |
+
+For cross-cutting work, apply every table row matching an affected path or
+verification step. A nearest-path guide is insufficient when the contract
+crosses ownership boundaries.
+
+## Source of truth
+
+Use this order when sources disagree:
+
+1. The current checkout and branch.
+2. `src/` runtime code and exported types.
+3. The tests and compiler contracts in `tests/`.
+4. Generated declarations from a fresh local build.
+5. Public documentation and external examples.
+
+Never prefer remembered, published, or documented APIs over this branch. Read
+`package.json`, `src/index.ts`, the feature barrel, implementation, closest
+tests, and routed guides. `lib/` is generated/untracked: build for declarations;
+never edit or include it.
+
+## Before editing
+
+1. Check status, branch, and diff; preserve unrelated work.
+2. Classify the contract: export, runtime, inference, gateway payload, REST
+   route, cache behavior, or internal implementation.
+3. Trace definition, barrels/root export, implementation, wrappers, direct
+   consumers, and tests before choosing the edit point.
+4. Prove public/type changes with compiler contracts, runtime changes with
+   executable regressions, and changes spanning both with both.
+5. Patch the owner; never hide core bugs behind consumer casts, duplicate
+   helpers, or docs-only workarounds.
+
+## Independent self-review
+
+Always self-review and validate proportionally. Independent review is only for
+large/material changes: root exports/declarations; registry/client inference;
+plugin lifecycle; gateway/worker behavior; cache; REST transport; runtime
+portability; behavior across owning subsystems; or explicit user request. Local
+low-risk fixes use main-thread review and targeted validation. The reviewer is
+a different, non-participant, read-only agent.
+
+- After implementation/validation stabilizes, spawn one reviewer. Context and
+  independence are separate. State its initial mode and exact `fork_turns` in
+  the spawn prompt; default to `fresh`.
+  - `fresh`: `fork_turns="none"`; use for unbiased/anchoring-resistant,
+    public/high-risk/ambiguous, or requested context-free review. Reveal no
+    rationale, intended solution, or suspected weaknesses.
+  - `contextual`: `fork_turns="all"` or a positive window; reuse prior
+    readings/decisions, but require challenge, not defense. It may improve
+    exact-prefix prompt-cache reuse; never promise host/model-dependent hits,
+    and confirm through exposed usage telemetry.
+- Both modes read applicable instructions and inspect `git status`, staged,
+  unstaged, and full relevant untracked files (`git diff` is insufficient),
+  then report correctness/regression risks without editing.
+- Verify findings, fix only confirmed issues, and rerun checks. After edits,
+  follow up with the same reviewer, identify the final change set, and state it
+  is reused, not newly fresh. A fresh reviewer retains its review context and
+  findings without receiving implementation history.
+- One reviewer per scope by default. Replace only if it joined implementation,
+  is unavailable/failed, needed specialty or context mode materially changes,
+  or the user asks for a new perspective.
+
+## Release and Git boundaries
+
+- Do not add a changeset unless explicitly requested; its configuration or
+  release automation does not authorize one during ordinary development.
+- Do not change package versions, release branches, workflows, tags, or publish
+  configuration unless the task explicitly requests release work.
+- Do not commit, push, open a PR, publish, or deploy unless explicitly
+  authorized.
+- Before authorized Git actions, re-check the branch and stage only intended
+  files.
+
+When a commit is authorized, `commitlint.config.js` and `.husky/commit-msg`
+enforce Conventional Commits. Use a concise title such as:
+
+```text
+fix(commands): preserve middleware rejection semantics
+feat: export logger types from the root
+feat!: remove a legacy public contract
+```
+
+Use a scope when it identifies the owning subsystem; it is optional. Use `!`
+and a `BREAKING CHANGE:` body only for a real breaking public contract. Recent
+history contains older exceptions, but they are not the rule for new commits.
+
+## Completion checklist
+
+Before handing off a change:
+
+- the edit is in the subsystem that owns the contract;
+- public exports, declarations, runtime behavior, and docs/comments agree;
+- direct callers and adjacent shared contexts were reviewed;
+- targeted tests prove the regression or contract;
+- the build/typecheck/full suite required by the blast radius passed freshly;
+- relevant Node/Bun/Deno behavior was checked when portability changed;
+- the full diff was read top to bottom;
+- when required, one different non-participant agent reviewed the final code in
+  the selected mode, was reused for follow-ups, and all confirmed findings were
+  resolved;
+- no generated `lib/`, debug output, secrets, dead scaffolding, unrelated
+  formatting, or user work is included;
+- no release or external action was inferred beyond the request;
+- any skipped verification has a concrete, disclosed residual risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ checkout; this is not a bot tutorial.
 
 ## Required instruction routing
 
-Codex auto-loads one guide per directory from project root to cwd, under its
-default 32 KiB combined cap. A root-started agent may not receive nested guides.
+Agent runners may load one guide per directory from the project root to the
+current working directory, and some impose a combined instruction-size cap. An
+agent started at the repository root may not receive nested guides.
+
 **Before editing, read this guide plus every guide routed below for every
 affected path, whether auto-loaded or not.** Subsystem guides add to, never
 replace, `src/AGENTS.md`.
@@ -70,15 +72,13 @@ low-risk fixes use main-thread review and targeted validation. The reviewer is
 a different, non-participant, read-only agent.
 
 - After implementation/validation stabilizes, spawn one reviewer. Context and
-  independence are separate. State its initial mode and exact `fork_turns` in
-  the spawn prompt; default to `fresh`.
-  - `fresh`: `fork_turns="none"`; use for unbiased/anchoring-resistant,
-    public/high-risk/ambiguous, or requested context-free review. Reveal no
-    rationale, intended solution, or suspected weaknesses.
-  - `contextual`: `fork_turns="all"` or a positive window; reuse prior
-    readings/decisions, but require challenge, not defense. It may improve
-    exact-prefix prompt-cache reuse; never promise host/model-dependent hits,
-    and confirm through exposed usage telemetry.
+  independence are separate. State its initial mode; default to `fresh`.
+  - `fresh`: start without prior task conversation or implementation context;
+    use for unbiased/anchoring-resistant, public/high-risk/ambiguous, or
+    requested context-free review. Reveal no rationale, intended solution, or
+    suspected weaknesses.
+  - `contextual`: provide the relevant prior readings and decisions when they
+    avoid repeated discovery, but require challenge, not defense.
 - Both modes read applicable instructions and inspect `git status`, staged,
   unstaged, and full relevant untracked files (`git diff` is insufficient),
   then report correctness/regression risks without editing.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,194 @@
+# Source-wide Seyfert guidance
+
+Read the repository-root `AGENTS.md` first. This guide applies to every path
+under `src/`; read the owning subsystem guide listed by the root router before
+changing a deeper path. The closest nested guide owns subsystem runtime facts;
+this guide owns shared public API, TypeScript, style, and compatibility rules.
+
+## Public API and type-system rules
+
+- The supported public surface is the root `seyfert` entrypoint. Export a new
+  public symbol through its feature barrel and `src/index.ts`; verify whether it
+  is a runtime value, a type-only export, or both.
+- Avoid new deep imports. A deep path is acceptable only when it is an
+  intentionally supported existing contract, such as the current custom
+  prefix-handler path.
+- `tsconfig.json` uses strict checking, declarations, `stripInternal`, unused
+  checks, and decorator metadata. An `@internal` annotation changes emitted
+  declarations; verify the built `.d.ts` when touching visibility.
+- Augment `SeyfertRegistry` for registered client, middleware, langs, or plugin
+  types. `UsingClient`, `DefaultLocale`, and registered middleware types are
+  derived aliases and are not augmentation targets.
+- `ParseClient` preserves the selected client across registry inference. A
+  change around it can affect commands, components, modals, menus, entry
+  points, and interaction responses, including lazy/editor resolution before
+  diagnostics run.
+- Preserve readonly inputs, overload inference, type guards, and declaration
+  merging. Do not replace a precise public type with `any` or a broad cast to
+  make a local compiler error disappear.
+- When runtime and type behavior can diverge, add both a compile-time assertion
+  and a runtime test. Follow `../tests/AGENTS.md` for those proofs.
+
+## Errors and validation
+
+Framework validation/runtime errors use `SeyfertError` from
+`src/common/it/error.ts`.
+
+- Reuse an existing stable error code when semantics match; otherwise add a
+  specific code/message and test it.
+- Preserve the original `cause` when wrapping lower-level failures.
+- Validation metadata should use `createValidationMetadata()` so `expected`,
+  `received`, and `receivedType` remain consistent. Add domain context as extra
+  metadata fields.
+- Plugin lifecycle failures follow `client/AGENTS.md`: use the plugin error
+  wrappers/aggregate error, not a generic `SeyfertError` replacement.
+- Test the code, metadata, cause, and user-observable control path that matter.
+
+## Formatting authority
+
+`biome.json` governs `src/**`: tabs (width 2), single quotes, semicolons,
+120-character lines, CRLF, arrow parentheses only when needed, and organized
+imports. Recommended rules are disabled; the only error-level lint rule is
+`useImportType`. Do not attribute other recommended rules to this repository.
+
+`.editorconfig` has similar basics, but Biome excludes `tests/**`, Markdown,
+workflows, and repository configuration. Match those files locally and use
+their owning tool; a green source check does not cover them.
+
+```sh
+# Format only intentionally changed production files
+./node_modules/.bin/biome check --write ./src/path/to/changed-file.ts
+# Read-only production-source verification
+./node_modules/.bin/biome check --no-errors-on-unmatched ./src
+```
+
+`check`, `check-h`, `lint`, and `format` all write. The pre-commit hook runs an
+unscoped `biome check --write`; after an authorized commit attempt, re-read the
+complete diff for spillover. CI may commit `chore: apply formatting`; format and
+inspect locally instead of relying on CI repair.
+
+## Imports and exports
+
+- Use `node:` specifiers for Node built-ins.
+- Use extensionless `src/` relatives; emission is CommonJS with Node resolution.
+- Use `import type` for wholly type-only imports and inline `type` for mixed
+  imports; let Biome organize ordering.
+- Use the established feature barrel for public features and direct modules for
+  implementation-only symbols. Do not reorganize unrelated imports.
+- Library source uses named exports, but default exports remain valid for
+  command/event/component/lang file loading and config/tests; do not ban them.
+- New public symbols normally need implementation, feature-barrel, and
+  `src/index.ts` exports. Run root-export/declaration-cycle contracts when root
+  exports or internal barrel dependencies change.
+- Internal test reachability does not justify a deep public import; verify the
+  root `seyfert` entrypoint separately.
+
+## Naming and file placement
+
+- Match the owning directory: public structures/builders usually use PascalCase;
+  handlers, adapters, shorters, routes, and types use local lower/camel/domain
+  conventions. Historical names (`entryPoint.ts`, `voiceStates.ts`,
+  `SharedTypes.ts`, `webhokEvents.ts`) are compatibility, not rename targets.
+- Do not rename files/public identifiers merely to normalize casing. New
+  classes/interfaces/type aliases use PascalCase; ordinary functions, methods,
+  fields, and locals use lowerCamelCase unless the subsystem says otherwise.
+- Gateway hooks use Discord `UPPER_SNAKE_CASE`; decorator factories (`Declare`,
+  `Options`, `Middlewares`) are PascalCase; preserve public helper spelling.
+  Constants follow neighbors. Prefix required unused parameters with `_`.
+  Existing `__filePath`-style contracts do not license new `__` private names.
+- Place code where its invariant is owned. Do not extract a generic utility for
+  one small expression or move framework-specific code to `common/` until shared.
+
+## TypeScript and declarations
+
+Strict checks include unused symbols, implicit returns, fallthrough,
+nullability, variance, decorator metadata, declarations, and `stripInternal`.
+
+- Keep public input collections `readonly` for tuples/`as const`; preserve
+  literals with readonly tuples, const type parameters, `as const`, and
+  `satisfies` where appropriate.
+- Prefer `unknown` for errors/untrusted data. `any` is allowed at dynamic
+  boundaries, but never widen a precise public contract to silence errors;
+  keep unavoidable casts local.
+- Use `satisfies` to validate without widening, especially for worker/gateway
+  messages, plugin contributions, and request options.
+- Preserve declaration-merging/augmentation interfaces. Do not swap
+  `interface` and `type` stylistically; use aliases for unions,
+  conditional/mapped types, and where locally established.
+- Add a named return type when declarations, registry augmentation,
+  circular/lazy inference, overloads, or public readability need one.
+- Preserve overloads, brands, conditional types, `this` returns, and type
+  guards; judge emitted declarations and consumer contracts too.
+- Non-null assertions and narrow casts require a real invariant; do not change
+  them mechanically.
+- `@internal` affects emitted declarations; `@deprecated` is public. Build and
+  inspect relevant `.d.ts` files after changing either.
+- Use `declare` for type-only class refinements that must not initialize at
+  runtime, following nearby client/builder patterns.
+
+## Shared class and wire conventions
+
+- Builders mutate `data`, return `this`, and serialize with `toJSON()`.
+  Validate where neighboring builders do and throw typed `SeyfertError`s.
+- Received components (`src/components/`) and outbound builders
+  (`src/builders/`) are different models. Update both only when the public
+  contract requires it; the components guide owns received-component behavior.
+- REST/gateway types keep Discord wire names; transformed camel-case data
+  belongs in `Transformers` and structures.
+
+Subsystem-specific idioms for shorters, cache resources, structures, and
+plugins live only in their nested guides.
+
+## Control flow and async behavior
+
+Preserve the semantics of existing `async`/`await`, promise chains, sequential
+loops, `Promise.all`/`allSettled`, and explicit fire-and-forget paths.
+
+- Keep `Awaitable<T>` callbacks sync-or-async; do not narrow them to
+  `Promise<T>`/`void` without a public decision.
+- Preserve ordering and rejection behavior across plugin interceptors,
+  lifecycle hooks, event transforms, cache writes, collectors, and error hooks.
+- Add `async` only to await work or intentionally return rejection.
+- Preserve intentional un-awaited handling. New rejectable work needs an
+  explicit rejection path, not an accidental floating promise.
+- Swallow errors only at intentional fallback/isolation boundaries; otherwise
+  propagate, preserve `cause`, or route through the owning logger/error hook.
+- Biome does not require braces, `for...of`, default switch clauses, or one
+  function style; match neighbors and keep control flow clear.
+
+## Logging and diagnostics
+
+- Use the owning logger for operations and `client.debugger` for opt-in detail.
+- Include available plugin/event/shard/command/custom-id/file identity.
+- Preserve plugin attribution through the plugin diagnostic/error wrappers.
+- Do not add `console.*` where a logger exists; low-level/bootstrap/docs
+  examples are exceptions, not a general pattern.
+
+## Comments, JSDoc, and suppressions
+
+- Document new public classes, methods, types, deprecations, and non-obvious
+  behavior; examples use current root imports.
+- Internal comments explain ordering, concurrency, declaration emission,
+  protocol quirks, or compatibility—not obvious code.
+- New `@ts-expect-error` directives explain their invariant/rejection. Prefer
+  them to `@ts-ignore`; do not copy unexplained historical suppressions.
+- Compiler negative cases must precisely explain why the form is rejected.
+- Do not substitute TODOs for in-scope behavior/tests or do incidental
+  comment/spelling cleanup outside the changed contract.
+
+## Compatibility
+
+- Preserve Node/Bun/Deno; reuse lazy/conditional environment loading and verify
+  affected runtimes.
+- Keep optional filesystem behavior out of serverless/Cloudflare-only paths.
+- Preserve exact Discord wire names and established public spelling.
+- Match local patterns before abstractions; avoid speculative compatibility,
+  unrelated cleanup, and formatting churn.
+
+## Do not standardize these globally
+
+Do not globally require `interface` versus `type`; ban `any`, casts, non-null
+assertions, or default exports; require all return types; rewrite promise style;
+require declarations versus arrows; add braces/default switch clauses; impose
+one casing or test-import source; mass-format; or rename public symbols as
+incidental cleanup.

--- a/src/api/AGENTS.md
+++ b/src/api/AGENTS.md
@@ -1,0 +1,23 @@
+# REST, routes, and transport subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns REST
+transport, retries, rate limits, route proxying, buckets, route types, and the
+boundary to shorters and structures. For cross-cutting work, follow the root
+routing table for every affected path and verification step.
+
+Keep the layers distinct:
+
+1. `src/types/rest/` and `src/types/payloads/` describe Discord data.
+2. `src/api/Routes/` describes route proxy shapes; these are types, not a
+   runtime `Routes` object.
+3. `src/api/Router.ts` builds the runtime proxy.
+4. `src/api/api.ts` handles auth, files, retries, rate limits, worker proxying,
+   and plugin REST observers.
+5. `src/common/shorters/` provides the public high-level operation.
+6. `src/client/transformers.ts` and `src/structures/` provide transformed
+   return values when appropriate.
+
+For a Discord endpoint, prefer adding or extending the shorter when it is a
+normal public resource operation. Use the raw proxy/request layer only where no
+shorter belongs. Do not introduce a parallel `fetch`/`axios` path around the
+REST handler.

--- a/src/cache/AGENTS.md
+++ b/src/cache/AGENTS.md
@@ -1,0 +1,15 @@
+# Cache subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns the
+cache facade, adapters, resources, intent checks, bulk operations, and packet-
+driven updates. For cross-cutting work, follow the root routing table for every
+affected path and verification step.
+
+- Cache behavior spans `src/cache/index.ts`, an adapter, a resource, gateway
+  hooks, and sometimes a shorter/structure.
+- Respect disabled-cache behavior, intent requirements, sync/async adapter
+  typing, worker adapters, and bulk-operation contracts.
+- Cache resources own hashing, relationships, intents, and sync/async adapter
+  behavior. Other subsystems must not access adapter storage directly.
+- The event/cache transformation and mutation boundary is owned by the events
+  guide; read it before changing packet-driven behavior.

--- a/src/client/AGENTS.md
+++ b/src/client/AGENTS.md
@@ -1,0 +1,100 @@
+# Client and plugin subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+client lifecycle, gateway semantic dispatch, client collectors/transformers,
+and the plugin subsystem. For cross-cutting work, follow the root routing table
+for every affected path and verification step.
+
+## Ownership map
+
+| Path | Responsibility |
+| --- | --- |
+| `src/client/base.ts` | Shared client lifecycle, services, configuration, command/component/lang loading, uploads, and plugin integration |
+| `src/client/client.ts` | Gateway client, packet dispatch, shard startup, events, and gateway plugin interception |
+| `src/client/httpclient.ts` | HTTP interaction client |
+| `src/client/workerclient.ts` | Worker client, manager messaging, worker proxying, and worker-side gateway handling |
+| `src/client/collectors.ts` | RAW, gateway-event, and custom-event collectors; distinct from component collectors |
+| `src/client/transformers.ts` | Converts Discord payloads into Seyfert structures |
+| `src/client/plugins.ts` | Resolves plugins, binds them to clients, runs lifecycle/hooks, and applies contributions |
+| `src/client/plugins/types.ts` | Public plugin contract, `SeyfertRegistry`, extensions, hooks, diagnostics, and contribution types |
+| `src/client/plugins/api.ts` | Mutation API exposed during plugin lifecycle phases |
+| `src/client/plugins/registry.ts` | Runtime registry, requirements, diagnostics, ownership, and cleanup bookkeeping |
+| `src/client/plugins/order.ts` | Stable contribution ordering |
+| `src/client/plugins/shared.ts` | Typed shared capabilities and disposal |
+| `src/client/plugins/errors.ts` | Plugin-specific wrapped and aggregate errors |
+
+## Client startup and shutdown
+
+- `BaseClient` constructs REST, cache, handlers, shorters, langs, plugins, and
+  shared plugin state.
+- `BaseClient.start()` validates the token, installs the command handler, sets
+  up plugins, starts the cache adapter, and loads langs, commands, and
+  components with plugin hooks/contributions.
+- `Client.start()` adds gateway event loading and shard execution.
+- `HttpClient.start()` currently runs the base startup and calls the inherited
+  `execute(options.httpConnection)`. The inherited implementation only handles
+  debug logger setup; this checkout does not wire `HttpServerAdapter` into a
+  real HTTP server. Treat HTTP-server behavior as an incomplete contract and
+  inspect callers/types before extending it.
+- `WorkerClient.start()` wires manager messaging, worker proxy/cache behavior,
+  plugin intents, base startup, and worker event handling.
+- `start()` does not upload application commands. `uploadCommands()` is a
+  separate public operation and must remain explicit.
+- `BaseClient.close()` owns plugin teardown only. Do not silently expand it to
+  close the gateway, REST client, or cache adapter without an intentional
+  public lifecycle decision.
+
+When changing startup ordering, inspect plugin hooks, service replacement,
+cache adapter initialization, file loaders, all three client variants, and the
+failure/cleanup path.
+
+## Gateway packets
+
+`Client.onPacket()` follows this shape:
+
+1. Plugin gateway-dispatch interceptors.
+2. Launch the RAW event and RAW collector with `Promise.allSettled()` without
+   awaiting them (fire-and-forget relative to the remaining packet path).
+3. Apply specialized presence/member filtering where applicable.
+4. Await the packet-specific event path; `EventHandler.execute()` awaits both
+   `runEvent()` and the event-specific collector.
+5. Dispatch commands, components, or modals after event execution for
+   interaction packets, or prefix commands for message packets.
+6. Transform ready state and emit bot-ready when all shards are ready.
+
+Outgoing gateway payloads pass through plugin wrappers before the configured
+send handler. A plugin may replace or veto a payload/packet with `null`; preserve
+that control flow and its diagnostics.
+
+## Plugins
+
+Plugin lifecycle is:
+
+```text
+register (synchronous construction) -> setup (client start) -> teardown (close, reverse order)
+```
+
+Plugin changes must preserve:
+
+- imported-plugin closure and extension inference;
+- `SeyfertRegistry` augmentation and `RegisteredPlugins`;
+- contribution ownership, overrides/removals, stable ordering, and cleanup via
+  lifecycle API and registry ownership, without direct array mutation or
+  duplicated ordering;
+- lifecycle phase restrictions;
+- requirements and optional-requirement diagnostics;
+- shared capability creation/disposal;
+- commands, components, modals, events, hooks, middleware, REST observers,
+  cache resources, gateway wrappers/interceptors, handler creators, and
+  transformers;
+- wrapped single errors and aggregate setup/teardown failures.
+
+Plugin lifecycle failures use their plugin error wrappers/aggregate error, not
+a generic `SeyfertError` replacement.
+
+Keep plugin `meta` descriptive rather than using it as a substitute for typed
+operational handles. The current type deliberately accepts arbitrary metadata,
+and requirement resolution may read `meta.version`; preserve that behavior.
+Use `shared` for genuine cross-plugin/application capabilities, while
+package-local handles may remain typed top-level extras as long as reserved
+Seyfert keys stay protected.

--- a/src/commands/AGENTS.md
+++ b/src/commands/AGENTS.md
@@ -1,0 +1,28 @@
+# Commands and interactions subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+command declarations, options, contexts, loading, subcommands, application
+interactions, and prefix handling. For cross-cutting work, follow the root
+routing table for every affected path and verification step.
+
+## Ownership and flow
+
+- Command declarations and runtime execution are split across
+  `src/commands/decorators.ts`, `handler.ts`, `handle.ts`, `optionresolver.ts`,
+  and `applications/**`.
+- `CommandHandler` owns file loading, reloads, subcommand defaults, upload
+  shapes, and programmatic registration.
+- `HandleCommand` owns incoming interaction and prefix-message dispatch.
+- `applications/shared.ts` is a critical public type hub: `UsingClient`,
+  `ParseClient`, middleware metadata, registry-derived types, internal options,
+  custom structures, and channel option mappings live there.
+- Middleware flow is `next()` or `stop()`. `stop()`/`stop(null)` is a silent
+  skip; `stop(reason)` is a middleware denial; thrown/rejected errors go to the
+  internal-error path.
+- `@AutoLoad()` scans the parent command directory recursively. Keep helpers
+  outside an auto-loaded subcommand tree and preserve inherited parent
+  defaults/middlewares when changing subcommand resolution.
+
+Changes here often affect command, component, modal, menu, entry-point, and
+interaction-response contexts through shared aliases. Verify adjacent contexts,
+not only the original reproduction.

--- a/src/common/shorters/AGENTS.md
+++ b/src/common/shorters/AGENTS.md
@@ -1,0 +1,13 @@
+# High-level resource shorters
+
+Follow the repository-root routing table before this guide; it supplies the
+source-wide and REST-layer prerequisites. This guide owns implementation order
+and cache/transform responsibilities under `src/common/shorters/`.
+
+- Shorters use the REST proxy, own cache maintenance, resolve files, transform
+  payloads, then return structures; preserve local ordering.
+- Follow the API guide's layer boundary and shorter-first endpoint rule. Raw
+  proxy/request work belongs below this layer, and structures/transformers own
+  transformed return values.
+- A shorter that touches cache or structure contracts also requires the cache
+  or structures guide and their owning tests.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -1,0 +1,15 @@
+# Components, modals, and collectors subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+received components, modal/component contexts, loading, matching, execution,
+and component collectors. For cross-cutting work, follow the root routing table
+for every affected path and verification step.
+
+- `ComponentHandler` owns component/modal loading, registration, matching,
+  collectors, and execution.
+- `ComponentContext`, `ModalContext`, and `InteractionContext` share response
+  and client typing with commands.
+- Preserve the distinction between run errors, middleware errors, and internal
+  framework errors.
+- The received-component/outbound-builder boundary and builder conventions are
+  owned by `src/AGENTS.md`; follow that boundary before crossing layers.

--- a/src/events/AGENTS.md
+++ b/src/events/AGENTS.md
@@ -1,0 +1,18 @@
+# Events subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+gateway/custom event types, loading, dispatch, hooks, event transforms, and
+event-side cache ordering. For cross-cutting work, follow the root routing table
+for every affected path and verification step.
+
+- `EventHandler` maps gateway names to hooks and transformed event arguments.
+- `CustomEventHandler` owns custom events (`runCustom`/`emit`) and injects the
+  client according to the existing event contract.
+- Gateway hooks under `src/events/hooks/` transform event arguments and may
+  inspect the previous cache value. `EventHandler.runEvent()` then awaits the
+  actual mutation through `Cache.onPacket()`/`onPacketDefault()` before running
+  event listeners. Keep transformation and cache ownership distinct.
+- Cloudflare Worker reload restrictions are intentional; preserve explicit
+  `RELOAD_NOT_SUPPORTED` behavior.
+- Follow the client guide for the packet-level ordering around RAW events,
+  collectors, interaction dispatch, and ready-state transformation.

--- a/src/structures/AGENTS.md
+++ b/src/structures/AGENTS.md
@@ -1,0 +1,14 @@
+# Structures subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+public runtime structures, transformed fields, methods, type guards, mixins,
+and declaration merging. For cross-cutting work, follow the root routing table
+for every affected path and verification step.
+
+- Structure fields originate in transformed Discord payloads. If a structure
+  method or type guard changes, verify both the runtime predicate/method and the
+  exported narrowed type.
+- Declaration merging used by structures and mixins is deliberate. Preserve
+  the mixins, align runtime fields with merged public interfaces, and do not
+  simplify the contract based only on the apparent class declaration.
+- Apply the wire-name and transformation boundary owned by `src/AGENTS.md`.

--- a/src/websocket/AGENTS.md
+++ b/src/websocket/AGENTS.md
@@ -1,0 +1,16 @@
+# Websocket, sharding, and workers subsystem
+
+Read the repository-root and `src/AGENTS.md` guides first. This guide owns
+shards, sockets, heartbeat/reconnect logic, sharding, workers, and managers. For
+cross-cutting work, follow the root routing table for every affected path and
+verification step.
+
+- Preserve socket lifecycle, heartbeat/reconnect ordering, shard startup, and
+  worker/manager message contracts when changing this subsystem.
+- Preserve the configured gateway send path and its async/rejection semantics;
+  the client guide owns plugin wrapping, veto behavior, and packet dispatch.
+- Worker, filesystem, Web API, or transport portability changes require the
+  relevant Bun/Deno path from `tests/AGENTS.md`, in addition to targeted gateway
+  and worker tests.
+- Apply the source-wide typing, async, wire-format, and portability rules from
+  `src/AGENTS.md`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,123 @@
+# Seyfert test and verification guidance
+
+Read the repository-root `AGENTS.md` first. For tests covering `src/**`, also
+read `src/AGENTS.md` and every owning subsystem guide routed by the root table.
+This guide owns test selection, compiler contracts, verification commands,
+portability checks, and test-file style.
+
+## Test ownership
+
+Use the closest existing test first.
+
+| Contract | Primary tests |
+| --- | --- |
+| Root exports and declaration cycles | `root-export-contract.ts`, `public-entrypoint-cycles.test.mts` |
+| Client lifecycle, config, and collectors | `invalid-token.test.mts`, `config-load.test.mts`, `client-collectors.test.mts` |
+| Plugin authoring and extensions | `plugin-authoring-contract.ts`, `plugins.test.mts`, `plugin-api.test.mts`, `client-plugins.test.mts` |
+| Registry/client inference | `command-context-client-type.test.mts` and the compile-time contracts |
+| Command declarations/options/subcommands/locales | `command-declare-*`, `command-options-contract.ts`, `command-subcommands-limit.test.mts`, `command-locales.test.mts` |
+| Command/component/modal contexts | `command-context-modal.test.mts`, `component-*.test.mts`, `modal-context-update.test.mts`, `interaction-reply.test.mts` |
+| REST/retries/uploads/shorters | `rest-retry-options.test.mts`, `interaction-request.test.mts`, `message-shorter.test.mts`, attachment/message tests |
+| Cache and structures | `cache.test.mts`, channel/guild/member/role/voice-state tests |
+| Gateway and workers | `gateway-send.test.mts`, `gateway-reconnect.test.mts`, `workermanager.test.mts` |
+| Builders and errors | `builder-validation.test.mts`, feature builder tests, `seyfert-error.test.mts` |
+| Langs and locale selection | `langs-handler.test.mts`, `context-lang-preference.test.mts`, `command-locales.test.mts` |
+| Shared foundations | `collection.test.mts`, `mixer.test.mts`, `bitfield.test.mts`, `common-utils.test.mts`, `logger.test.mts`, `formatter.test.mts` |
+
+Compile-time contract files are real tests even though they do not use Vitest.
+`tests/tsconfig.json` maps `seyfert` to the freshly built `lib/index.d.ts`, so
+type verification checks the consumer-facing declaration surface.
+
+For a new regression:
+
+- prefer adding it to the owning file rather than creating a broad
+  miscellaneous suite;
+- reproduce the public failure, not an implementation detail;
+- use a temporary consumer project and the TypeScript compiler API when normal
+  `tsc` diagnostics cannot reproduce editor/lazy-resolution behavior;
+- keep fixtures minimal and clean them up in `finally` blocks;
+- test adjacent shared contexts when the changed alias or handler feeds more
+  than one surface.
+
+## Commands
+
+The repository pins `pnpm@11.10.0`. CI uses Node 22 and runs the suite under
+Node, Bun, and Deno.
+
+```sh
+# Reproduce the Node dependency graph used by CI
+pnpm install --frozen-lockfile
+
+# Build JS and declarations
+pnpm run build
+
+# Build, then type-check all test contracts
+pnpm run test:types
+
+# Target the strict public authoring contracts
+./node_modules/.bin/tsc --noEmit --project tests/plugin-authoring-tsconfig.json
+
+# Run one Vitest file
+./node_modules/.bin/vitest run --config ./tests/vitest.config.mts ./tests/<name>.test.mts
+
+# Full build + type contracts + runtime tests
+pnpm test
+
+# Read-only production-source check
+./node_modules/.bin/biome check --no-errors-on-unmatched ./src
+```
+
+When a portability change requires local Bun/Deno parity, mirror
+`.github/workflows/check.yml`:
+
+```sh
+# Bun
+HUSKY=0 bun install --ignore-scripts
+bun run build
+bun --bun ./node_modules/vitest/vitest.mjs run --config ./tests/vitest.config.mts ./tests/
+
+# Deno
+HUSKY=0 deno install
+deno run -A npm:typescript/tsc --outDir ./lib
+deno run -A npm:vitest run --config ./tests/vitest.config.mts ./tests/
+```
+
+## Verification ladder
+
+Use the ladder proportionally:
+
+1. Inspect/format the changed file.
+2. Run the targeted compiler contract or Vitest regression.
+3. Build declarations for public/type changes.
+4. Run `pnpm test` for shared/public/runtime changes.
+5. Run the relevant Bun/Deno path when changing portability, workers,
+   filesystem behavior, Web APIs, or transport code.
+6. Run a real gateway smoke only when the task requires it and a token is
+   explicitly available.
+
+`tests/vitest.config.mts` disables file parallelism and isolation, so tests may
+share module state. Preserve cleanup and avoid tests that depend on accidental
+execution order. Gateway/custom-event collectors in `src/client/collectors.ts`
+and component collectors in `ComponentHandler` are separate systems; test the
+one owned by the changed path.
+
+The repository scripts `check`, `check-h`, `lint`, and `format` all use
+`--write`; they mutate source. Use the direct Biome command above when only a
+read-only check is intended.
+
+## Test code style
+
+Runtime tests are `*.test.mts`; compiler contracts are `.ts` files loaded by a
+test tsconfig. Import according to the subject:
+
+- `../src/...` for an internal runtime unit;
+- `../lib/...` when emitted output is the subject;
+- `seyfert` through test path mapping for the consumer-facing public contract.
+
+Do not normalize import sources. The dominant Vitest vocabulary is `describe`,
+`test`, `expect`, and `vi`; preserve other local styles. With isolation/file
+parallelism disabled, restore spies/mocks/globals, real timers (preferably in
+`finally`/`afterEach`), and singleton/module state; remove temporary directories
+in `finally`; never depend on test order. Name regressions after observable
+guarantees, use small setup helpers when clearer, and cover accepted plus
+explained negative forms when both define a contract.


### PR DESCRIPTION
## Summary

- Add a compact root `AGENTS.md` router plus nested source, test, and subsystem development guides.
- Keep automatically loaded instruction chains compact for agent runners with combined document limits.
- Change documentation only; structural checks, path resolution, and the strict quality review passed.

## Root Cause

Seyfert's development guidance was too large to remain reliable as one root instruction file. Splitting it by ownership avoids truncation in runners with instruction-size limits and keeps subsystem-specific guidance close to the code it governs.