### PR TITLE
feat: update Discord API contracts

### DIFF
--- a/src/api/Routes/users.ts
+++ b/src/api/Routes/users.ts
@@ -1,5 +1,6 @@
 import type {
 	APIDMChannel,
+	RESTDeleteAPICurrentUserApplicationRoleConnectionResult,
 	RESTDeleteAPIGuildResult,
 	RESTGetAPICurrentUserApplicationRoleConnectionResult,
 	RESTGetAPICurrentUserConnectionsResult,
@@ -48,6 +49,7 @@ export interface UserRoutes {
 			applications(applicationId: string): {
 				'role-connection': {
 					get(args?: RestArgumentsNoBody): Promise<RESTGetAPICurrentUserApplicationRoleConnectionResult>;
+					delete(args?: RestArgumentsNoBody): Promise<RESTDeleteAPICurrentUserApplicationRoleConnectionResult>;
 					put(
 						args: RestArguments<RESTPutAPICurrentUserApplicationRoleConnectionJSONBody>,
 					): Promise<RESTPutAPICurrentUserApplicationRoleConnectionResult>;

--- a/src/structures/Message.ts
+++ b/src/structures/Message.ts
@@ -28,6 +28,7 @@ import type {
 	APIMessage,
 	APIUser,
 	GatewayMessageCreateDispatchData,
+	TextChannelType,
 } from '../types';
 import type { AllChannels } from './channels';
 import { DiscordBase } from './extra/DiscordBase';
@@ -44,6 +45,7 @@ export interface BaseMessage
 		ObjectToLower<Omit<MessageData, 'timestamp' | 'author' | 'mentions' | 'components' | 'poll' | 'embeds'>> {
 	timestamp?: number;
 	guildId?: string;
+	channelType?: TextChannelType;
 	author: UserStructure;
 	member?: GuildMemberStructure;
 	components: TopLevelComponents[];

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -35,6 +35,7 @@ import type {
 	GatewayPresenceUpdate as RawGatewayPresenceUpdate,
 	GatewayThreadListSync as RawGatewayThreadListSync,
 	GatewayThreadMembersUpdate as RawGatewayThreadMembersUpdate,
+	TextChannelType,
 } from './payloads/index';
 import type { APISoundboardSound } from './payloads/soundboard';
 import type { ReactionType } from './rest/index';
@@ -1288,6 +1289,10 @@ export interface GatewayMessageEventExtraFields {
 	 * ID of the guild the message was sent in
 	 */
 	guild_id?: Snowflake;
+	/**
+	 * The type of channel the message was sent in
+	 */
+	channel_type?: TextChannelType;
 	/**
 	 * Member properties for this message's author
 	 *

--- a/src/types/payloads/application.ts
+++ b/src/types/payloads/application.ts
@@ -100,6 +100,12 @@ export interface APIApplication {
 	 */
 	flags: ApplicationFlags;
 	/**
+	 * The application's public flags, including bits beyond bit 30, serialized as a string
+	 *
+	 * This field is only returned in responses. Requests that accept application flags use `flags`.
+	 */
+	flags_new?: string;
+	/**
 	 * Approximate count of guilds the application has been added to
 	 */
 	approximate_guild_count?: number;

--- a/src/types/payloads/auditLog.ts
+++ b/src/types/payloads/auditLog.ts
@@ -220,8 +220,10 @@ export enum AuditLogEvent {
 	HomeSettingsCreate = 190,
 	HomeSettingsUpdate,
 
+	/** @deprecated Use {@link VoiceChannelStatusCreate} instead. */
 	VoiceChannelStatusUpdate = 192,
-	VoiceChannelStatusDelete,
+	VoiceChannelStatusCreate = VoiceChannelStatusUpdate,
+	VoiceChannelStatusDelete = 193,
 }
 
 /**

--- a/src/types/payloads/channel.ts
+++ b/src/types/payloads/channel.ts
@@ -48,6 +48,10 @@ export interface APIPartialChannel {
 export interface APIChannelBase<T extends ChannelType> extends APIPartialChannel {
 	type: T;
 	flags?: ChannelFlags;
+	/**
+	 * Application id associated with the channel
+	 */
+	application_id?: Snowflake | null;
 }
 
 export type TextChannelType =
@@ -771,6 +775,7 @@ export enum MessageActivityType {
 	Spectate,
 	Listen,
 	JoinRequest = 5,
+	StreamRequest = 6,
 }
 
 /**

--- a/src/types/payloads/gateway.ts
+++ b/src/types/payloads/gateway.ts
@@ -126,6 +126,10 @@ export interface GatewayPresenceClientStatus {
 	 * The user's status set for an active web (browser, bot account) application session
 	 */
 	web?: PresenceUpdateReceiveStatus;
+	/**
+	 * The user's status set for an active virtual reality application session
+	 */
+	vr?: PresenceUpdateReceiveStatus;
 }
 
 /**

--- a/src/types/payloads/monetization.ts
+++ b/src/types/payloads/monetization.ts
@@ -179,9 +179,9 @@ export interface APISubscription {
 
 export enum SubscriptionStatus {
 	/**	Subscription is active and scheduled to renew. */
-	Active,
-	/** Subscription is active but will not renew. */
-	Ending,
+	Active = 0,
 	/**	Subscription is inactive and not being charged. */
-	Inactive,
+	Inactive = 1,
+	/** Subscription is active but will not renew. */
+	Ending = 2,
 }

--- a/src/types/payloads/oauth2.ts
+++ b/src/types/payloads/oauth2.ts
@@ -31,6 +31,10 @@ export enum OAuth2Scopes {
 	 */
 	Identify = 'identify',
 	/**
+	 * Allows your app to read a user's Nitro subscription type. Requires Discord approval.
+	 */
+	IdentifyPremium = 'identify.premium',
+	/**
 	 * Allows [/users/@me/guilds](https://docs.discord.com/developers/resources/user#get-current-user-guilds)
 	 * to return basic information about all of a user's guilds
 	 *

--- a/src/types/payloads/user.ts
+++ b/src/types/payloads/user.ts
@@ -348,11 +348,13 @@ export enum ConnectionService {
 	Facebook = 'facebook',
 	GitHub = 'github',
 	Instagram = 'instagram',
+	/** @deprecated Riot Games and League of Legends connections are no longer returned by Discord. */
 	LeagueOfLegends = 'leagueoflegends',
 	Mastodon = 'mastodon',
 	PayPal = 'paypal',
 	PlayStationNetwork = 'playstation',
 	Reddit = 'reddit',
+	/** @deprecated Riot Games connections are no longer returned by Discord. */
 	RiotGames = 'riotgames',
 	Spotify = 'spotify',
 	Skype = 'skype',

--- a/src/types/rest/oauth2.ts
+++ b/src/types/rest/oauth2.ts
@@ -1,5 +1,12 @@
 import type { Permissions, Snowflake } from '..';
-import type { APIApplication, APIGuild, APIUser, APIWebhook, OAuth2Scopes } from '../payloads';
+import type {
+	APIApplication,
+	APIGuild,
+	APIUser,
+	APIWebhook,
+	ApplicationIntegrationType,
+	OAuth2Scopes,
+} from '../payloads';
 
 /**
  * https://docs.discord.com/developers/topics/oauth2#get-current-bot-application-information
@@ -120,7 +127,7 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	/**
 	 * Needs to include bot for the bot flow
 	 */
-	scope:
+	scope?:
 		| OAuth2Scopes.Bot
 		| `${OAuth2Scopes.Bot}${' ' | '%20'}${string}`
 		| `${string}${' ' | '%20'}${OAuth2Scopes.Bot}`
@@ -139,6 +146,10 @@ export interface RESTOAuth2BotAuthorizationQuery {
 	 * `true` or `false`—disallows the user from changing the guild dropdown
 	 */
 	disable_guild_select?: boolean;
+	/**
+	 * The installation context for the authorization
+	 */
+	integration_type?: ApplicationIntegrationType;
 }
 
 /**

--- a/src/types/rest/user.ts
+++ b/src/types/rest/user.ts
@@ -140,3 +140,8 @@ export interface RESTPutAPICurrentUserApplicationRoleConnectionJSONBody {
  * https://docs.discord.com/developers/resources/user#update-user-application-role-connection
  */
 export type RESTPutAPICurrentUserApplicationRoleConnectionResult = APIApplicationRoleConnection;
+
+/**
+ * https://docs.discord.com/developers/resources/user#delete-current-user-application-role-connection
+ */
+export type RESTDeleteAPICurrentUserApplicationRoleConnectionResult = undefined;

--- a/tests/api-enums.test.mts
+++ b/tests/api-enums.test.mts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+import { AuditLogEvent, MessageActivityType, SubscriptionStatus } from '../src/types';
+
+describe('Discord API enums', () => {
+	test('uses the documented subscription and activity values', () => {
+		expect(SubscriptionStatus.Active).toBe(0);
+		expect(SubscriptionStatus.Inactive).toBe(1);
+		expect(SubscriptionStatus.Ending).toBe(2);
+		expect(MessageActivityType.StreamRequest).toBe(6);
+	});
+
+	test('keeps the old voice channel status name as an alias of the canonical event', () => {
+		expect(AuditLogEvent.VoiceChannelStatusCreate).toBe(192);
+		expect(AuditLogEvent.VoiceChannelStatusUpdate).toBe(AuditLogEvent.VoiceChannelStatusCreate);
+		expect(AuditLogEvent[192]).toBe('VoiceChannelStatusCreate');
+	});
+});

--- a/tests/message-structure.test.mts
+++ b/tests/message-structure.test.mts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'vitest';
+import { Message } from '../src/structures/Message';
+import { ChannelType } from '../src/types';
+
+describe('Message structure', () => {
+	test('exposes the message create channel type', () => {
+		const message = new Message({} as never, {
+			id: '1486777868649005056',
+			channel_id: '1486777868649005057',
+			channel_type: ChannelType.GuildText,
+			author: { id: '1486777868649005058' },
+			components: [],
+			embeds: [],
+			mention_roles: [],
+			mentions: [],
+		} as never);
+
+		expect(message.channelType).toBe(ChannelType.GuildText);
+	});
+});

--- a/tests/root-export-contract.ts
+++ b/tests/root-export-contract.ts
@@ -1,31 +1,48 @@
 import {
+	ApplicationIntegrationType,
+	AuditLogEvent,
 	ChannelType,
 	EmbedColors,
 	Formatter,
 	HeadingLevel,
+	MessageActivityType,
 	OAuth2Scopes,
+	PresenceUpdateReceiveStatus,
 	SeyfertError,
 	SeyfertErrorMessages,
+	SubscriptionStatus,
 	TimestampStyle,
 	config,
 	createValidationMetadata,
+	type APIApplication,
+	type APIChannelBase,
+	type APIGroupDMChannel,
 	type APIInteractionDataResolvedChannel,
+	type APIRoutes,
+	type ApplicationStructure,
 	type BotConfig,
 	type ChannelLink,
 	type CommandOptionChannel,
 	type DMChannelStructure,
+	type GatewayMessageCreateDispatchData,
+	type GatewayPresenceClientStatus,
 	type GroupDMChannelStructure,
 	type HttpConfig,
 	type MaybeResolvedChannel,
 	type MessageLink,
+	type MessageStructure,
 	type OAuth2URLOptions,
 	type PropWhen,
+	type RESTDeleteAPICurrentUserApplicationRoleConnectionResult,
+	type RESTOAuth2BotAuthorizationQuery,
+	type RESTPatchCurrentApplicationJSONBody,
 	type ResolvedChannel,
 	type SeyfertErrorCode,
 	type ShardData,
 	type ShardManagerOptions,
 	type StructPropState,
 	type StructStates,
+	type TextChannelType,
 	type TextGuildChannelStructure,
 	type Timestamp,
 	type WorkerData,
@@ -155,3 +172,47 @@ expectType<APIInteractionDataResolvedChannel>({
 	type: ChannelType.DM,
 	permissions: '0',
 });
+
+expectType<0>(SubscriptionStatus.Active);
+expectType<1>(SubscriptionStatus.Inactive);
+expectType<2>(SubscriptionStatus.Ending);
+expectType<192>(AuditLogEvent.VoiceChannelStatusCreate);
+expectType<192>(AuditLogEvent.VoiceChannelStatusUpdate);
+expectType<6>(MessageActivityType.StreamRequest);
+expectType<'identify.premium'>(OAuth2Scopes.IdentifyPremium);
+
+expectType<RESTOAuth2BotAuthorizationQuery>({ client_id: 'application-id' });
+expectType<RESTOAuth2BotAuthorizationQuery>({
+	client_id: 'application-id',
+	integration_type: ApplicationIntegrationType.GuildInstall,
+});
+
+declare const application: APIApplication;
+expectType<string | undefined>(application.flags_new);
+
+declare const applicationStructure: ApplicationStructure;
+expectType<string | undefined>(applicationStructure.flagsNew);
+
+// @ts-expect-error flags_new is response-only; application writes continue to use flags.
+expectType<RESTPatchCurrentApplicationJSONBody>({ flags_new: '8192' });
+
+declare const gatewayMessage: GatewayMessageCreateDispatchData;
+expectType<TextChannelType | undefined>(gatewayMessage.channel_type);
+
+declare const messageStructure: MessageStructure;
+expectType<TextChannelType | undefined>(messageStructure.channelType);
+
+declare const clientStatus: GatewayPresenceClientStatus;
+expectType<PresenceUpdateReceiveStatus | undefined>(clientStatus.vr);
+
+declare const guildChannel: APIChannelBase<ChannelType.GuildText>;
+expectType<string | null | undefined>(guildChannel.application_id);
+expectType<string | null | undefined>(guildChannelStructure.applicationId);
+
+declare const groupDM: APIGroupDMChannel;
+expectType<string | undefined>(groupDM.application_id);
+
+declare const routes: APIRoutes;
+expectType<Promise<RESTDeleteAPICurrentUserApplicationRoleConnectionResult>>(
+	routes.users('@me').applications('application-id')['role-connection'].delete(),
+);

--- a/tests/user-routes.test.mts
+++ b/tests/user-routes.test.mts
@@ -1,0 +1,16 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Router } from '../src/api/Router';
+
+describe('user routes', () => {
+	test('deletes the current user application role connection', async () => {
+		const request = vi.fn(async () => undefined);
+		const routes = new Router({ request } as never).createProxy();
+
+		await routes.users('@me').applications('application-id')['role-connection'].delete();
+
+		expect(request).toHaveBeenCalledWith(
+			'DELETE',
+			'/users/@me/applications/application-id/role-connection',
+		);
+	});
+});


### PR DESCRIPTION
Syncs Seyfert's payload, gateway, REST, and enum contracts with the current official Discord API documentation.

This covers corrected subscription and audit log values, the `identify.premium` scope, application `flags_new`, message channel types, VR presence, nullable channel application IDs, the stream-request activity type, connection deprecations, and the current-user application role-connection delete route.

These definitions had drifted behind changes published in `discord/discord-api-docs` since the last sync.