### PR TITLE
feat: add file type filtering

### DIFF
--- a/src/builders/FileUpload.ts
+++ b/src/builders/FileUpload.ts
@@ -1,4 +1,5 @@
-import { type APIFileUploadComponent, ComponentType } from '../types';
+import type { RestOrArray } from '../common';
+import { type APIFileUploadComponent, ComponentType, type FileUploadType } from '../types';
 import { BaseComponentBuilder } from './Base';
 
 export class FileUpload extends BaseComponentBuilder<APIFileUploadComponent> {
@@ -53,6 +54,16 @@ export class FileUpload extends BaseComponentBuilder<APIFileUploadComponent> {
 	 */
 	setRequired(required: boolean) {
 		this.data.required = required;
+		return this;
+	}
+
+	/**
+	 * Sets the file types accepted by the file upload.
+	 * @param fileTypes - Media groups or dot-prefixed file extensions to accept (maximum of 10).
+	 * @returns The current FileUpload instance.
+	 */
+	setFileTypes(...fileTypes: RestOrArray<FileUploadType>) {
+		this.data.file_types = fileTypes.flat() as FileUploadType[];
 		return this;
 	}
 }

--- a/src/commands/applications/options.ts
+++ b/src/commands/applications/options.ts
@@ -6,6 +6,7 @@ import {
 	type APIApplicationCommandBasicOption,
 	type APIApplicationCommandOptionChoice,
 	ApplicationCommandOptionType,
+	type FileUploadType,
 } from '../../types';
 import type { LocalizationMap } from '../../types/payloads';
 import type {
@@ -142,7 +143,9 @@ export type SeyfertChannelOption<C = keyof SeyfertChannelMap, R = true | false, 
 };
 export type SeyfertRoleOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Role, R>;
 export type SeyfertMentionableOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Mentionable, R>;
-export type SeyfertAttachmentOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Attachment, R>;
+export type SeyfertAttachmentOption<R = boolean> = SeyfertBasicOption<ApplicationCommandOptionType.Attachment, R> & {
+	file_types?: readonly FileUploadType[];
+};
 
 export function createStringOption<
 	R extends boolean,

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -4,6 +4,7 @@ import type { Logger, NulleableCoalising, OmitInsert } from '../common';
 import { BaseHandler, isCloudflareWorker, magicImport, SeyfertError } from '../common';
 import { PermissionsBitField } from '../structures/extra/Permissions';
 import {
+	type APIApplicationCommandAttachmentOption,
 	type APIApplicationCommandChannelOption,
 	type APIApplicationCommandIntegerOption,
 	type APIApplicationCommandNumberOption,
@@ -188,6 +189,16 @@ export class CommandHandler extends BaseHandler {
 					this.shouldUploadChoices(option, cached)
 				);
 			case ApplicationCommandOptionType.Attachment:
+				{
+					const cachedAttachment = cached as APIApplicationCommandAttachmentOption;
+					if (option.file_types?.length !== cachedAttachment.file_types?.length) return true;
+					if (option.file_types && cachedAttachment.file_types) {
+						const fileTypes = [...option.file_types].sort();
+						const cachedFileTypes = [...cachedAttachment.file_types].sort();
+						return fileTypes.some((fileType, index) => fileType !== cachedFileTypes[index]);
+					}
+				}
+				break;
 			case ApplicationCommandOptionType.Boolean:
 			case ApplicationCommandOptionType.Mentionable:
 			case ApplicationCommandOptionType.Role:

--- a/src/types/payloads/_interactions/_applicationCommands/_chatInput/attachment.ts
+++ b/src/types/payloads/_interactions/_applicationCommands/_chatInput/attachment.ts
@@ -1,9 +1,12 @@
-import type { Snowflake } from '../../../../index';
+import type { FileUploadType, Snowflake } from '../../../../index';
 import type { APIApplicationCommandOptionBase, APIInteractionDataOptionBase } from './base';
 import type { ApplicationCommandOptionType } from './shared';
 
 export type APIApplicationCommandAttachmentOption =
-	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment>;
+	APIApplicationCommandOptionBase<ApplicationCommandOptionType.Attachment> & {
+		/** File types to accept; can contain media groups or dot-prefixed file extensions (maximum of 10) */
+		file_types?: FileUploadType[];
+	};
 
 export type APIApplicationCommandInteractionDataAttachmentOption = APIInteractionDataOptionBase<
 	ApplicationCommandOptionType.Attachment,

--- a/src/types/payloads/components.ts
+++ b/src/types/payloads/components.ts
@@ -624,6 +624,11 @@ export interface APILabelComponent extends APIBaseComponent<ComponentType.Label>
 }
 
 /**
+ * https://docs.discord.com/developers/reference#file-type-filtering
+ */
+export type FileUploadType = 'audio' | 'image' | 'video' | `.${string}`;
+
+/**
  * https://docs.discord.com/developers/components/reference#file-upload
  */
 export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.FileUpload> {
@@ -637,6 +642,8 @@ export interface APIFileUploadComponent extends APIBaseComponent<ComponentType.F
 	max_values?: number;
 	/** Whether the file upload is required (defaults to false) */
 	required?: boolean;
+	/** File types to accept; can contain media groups or dot-prefixed file extensions (maximum of 10) */
+	file_types?: FileUploadType[];
 }
 
 /**

--- a/tests/command-options-contract.ts
+++ b/tests/command-options-contract.ts
@@ -10,6 +10,8 @@
 //     the fix), so these are the cases that turn red if the fix is reverted. Do not inline them.
 //   • SIN `as const` → behaves exactly as before the fix: the value type is widened.
 import {
+	ApplicationCommandOptionType,
+	type APIApplicationCommandAttachmentOption,
 	type Attachment,
 	ChannelType,
 	type CommandContext,
@@ -22,11 +24,13 @@ import {
 	createRoleOption,
 	createStringOption,
 	createUserOption,
+	type FileUploadType,
 	type GuildMemberStructure,
 	type GuildRoleStructure,
 	type InteractionGuildMemberStructure,
 	type OKFunction,
 	type ResolvedChannel,
+	type SeyfertAttachmentOption,
 	type TextGuildChannelStructure,
 	type UserStructure,
 	type VoiceChannelStructure,
@@ -160,6 +164,24 @@ expectType<true>(true as Equal<typeof channelCtx.options.mutableOne, ResolvedTex
 expectType<true>(
 	true as Equal<typeof channelCtx.options.mutableMany, ResolvedTextOrVoiceChannel>,
 );
+
+// ─────────────────────────── attachment file_types ───────────────────────────
+const attachmentFileTypes = ['image', '.pdf'] as const satisfies readonly FileUploadType[];
+
+expectType<APIApplicationCommandAttachmentOption>({
+	type: ApplicationCommandOptionType.Attachment,
+	name: 'document',
+	description: 'Upload a document',
+	file_types: [...attachmentFileTypes],
+});
+expectType<SeyfertAttachmentOption>({
+	description: 'Upload a document',
+	file_types: attachmentFileTypes,
+});
+createAttachmentOption({ description: 'Upload a document', file_types: attachmentFileTypes });
+
+// @ts-expect-error File extension filters must be dot-prefixed.
+expectType<FileUploadType>('pdf');
 
 // ───────────── every create*Option — SIN callback (tipo base) ─────────────
 const withoutCallback = {

--- a/tests/file-upload-contract.ts
+++ b/tests/file-upload-contract.ts
@@ -1,0 +1,18 @@
+import {
+	ComponentType,
+	FileUpload,
+	type APIFileUploadComponent,
+	type FileUploadType,
+} from 'seyfert';
+
+declare function expectType<T>(value: T): void;
+
+expectType<APIFileUploadComponent>({
+	type: ComponentType.FileUpload,
+	custom_id: 'documents',
+	file_types: ['image', '.pdf'],
+});
+new FileUpload().setFileTypes('image', '.pdf');
+
+declare const fileUploadType: FileUploadType;
+expectType<'audio' | 'image' | 'video' | `.${string}`>(fileUploadType);

--- a/tests/file-upload.test.mts
+++ b/tests/file-upload.test.mts
@@ -1,0 +1,56 @@
+import { describe, expect, test, vi } from 'vitest';
+import { FileUpload } from '../src/builders/FileUpload';
+import { CommandHandler } from '../src/commands/handler';
+import {
+	type APIApplicationCommandAttachmentOption,
+	ApplicationCommandOptionType,
+	ComponentType,
+	type FileUploadType,
+} from '../src/types';
+
+class ExposedCommandHandler extends CommandHandler {
+	shouldUploadAttachment(
+		option: APIApplicationCommandAttachmentOption,
+		cached: APIApplicationCommandAttachmentOption,
+	) {
+		return this.shouldUploadOption(option, cached);
+	}
+}
+
+function attachment(fileTypes?: FileUploadType[]): APIApplicationCommandAttachmentOption {
+	return {
+		type: ApplicationCommandOptionType.Attachment,
+		name: 'document',
+		description: 'Upload a document',
+		file_types: fileTypes,
+	};
+}
+
+function createCommandHandler() {
+	const logger = { warn: vi.fn(), error: vi.fn() };
+	const client = { langs: { values: {} }, options: {} };
+	return new ExposedCommandHandler(logger as never, client as never);
+}
+
+describe('file type filtering', () => {
+	test('serializes file upload component filters', () => {
+		const upload = new FileUpload().setCustomId('documents').setFileTypes(['image', '.pdf']);
+
+		expect(upload.toJSON()).toEqual({
+			type: ComponentType.FileUpload,
+			custom_id: 'documents',
+			file_types: ['image', '.pdf'],
+		});
+	});
+
+	test('detects changes to attachment option filters before uploading commands', () => {
+		const handler = createCommandHandler();
+
+		expect(handler.shouldUploadAttachment(attachment(['image', '.pdf']), attachment(['.pdf', 'image']))).toBe(
+			false,
+		);
+		expect(handler.shouldUploadAttachment(attachment(['image']), attachment(['video']))).toBe(true);
+		expect(handler.shouldUploadAttachment(attachment(['image', '.pdf']), attachment(['image']))).toBe(true);
+		expect(handler.shouldUploadAttachment(attachment([]), attachment())).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds Discord's `file_types` filtering contract to File Upload components and attachment command options.

The public API exposes `FileUploadType`, accepts filters through `FileUpload#setFileTypes` and `createAttachmentOption`, and includes them when deciding whether cached commands must be uploaded. Filters can use Discord's media groups or dot-prefixed file extensions.

Seyfert previously had no representation for this field, so valid filters could not be declared through the framework and cached command comparisons ignored them.