### PR TITLE
fix(websocket)!: stabilize shard reconnect lifecycle

### DIFF
--- a/src/websocket/discord/shard.ts
+++ b/src/websocket/discord/shard.ts
@@ -24,7 +24,6 @@ import { ShardSocketCloseCodes } from './shared';
 export interface ShardHeart {
 	interval: number;
 	nodeInterval?: NodeJS.Timeout;
-	ackTimeout?: NodeJS.Timeout;
 	lastAck?: number;
 	lastBeat?: number;
 	ack: boolean;
@@ -44,8 +43,13 @@ export class Shard {
 		ack: true,
 	};
 
-	private isConnecting = false;
 	private reconnectPromise: Promise<void> | undefined;
+	// Invalidates delayed connects and callbacks that belong to a replaced socket.
+	private lifecycle = 0;
+	private connectingLifecycle?: number;
+	private handledWebsocket?: BaseSocket;
+	private localClose?: { websocket: BaseSocket; applyPolicy: boolean };
+	private firstHeartbeatTimeout?: NodeJS.Timeout;
 
 	bucket: DynamicBucket;
 	offlineSendQueue: ((_?: unknown) => void)[] = [];
@@ -127,41 +131,83 @@ export class Shard {
 	}
 
 	async connect() {
-		if (this.isConnecting) {
+		if (this.connectingLifecycle === undefined) this.reconnectPromise = undefined;
+		return this.connectSocket(false);
+	}
+
+	private async connectSocket(immediate: boolean) {
+		if (this.connectingLifecycle !== undefined) {
 			this.debugger?.debug(`[Shard #${this.id}] Already connecting, skipping`);
 			return;
 		}
 
-		this.isConnecting = true;
-		await this.connectTimeout.wait();
+		const lifecycle = ++this.lifecycle;
+		this.connectingLifecycle = lifecycle;
+		if (!immediate) await this.connectTimeout.wait();
+		if (this.connectingLifecycle !== lifecycle) return;
+		if (lifecycle !== this.lifecycle) {
+			this.connectingLifecycle = undefined;
+			return;
+		}
 		if (this.isOpen) {
 			this.debugger?.debug(`[Shard #${this.id}] Attempted to connect while open`);
-			this.isConnecting = false;
+			this.connectingLifecycle = undefined;
 			return;
 		}
 
-		clearTimeout(this.heart.nodeInterval);
+		this.clearHeartbeat();
+		clearTimeout(this.connectionTimeout);
 
-		this.debugger?.debug(`[Shard #${this.id}] Connecting to ${this.currentGatewayURL}`);
-
-		this.connectionTimeout = setTimeout(
-			() => this.reconnect(ShardSocketCloseCodes.Timeout),
-			this.options.connectionTimeout,
-		);
+		const url = this.currentGatewayURL;
+		this.debugger?.debug(`[Shard #${this.id}] Connecting to ${url}`);
 
 		// @ts-expect-error Use native websocket when using Bun
-		this.websocket = new BaseSocket(typeof Bun === 'undefined' ? 'ws' : 'bun', this.currentGatewayURL);
+		const websocket = new BaseSocket(typeof Bun === 'undefined' ? 'ws' : 'bun', url);
+		this.isReady = false;
+		this.handledWebsocket = undefined;
+		this.localClose = undefined;
+		this.websocket = websocket;
 
-		this.websocket.onmessage = ({ data }: { data: string | Buffer }) => {
-			this.handleMessage(data);
+		this.connectionTimeout = setTimeout(() => {
+			if (!this.isCurrentConnection(websocket)) return;
+			void this.reconnectWith(
+				ShardSocketCloseCodes.Timeout,
+				this.options.reconnectTimeout,
+				'Gateway connection timed out',
+			).catch(error => this.logger.error(error));
+		}, this.options.connectionTimeout);
+
+		websocket.onmessage = ({ data }: { data: string | Buffer }) => {
+			if (!this.isCurrentConnection(websocket)) return;
+			try {
+				void Promise.resolve(this.handleMessage(data)).catch(error => this.logger.error(error));
+			} catch (error) {
+				this.logger.error(error);
+			}
 		};
 
-		this.websocket.onclose = (event: { code: number; reason: string }) => this.handleClosed(event);
+		websocket.onclose = (event: { code: number; reason: string }) => {
+			if (!this.isCurrentConnection(websocket)) return;
+			const localClose = this.localClose?.websocket === websocket ? this.localClose : undefined;
+			void this.handleConnectionClosed(
+				{
+					code: event.code,
+					reason: event.reason,
+					locallyInitiated: !!localClose,
+					applyPolicy: localClose?.applyPolicy,
+				},
+				websocket,
+			).catch(error => this.logger.error(error));
+		};
 
-		this.websocket.onerror = (event: ErrorEvent) => this.logger.error(`Shard #${this.id}`, event);
+		websocket.onerror = (event: ErrorEvent) => {
+			if (!this.isCurrentConnection(websocket)) return;
+			this.logger.error(`Shard #${this.id}`, event);
+		};
 
-		this.websocket.onopen = () => {
-			this.isConnecting = false;
+		websocket.onopen = () => {
+			if (!this.isCurrentConnection(websocket)) return;
+			this.connectingLifecycle = undefined;
 			this.heart.ack = true;
 			void this.options.onShardReconnect?.({ shardId: this.id });
 		};
@@ -185,8 +231,16 @@ export class Shard {
 			);
 		}
 		await this.checkOffline(force);
+		const websocket = this.websocket;
 		await this.bucket.acquire(force);
 		await this.checkOffline(force);
+		// Authentication is connection-scoped; never deliver an Identify or Resume
+		// that finished waiting after its socket was replaced.
+		if (
+			(message.op === GatewayOpcodes.Identify || message.op === GatewayOpcodes.Resume) &&
+			(!websocket || !this.isCurrentConnection(websocket))
+		)
+			return;
 		this.websocket?.send(JSON.stringify(message));
 	}
 
@@ -220,52 +274,124 @@ export class Shard {
 	}
 
 	heartbeat(requested: boolean) {
+		const websocket = this.websocket;
+		if (!websocket) return;
 		this.debugger?.debug(
 			`[Shard #${this.id}] Sending ${requested ? '' : 'un'}requested heartbeat (Ack=${this.heart.ack})`,
 		);
+		if (!requested && !this.heart.ack) {
+			void this.reconnectWith(
+				ShardSocketCloseCodes.ZombiedConnection,
+				0,
+				'Heartbeat ACK was not received before the next interval',
+			).catch(error => this.logger.error(error));
+			return;
+		}
+		if (websocket.readyState !== 1) return;
 		if (!requested) {
-			if (!this.heart.ack) {
-				this.reconnect(ShardSocketCloseCodes.ZombiedConnection);
-				return;
-			}
 			this.heart.ack = false;
 		}
 
 		this.heart.lastBeat = Date.now();
 
-		this.websocket!.send(
+		websocket.send(
 			JSON.stringify({
 				op: GatewayOpcodes.Heartbeat,
 				d: this.data.resume_seq ?? null,
 			}),
 		);
-
-		clearTimeout(this.heart.ackTimeout);
-		this.heart.ackTimeout = setTimeout(() => {
-			if (!this.heart.ack) {
-				this.reconnect(ShardSocketCloseCodes.ZombiedConnection);
-			}
-		}, this.heart.interval * 1.5);
 	}
 
 	disconnect(code = ShardSocketCloseCodes.Shutdown) {
-		clearTimeout(this.connectionTimeout);
-		this.connectionTimeout = undefined;
-		clearTimeout(this.heart.ackTimeout);
-		this.isConnecting = false;
+		this.lifecycle++;
+		this.reconnectPromise = undefined;
 		this.debugger?.info(`[Shard #${this.id}] Disconnecting`);
-		this.close(code, 'Shard down request');
+		this.closeConnection(code, 'Shard down request', this.shouldApplyLocalClosePolicy(code));
 	}
 
 	async reconnect(code = ShardSocketCloseCodes.Reconnect) {
-		return (this.reconnectPromise ??= (async () => {
+		return this.reconnectWith(code, this.options.reconnectTimeout, 'Shard reconnect request');
+	}
+
+	private reconnectWith(
+		code: number,
+		wait: number,
+		reason: string,
+		immediate = code === ShardSocketCloseCodes.Timeout ? false : this.resumable,
+	) {
+		if (this.reconnectPromise) return this.reconnectPromise;
+		const reconnect = (async () => {
+			const lifecycle = ++this.lifecycle;
 			this.debugger?.info(`[Shard #${this.id}] Reconnecting`);
-			this.disconnect(code);
-			await delay(this.options.reconnectTimeout);
-			await this.connect();
-		})().finally(() => {
-			this.reconnectPromise = undefined;
-		}));
+			this.closeConnection(code, reason);
+			if (code === ShardSocketCloseCodes.Timeout) this.resetSession();
+			if (wait > 0) await delay(wait);
+			if (lifecycle !== this.lifecycle) return;
+			await this.connectSocket(immediate);
+		})();
+		const settled = reconnect.finally(() => {
+			if (this.reconnectPromise === settled) this.reconnectPromise = undefined;
+		});
+		this.reconnectPromise = settled;
+		return settled;
+	}
+
+	private isCurrentConnection(websocket: BaseSocket) {
+		return this.websocket === websocket && this.handledWebsocket !== websocket;
+	}
+
+	private clearHeartbeat() {
+		clearTimeout(this.firstHeartbeatTimeout);
+		clearInterval(this.heart.nodeInterval);
+		this.firstHeartbeatTimeout = undefined;
+		this.heart.nodeInterval = undefined;
+	}
+
+	private resetSession() {
+		this.data.resume_seq = null;
+		this.data.session_id = undefined;
+		this.data.resume_gateway_url = undefined;
+		this.pendingGuilds = undefined;
+	}
+
+	private startHeartbeat(websocket: BaseSocket) {
+		this.clearHeartbeat();
+		this.heart.ack = true;
+		this.firstHeartbeatTimeout = setTimeout(() => {
+			if (!this.isCurrentConnection(websocket)) return;
+			this.heartbeat(false);
+			this.heart.nodeInterval = setInterval(() => {
+				if (this.isCurrentConnection(websocket)) this.heartbeat(false);
+			}, this.heart.interval);
+		}, this.heart.interval * Math.random());
+	}
+
+	private closeConnection(code: number, reason: string, applyPolicy = false) {
+		const websocket = this.websocket;
+		if (!websocket) {
+			this.connectingLifecycle = undefined;
+			clearTimeout(this.connectionTimeout);
+			this.connectionTimeout = undefined;
+			this.clearHeartbeat();
+			this.debugger?.warn(`[Shard #${this.id}] Is not open, reason:`, reason);
+			return;
+		}
+
+		this.debugger?.debug(`[Shard #${this.id}] Called close with reason:`, reason);
+		// Native and custom sockets report local Close frames differently. Mark the
+		// owner before closing so both paths finalize the same lifecycle exactly once.
+		this.localClose = { websocket, applyPolicy };
+		try {
+			websocket.close(code, reason);
+		} catch (error) {
+			this.localClose = undefined;
+			throw error;
+		}
+		this.connectingLifecycle = undefined;
+		if (this.handledWebsocket !== websocket) {
+			const close = { code, reason, locallyInitiated: true, applyPolicy };
+			void this.handleConnectionClosed(close, websocket).catch(error => this.logger.error(error));
+		}
 	}
 
 	private flushOfflineSendQueue() {
@@ -282,14 +408,12 @@ export class Shard {
 
 		switch (packet.op) {
 			case GatewayOpcodes.Hello: {
+				const websocket = this.websocket;
+				if (!websocket) return;
 				clearTimeout(this.connectionTimeout);
 				this.connectionTimeout = undefined;
-				clearInterval(this.heart.nodeInterval);
-
 				this.heart.interval = packet.d.heartbeat_interval;
-
-				this.heartbeat(false);
-				this.heart.nodeInterval = setInterval(() => this.heartbeat(false), this.heart.interval);
+				this.startHeartbeat(websocket);
 
 				if (this.resumable) {
 					return this.resume();
@@ -300,24 +424,21 @@ export class Shard {
 				{
 					this.heart.ack = true;
 					this.heart.lastAck = Date.now();
-					clearTimeout(this.heart.ackTimeout);
 				}
 				break;
 			case GatewayOpcodes.Heartbeat:
 				this.heartbeat(true);
 				break;
 			case GatewayOpcodes.Reconnect:
-				return this.reconnect();
+				return this.reconnectWith(ShardSocketCloseCodes.Reconnect, 0, 'Discord requested a reconnect', true);
 			case GatewayOpcodes.InvalidSession: {
-				if (packet.d) {
-					if (!this.resumable) {
-						return this.logger.fatal(`Shard #${this.id} received a non-resumable InvalidSession, cannot resume.`);
-					}
-					return this.resume();
-				}
-				this.data.resume_seq = 0;
-				this.data.session_id = undefined;
-				return this.identify();
+				const canResume = packet.d && this.resumable;
+				if (!canResume) this.resetSession();
+				return this.reconnectWith(
+					ShardSocketCloseCodes.Reconnect,
+					0,
+					canResume ? 'Discord invalidated the resumable session' : 'Discord invalidated the session',
+				);
 			}
 			case GatewayOpcodes.Dispatch:
 				{
@@ -432,6 +553,7 @@ export class Shard {
 				}
 				break;
 		}
+		return undefined;
 	}
 
 	async requestGuildMember(
@@ -485,63 +607,82 @@ export class Shard {
 		return promise;
 	}
 
-	protected async handleClosed(close: { code: number; reason: string }) {
-		this.isReady = false;
-		clearInterval(this.heart.nodeInterval);
-		clearTimeout(this.heart.ackTimeout);
-		this.logger.warn(
-			`Shard #${this.id} closed: ${ShardSocketCloseCodes[close.code] ?? GatewayCloseCodes[close.code] ?? close.code} (${close.code})`,
-			close.reason,
+	private isExpectedLocalClose(code: number) {
+		return (
+			code === ShardSocketCloseCodes.Shutdown ||
+			code === ShardSocketCloseCodes.Reconnect ||
+			code === ShardSocketCloseCodes.Resharding ||
+			code === ShardSocketCloseCodes.ShutdownAll
 		);
+	}
+
+	private shouldApplyLocalClosePolicy(code: number) {
+		return !this.isExpectedLocalClose(code) && code !== ShardSocketCloseCodes.ZombiedConnection;
+	}
+
+	private async handleConnectionClosed(
+		close: { code: number; reason: string; locallyInitiated?: boolean; applyPolicy?: boolean },
+		websocket: BaseSocket | null,
+	) {
+		if (!websocket || !this.isCurrentConnection(websocket)) return;
+		this.handledWebsocket = websocket;
+		if (this.localClose?.websocket === websocket) this.localClose = undefined;
+		this.isReady = false;
+		this.connectingLifecycle = undefined;
+		clearTimeout(this.connectionTimeout);
+		this.connectionTimeout = undefined;
+		this.clearHeartbeat();
+
+		const closeMessage = `Shard #${this.id} closed: ${
+			ShardSocketCloseCodes[close.code] ?? GatewayCloseCodes[close.code] ?? close.code
+		} (${close.code})`;
+		if (close.locallyInitiated && this.isExpectedLocalClose(close.code)) {
+			this.logger.info(closeMessage, close.reason);
+		} else {
+			this.logger.warn(closeMessage, close.reason);
+		}
 
 		try {
-			switch (close.code) {
-				case ShardSocketCloseCodes.Shutdown:
-				case ShardSocketCloseCodes.Reconnect:
-				case ShardSocketCloseCodes.Resharding:
-				case ShardSocketCloseCodes.ShutdownAll:
-				case ShardSocketCloseCodes.ZombiedConnection:
-					//Force disconnect, ignore
-					break;
-				case 1000:
-				case GatewayCloseCodes.UnknownOpcode:
-				case GatewayCloseCodes.InvalidSeq:
-				case GatewayCloseCodes.SessionTimedOut:
-				// shard failed to connect, try connecting from scratch
-				case ShardSocketCloseCodes.Timeout:
-					{
-						this.data.resume_seq = 0;
-						this.data.session_id = undefined;
-						this.data.resume_gateway_url = undefined;
-						await this.reconnect();
-					}
-					break;
-				case 1001:
-				case 1006:
-				case GatewayCloseCodes.UnknownError:
-				case GatewayCloseCodes.DecodeError:
-				case GatewayCloseCodes.NotAuthenticated:
-				case GatewayCloseCodes.AlreadyAuthenticated:
-				case GatewayCloseCodes.RateLimited:
-					{
-						this.logger.info('Trying to reconnect');
-						await this.reconnect();
-					}
-					break;
-				case GatewayCloseCodes.AuthenticationFailed:
-				case GatewayCloseCodes.DisallowedIntents:
-				case GatewayCloseCodes.InvalidAPIVersion:
-				case GatewayCloseCodes.InvalidIntents:
-				case GatewayCloseCodes.InvalidShard:
-				case GatewayCloseCodes.ShardingRequired:
-					this.logger.fatal(`Shard #${this.id} cannot reconnect`);
-					break;
-				default:
-					{
-						this.logger.warn(`Shard #${this.id} unknown close code (${close.code}), trying to reconnect anyways`);
-						await this.reconnect();
-					}
-					break;
+			if (!close.locallyInitiated || close.applyPolicy) {
+				switch (close.code) {
+					case 1000:
+					case GatewayCloseCodes.UnknownOpcode:
+					case GatewayCloseCodes.InvalidSeq:
+					case GatewayCloseCodes.SessionTimedOut:
+					case ShardSocketCloseCodes.Timeout:
+						{
+							this.resetSession();
+							await this.reconnect();
+						}
+						break;
+					case 1001:
+					case 1006:
+					case GatewayCloseCodes.UnknownError:
+					case GatewayCloseCodes.DecodeError:
+					case GatewayCloseCodes.NotAuthenticated:
+					case GatewayCloseCodes.AlreadyAuthenticated:
+					case GatewayCloseCodes.RateLimited:
+						{
+							this.logger.info('Trying to reconnect');
+							await this.reconnect();
+						}
+						break;
+					case GatewayCloseCodes.AuthenticationFailed:
+					case GatewayCloseCodes.DisallowedIntents:
+					case GatewayCloseCodes.InvalidAPIVersion:
+					case GatewayCloseCodes.InvalidIntents:
+					case GatewayCloseCodes.InvalidShard:
+					case GatewayCloseCodes.ShardingRequired:
+						this.lifecycle++;
+						this.logger.fatal(`Shard #${this.id} cannot reconnect`);
+						break;
+					default:
+						{
+							this.logger.warn(`Shard #${this.id} unknown close code (${close.code}), trying to reconnect anyways`);
+							await this.reconnect();
+						}
+						break;
+				}
 			}
 		} finally {
 			await this.options.onShardDisconnect?.({
@@ -553,23 +694,18 @@ export class Shard {
 	}
 
 	close(code: number, reason: string) {
-		clearInterval(this.heart.nodeInterval);
-		if (!this.websocket) {
-			return this.debugger?.warn(`[Shard #${this.id}] Is not open, reason:`, reason);
-		}
-		this.debugger?.debug(`[Shard #${this.id}] Called close with reason:`, reason);
-		this.websocket?.close(code, reason);
+		this.lifecycle++;
+		this.reconnectPromise = undefined;
+		this.closeConnection(code, reason, this.shouldApplyLocalClosePolicy(code));
 	}
 
 	protected handleMessage(data: string | Buffer) {
 		let packet: GatewayDispatchPayload;
 		try {
-			if (data instanceof Buffer) {
-				data = inflateSync(data);
-			}
+			if (data instanceof Buffer) data = inflateSync(data);
 			packet = JSON.parse(data as string);
-		} catch (e) {
-			this.logger.error(e);
+		} catch (error) {
+			this.logger.error(error);
 			return;
 		}
 		return this.onpacket(packet);

--- a/tests/gateway-reconnect.test.mts
+++ b/tests/gateway-reconnect.test.mts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { GatewayDispatchEvents, GatewayOpcodes } from '../src/types';
 import { Shard } from '../src/websocket/discord/shard';
 import { ShardSocketCloseCodes, type ShardOptions } from '../src/websocket/discord/shared';
 
@@ -8,6 +9,8 @@ afterEach(() => {
 	vi.resetModules();
 	vi.restoreAllMocks();
 	vi.useRealTimers();
+	vi.doUnmock('../src/websocket/discord/basesocket');
+	FakeBaseSocket.instances.length = 0;
 });
 
 describe('gateway reconnect stability', () => {
@@ -106,6 +109,554 @@ describe('gateway reconnect stability', () => {
 		expect(onclose).toHaveBeenCalledWith({
 			code: 1006,
 			reason: 'boom-6',
+		});
+	});
+});
+
+type CloseEvent = {
+	code: number;
+	reason: string;
+};
+
+class FakeBaseSocket {
+	static instances: FakeBaseSocket[] = [];
+
+	readyState = 0;
+	sent: unknown[] = [];
+	onopen = () => {};
+	onmessage = (_event: { data: string | Buffer }) => {};
+	onclose = (_event: CloseEvent) => {};
+	onerror = (_error: unknown) => {};
+
+	close = vi.fn((_code: number, _reason: string) => {
+		this.readyState = 3;
+	});
+
+	send = vi.fn((data: string) => {
+		this.sent.push(JSON.parse(data));
+	});
+
+	ping = vi.fn(async () => 0);
+
+	constructor(
+		_kind: 'ws' | 'bun',
+		readonly url: string,
+	) {
+		FakeBaseSocket.instances.push(this);
+	}
+
+	open() {
+		this.readyState = 1;
+		this.onopen();
+	}
+
+	message(packet: unknown) {
+		this.onmessage({ data: JSON.stringify(packet) });
+	}
+
+	remoteClose(event: CloseEvent) {
+		this.readyState = 3;
+		this.onclose(Object.create(event) as CloseEvent);
+	}
+}
+
+function gatewayInfo() {
+	return {
+		url: 'wss://gateway.discord.gg',
+		shards: 1,
+		session_start_limit: {
+			total: 1,
+			remaining: 1,
+			reset_after: 0,
+			max_concurrency: 1,
+		},
+	};
+}
+
+function createOptions(overrides: Partial<ShardOptions> = {}): ShardOptions {
+	return {
+		token: 'token',
+		intents: 0,
+		compress: false,
+		info: gatewayInfo(),
+		handlePayload: vi.fn(),
+		...overrides,
+	} as ShardOptions;
+}
+
+function hello(heartbeatInterval = 1_000) {
+	return {
+		op: GatewayOpcodes.Hello,
+		d: { heartbeat_interval: heartbeatInterval },
+		s: null,
+		t: null,
+	};
+}
+
+function gatewayPacket(op: GatewayOpcodes, data: unknown = null) {
+	return { op, d: data, s: null, t: null };
+}
+
+function ready(sequence = 1, sessionId = 'session-b') {
+	return {
+		op: GatewayOpcodes.Dispatch,
+		t: GatewayDispatchEvents.Ready,
+		s: sequence,
+		d: {
+			guilds: [],
+			resume_gateway_url: 'wss://resume-b.discord.gg',
+			session_id: sessionId,
+		},
+	};
+}
+
+async function loadLifecycleShard() {
+	vi.resetModules();
+	FakeBaseSocket.instances.length = 0;
+	vi.doMock('../src/websocket/discord/basesocket', () => ({ BaseSocket: FakeBaseSocket }));
+	vi.spyOn(Math, 'random').mockReturnValue(0.5);
+	return (await import('../src/websocket/discord/shard')).Shard;
+}
+
+async function createConnectedShard(overrides: Partial<ShardOptions> = {}) {
+	const LifecycleShard = await loadLifecycleShard();
+	const shard = new LifecycleShard(0, createOptions(overrides));
+	shard.connectTimeout.wait = vi.fn().mockResolvedValue(true);
+	await shard.connect();
+	const socket = FakeBaseSocket.instances.at(-1)!;
+	return { shard, socket };
+}
+
+describe('gateway reconnect lifecycle', () => {
+	test('a missed heartbeat ACK replaces the zombied connection after the transport stops being open', async () => {
+		vi.useFakeTimers();
+		const { shard, socket } = await createConnectedShard({ reconnectTimeout: 60_000 });
+		vi.mocked(Math.random).mockReturnValue(0);
+		socket.open();
+		socket.message(hello());
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(shard.heart.ack).toBe(false);
+		socket.readyState = 2;
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(socket.close).toHaveBeenCalledWith(
+			ShardSocketCloseCodes.ZombiedConnection,
+			'Heartbeat ACK was not received before the next interval',
+		);
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+	});
+
+	test('Opcode 7 opens a replacement immediately and resumes only after its HELLO', async () => {
+		vi.useFakeTimers();
+		const { shard, socket: first } = await createConnectedShard({ reconnectTimeout: 60_000 });
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		first.open();
+		first.message(gatewayPacket(GatewayOpcodes.Reconnect));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+
+		expect(first.close).toHaveBeenCalledWith(ShardSocketCloseCodes.Reconnect, 'Discord requested a reconnect');
+		expect(first.sent).toEqual([]);
+
+		const second = FakeBaseSocket.instances[1]!;
+		second.open();
+		second.message(hello());
+		await vi.waitFor(() => expect(second.sent).toHaveLength(1));
+
+		expect(first.sent).toEqual([]);
+		expect(second.sent).toEqual([expect.objectContaining({ op: GatewayOpcodes.Resume })]);
+	});
+
+	test('Opcode 7 before HELLO bypasses the per-shard connection delay', async () => {
+		vi.useFakeTimers();
+		const LifecycleShard = await loadLifecycleShard();
+		const shard = new LifecycleShard(0, createOptions());
+		const wait = vi.spyOn(shard.connectTimeout, 'wait');
+		await shard.connect();
+		const first = FakeBaseSocket.instances[0]!;
+		first.open();
+
+		first.message(gatewayPacket(GatewayOpcodes.Reconnect));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+		expect(wait).toHaveBeenCalledOnce();
+	});
+
+	test('a connection timeout discards the failed resume session before retrying', async () => {
+		vi.useFakeTimers();
+		const LifecycleShard = await loadLifecycleShard();
+		const shard = new LifecycleShard(
+			0,
+			createOptions({
+				connectionTimeout: 30_000,
+				reconnectTimeout: 10_000,
+			}),
+		);
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://dead-edge.discord.gg',
+			session_id: 'session-a',
+		};
+		shard.pendingGuilds = new Set(['guild']);
+		shard.connectTimeout.wait = vi.fn().mockResolvedValue(true);
+
+		await shard.connect();
+		const first = FakeBaseSocket.instances[0]!;
+		expect(new URL(first.url).hostname).toBe('dead-edge.discord.gg');
+
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(first.close).toHaveBeenCalledWith(ShardSocketCloseCodes.Timeout, 'Gateway connection timed out');
+		expect(shard.data.resume_seq).toBeNull();
+		expect(shard.data.resume_gateway_url).toBeUndefined();
+		expect(shard.data.session_id).toBeUndefined();
+		expect(shard.pendingGuilds).toBeUndefined();
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+		expect(new URL(FakeBaseSocket.instances[1]!.url).hostname).toBe('gateway.discord.gg');
+	});
+
+	test('a 1006 creates one replacement after the configured backoff and resumes', async () => {
+		vi.useFakeTimers();
+		const onShardDisconnect = vi.fn();
+		const { shard, socket: first } = await createConnectedShard({ reconnectTimeout: 1_000, onShardDisconnect });
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		first.open();
+		first.remoteClose({ code: 1006, reason: 'connection reset' });
+		first.remoteClose({ code: 1006, reason: 'duplicate close callback' });
+
+		expect(FakeBaseSocket.instances).toHaveLength(1);
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+
+		const second = FakeBaseSocket.instances[1]!;
+		expect(new URL(second.url).hostname).toBe('resume.discord.gg');
+		second.open();
+		second.message(hello());
+		await vi.waitFor(() => expect(second.sent).toHaveLength(1));
+
+		expect(second.sent).toEqual([expect.objectContaining({ op: GatewayOpcodes.Resume })]);
+		expect(onShardDisconnect).toHaveBeenCalledOnce();
+		expect(onShardDisconnect).toHaveBeenCalledWith({
+			shardId: 0,
+			code: 1006,
+			reason: 'connection reset',
+		});
+	});
+
+	test('a stale authentication cannot be sent after its socket is replaced', async () => {
+		vi.useFakeTimers();
+		const { shard, socket: first } = await createConnectedShard();
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		let release!: () => void;
+		const acquire = vi
+			.spyOn(shard.bucket, 'acquire')
+			.mockImplementationOnce(() => new Promise<void>(resolve => (release = resolve)))
+			.mockResolvedValue(undefined);
+		first.open();
+		const staleAuthentication = shard.resume();
+		await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce());
+
+		first.message(gatewayPacket(GatewayOpcodes.Reconnect));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+		release();
+		await vi.waitFor(() => expect(shard.offlineSendQueue).toHaveLength(1));
+
+		const second = FakeBaseSocket.instances[1]!;
+		second.open();
+		second.message(hello());
+		await vi.waitFor(() => expect(second.sent).toHaveLength(1));
+		second.message(ready(42));
+		await staleAuthentication;
+
+		expect(first.sent).toEqual([]);
+		expect(second.sent).toEqual([expect.objectContaining({ op: GatewayOpcodes.Resume })]);
+	});
+
+	test('Opcode 9 reconnects before authenticating and preserves only resumable sessions', async () => {
+		vi.useFakeTimers();
+		const resumable = await createConnectedShard();
+		resumable.shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		resumable.socket.open();
+		resumable.socket.message(gatewayPacket(GatewayOpcodes.InvalidSession, true));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+		const resumedSocket = FakeBaseSocket.instances[1]!;
+		resumedSocket.open();
+		resumedSocket.message(hello());
+		await vi.waitFor(() => expect(resumedSocket.sent).toHaveLength(1));
+		expect(resumedSocket.sent).toEqual([expect.objectContaining({ op: GatewayOpcodes.Resume })]);
+
+		const nonResumable = await createConnectedShard();
+		nonResumable.shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		nonResumable.shard.pendingGuilds = new Set(['guild']);
+		nonResumable.socket.open();
+		nonResumable.socket.message(gatewayPacket(GatewayOpcodes.InvalidSession, false));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+		expect(nonResumable.shard.data.resume_seq).toBeNull();
+		expect(nonResumable.shard.data.resume_gateway_url).toBeUndefined();
+		expect(nonResumable.shard.data.session_id).toBeUndefined();
+		expect(nonResumable.shard.pendingGuilds).toBeUndefined();
+		const identifiedSocket = FakeBaseSocket.instances[1]!;
+		identifiedSocket.open();
+		identifiedSocket.message(hello());
+		await vi.waitFor(() => expect(identifiedSocket.sent).toHaveLength(1));
+		expect(identifiedSocket.sent).toEqual([expect.objectContaining({ op: GatewayOpcodes.Identify })]);
+	});
+
+	test('late callbacks from a replaced socket cannot mutate the active lifecycle', async () => {
+		vi.useFakeTimers();
+		const handlePayload = vi.fn();
+		const onShardDisconnect = vi.fn();
+		const onShardReconnect = vi.fn();
+		const { shard, socket: first } = await createConnectedShard({
+			handlePayload,
+			onShardDisconnect,
+			onShardReconnect,
+		});
+		first.open();
+		first.message(gatewayPacket(GatewayOpcodes.Reconnect));
+		await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+
+		const second = FakeBaseSocket.instances[1]!;
+		second.open();
+		second.message(hello());
+		await vi.waitFor(() => expect(second.sent).toHaveLength(1));
+		second.message(ready(42));
+		const payloadCalls = handlePayload.mock.calls.length;
+		const reconnectCalls = onShardReconnect.mock.calls.length;
+		const disconnectCalls = onShardDisconnect.mock.calls.length;
+
+		first.open();
+		first.message(ready(999, 'stale-session'));
+		first.remoteClose({ code: 1006, reason: 'stale EOF' });
+
+		expect(shard.websocket).toBe(second);
+		expect(shard.data.resume_seq).toBe(42);
+		expect(shard.data.session_id).toBe('session-b');
+		expect(shard.isReady).toBe(true);
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+		expect(handlePayload).toHaveBeenCalledTimes(payloadCalls);
+		expect(onShardReconnect).toHaveBeenCalledTimes(reconnectCalls);
+		expect(onShardDisconnect).toHaveBeenCalledTimes(disconnectCalls);
+	});
+
+	test.each([
+		['disconnect', (shard: Shard) => shard.disconnect()],
+		['close', (shard: Shard) => shard.close(ShardSocketCloseCodes.Shutdown, 'manual close')],
+	] as const)('%s cancels a connection that is still waiting to start', async (_name, cancel) => {
+		const LifecycleShard = await loadLifecycleShard();
+		const shard = new LifecycleShard(0, createOptions());
+		let release!: (value: boolean) => void;
+		shard.connectTimeout.wait = vi.fn(
+			() =>
+				new Promise<boolean>(resolve => {
+					release = resolve;
+				}),
+		);
+
+		const connecting = shard.connect();
+		cancel(shard);
+		release(true);
+		await connecting;
+
+		expect(FakeBaseSocket.instances).toEqual([]);
+		expect(shard.websocket).toBeNull();
+	});
+
+	test('canceling a reconnect backoff prevents it from replacing a newer lifecycle', async () => {
+		vi.useFakeTimers();
+		const { shard, socket } = await createConnectedShard({ reconnectTimeout: 1_000 });
+		socket.open();
+
+		const canceledReconnect = shard.reconnect();
+		shard.disconnect();
+		const replacementReconnect = shard.reconnect();
+		await vi.advanceTimersByTimeAsync(1_000);
+		await Promise.all([canceledReconnect, replacementReconnect]);
+
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+	});
+
+	test('an invalidated queued connect does not leave the shard permanently connecting', async () => {
+		vi.useFakeTimers();
+		const LifecycleShard = await loadLifecycleShard();
+		const shard = new LifecycleShard(0, createOptions({ reconnectTimeout: 1_000 }));
+		shard.connectTimeout.wait = vi.fn().mockResolvedValue(true);
+		await shard.connect();
+		const first = FakeBaseSocket.instances[0]!;
+		first.open();
+		first.remoteClose({ code: 1006, reason: 'connection reset' });
+
+		let release!: (value: boolean) => void;
+		shard.connectTimeout.wait = vi.fn(
+			() =>
+				new Promise<boolean>(resolve => {
+					release = resolve;
+				}),
+		);
+		const queuedConnect = shard.connect();
+		await vi.advanceTimersByTimeAsync(1_000);
+		shard.disconnect(ShardSocketCloseCodes.Resharding);
+		release(true);
+		await queuedConnect;
+
+		shard.connectTimeout.wait = vi.fn().mockResolvedValue(true);
+		await shard.connect();
+		expect(FakeBaseSocket.instances).toHaveLength(2);
+	});
+
+	test('a direct connect supersedes an older reconnect single-flight', async () => {
+		vi.useFakeTimers();
+		const LifecycleShard = await loadLifecycleShard();
+		const shard = new LifecycleShard(0, createOptions({ reconnectTimeout: 10_000 }));
+		shard.connectTimeout.wait = vi.fn().mockResolvedValue(true);
+		await shard.connect();
+		const first = FakeBaseSocket.instances[0]!;
+		first.open();
+		first.remoteClose({ code: 1006, reason: 'first reset' });
+
+		await shard.connect();
+		const second = FakeBaseSocket.instances[1]!;
+		second.open();
+		second.remoteClose({ code: 1006, reason: 'second reset' });
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(FakeBaseSocket.instances).toHaveLength(3);
+	});
+
+	test.each([1000, ShardSocketCloseCodes.Timeout])(
+		'a public close with policy code %s resets the session and reconnects',
+		async code => {
+			const { shard, socket } = await createConnectedShard({ reconnectTimeout: 0 });
+			shard.data = {
+				resume_seq: 42,
+				resume_gateway_url: 'wss://resume.discord.gg',
+				session_id: 'session-a',
+			};
+			shard.pendingGuilds = new Set(['guild']);
+			socket.open();
+
+			shard.close(code, 'public policy close');
+			await vi.waitFor(() => expect(FakeBaseSocket.instances).toHaveLength(2));
+
+			expect(shard.data.resume_seq).toBeNull();
+			expect(shard.data.resume_gateway_url).toBeUndefined();
+			expect(shard.data.session_id).toBeUndefined();
+			expect(shard.pendingGuilds).toBeUndefined();
+		},
+	);
+
+	test('a failed transport close does not finalize or replace the active socket', async () => {
+		const onShardDisconnect = vi.fn();
+		const { shard, socket } = await createConnectedShard({ reconnectTimeout: 0, onShardDisconnect });
+		socket.close.mockImplementationOnce(() => {
+			throw new RangeError('invalid close frame');
+		});
+		socket.open();
+
+		await expect(shard.reconnect()).rejects.toThrow('invalid close frame');
+
+		expect(shard.websocket).toBe(socket);
+		expect(shard.isOpen).toBe(true);
+		expect(FakeBaseSocket.instances).toHaveLength(1);
+		expect(onShardDisconnect).not.toHaveBeenCalled();
+	});
+
+	test('a failed close preserves connection ownership while the socket is handshaking', async () => {
+		const { shard, socket } = await createConnectedShard();
+		socket.close.mockImplementationOnce(() => {
+			throw new RangeError('invalid close frame');
+		});
+
+		expect(() => shard.close(ShardSocketCloseCodes.Reconnect, 'failed handshake close')).toThrow(
+			'invalid close frame',
+		);
+		await shard.connect();
+
+		expect(FakeBaseSocket.instances).toHaveLength(1);
+		expect(shard.websocket).toBe(socket);
+	});
+
+	test('a failed public timeout reconnect preserves the active resume session', async () => {
+		const { shard, socket } = await createConnectedShard({ reconnectTimeout: 0 });
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://resume.discord.gg',
+			session_id: 'session-a',
+		};
+		shard.pendingGuilds = new Set(['guild']);
+		socket.close.mockImplementationOnce(() => {
+			throw new RangeError('invalid close frame');
+		});
+		socket.open();
+
+		await expect(shard.reconnect(ShardSocketCloseCodes.Timeout)).rejects.toThrow('invalid close frame');
+
+		expect(shard.data.resume_seq).toBe(42);
+		expect(shard.data.resume_gateway_url).toBe('wss://resume.discord.gg');
+		expect(shard.data.session_id).toBe('session-a');
+		expect(shard.pendingGuilds).toEqual(new Set(['guild']));
+		expect(shard.websocket).toBe(socket);
+		expect(shard.isOpen).toBe(true);
+	});
+
+	test('a public timeout reconnect discards the failed resume session', async () => {
+		const { shard, socket } = await createConnectedShard({ reconnectTimeout: 0 });
+		shard.data = {
+			resume_seq: 42,
+			resume_gateway_url: 'wss://dead-edge.discord.gg',
+			session_id: 'session-a',
+		};
+		shard.pendingGuilds = new Set(['guild']);
+		socket.open();
+
+		await shard.reconnect(ShardSocketCloseCodes.Timeout);
+
+		expect(shard.data.resume_seq).toBeNull();
+		expect(shard.data.resume_gateway_url).toBeUndefined();
+		expect(shard.data.session_id).toBeUndefined();
+		expect(shard.pendingGuilds).toBeUndefined();
+		expect(new URL(FakeBaseSocket.instances[1]!.url).hostname).toBe('gateway.discord.gg');
+	});
+
+	test('a public local close finalizes the socket exactly once', async () => {
+		const onShardDisconnect = vi.fn();
+		const { shard, socket } = await createConnectedShard({ onShardDisconnect });
+		socket.close.mockImplementationOnce((code, reason) => {
+			socket.readyState = 3;
+			socket.onclose({ code, reason });
+		});
+		socket.open();
+
+		shard.close(ShardSocketCloseCodes.Reconnect, 'manual reconnect');
+		await vi.waitFor(() => expect(onShardDisconnect).toHaveBeenCalledOnce());
+		socket.remoteClose({ code: ShardSocketCloseCodes.Reconnect, reason: 'manual reconnect' });
+
+		expect(socket.close).toHaveBeenCalledWith(ShardSocketCloseCodes.Reconnect, 'manual reconnect');
+		expect(onShardDisconnect).toHaveBeenCalledOnce();
+		expect(onShardDisconnect).toHaveBeenCalledWith({
+			shardId: 0,
+			code: ShardSocketCloseCodes.Reconnect,
+			reason: 'manual reconnect',
 		});
 	});
 });


### PR DESCRIPTION
This Gateway reconnect issue has been around for a while. A random `1006` isn't necessarily caused by Seyfert, but Seyfert still needs to recover from it without getting stuck or starting several reconnects for the same shard.

The problem was that reconnect state was shared between `isConnecting`, timers, promises, and WebSocket callbacks without knowing which socket owned each operation. An old callback or queued connection could continue after its socket had already been replaced.

This PR gives every connection a lifecycle owner. Timers, callbacks, queued connects, and authentication can only continue while they still belong to the current socket. Reconnects are also single-flight, so several signals happening together produce one replacement connection.

It also makes sure that:

- `IDENTIFY` and `RESUME` are only sent after `HELLO`.
- A resumable `1006` keeps its session and uses `resume_gateway_url`.
- A `3050` timeout clears the failed session and starts fresh.
- Missing heartbeat ACKs replace zombied connections.
- Late or repeated close events are ignored.
- Disconnecting cancels pending connects and reconnect backoffs.
- Local reconnect closes don't trigger another reconnect recursively.

`ShardHeart.ackTimeout` was removed because it duplicated the heartbeat loop and both timers could race with each other. There is no deprecated replacement because that timer no longer owns any behavior.

I ran the change by itself for around 8 hours and 43 minutes. It received 2 closes with code `1006`; both resumed correctly, with no errors or reconnect loop.

I also ran a 32 + 32 shard comparison for around 33 hours and 29 minutes. Both sides had roughly 1,070 ready shard-hours and received 55 closes with code `1006`. All 110 connections recovered through `RESUME` and `RESUMED`, and neither side reproduced the quick reconnect loop from the original report.

That comparison didn't show a reduction in the number of `1006` closes. What it did show is that the new lifecycle handled every close without losing readiness or creating a reconnect cascade.

A later run reproduced the internal `3050` timeout loop on both sides during a shared no-`HELLO` period. That run is what exposed the remaining ownership and timeout races fixed by the final version of this PR.