### PR TITLE
fix(api): align REST contract with Discord

### DIFF
--- a/src/api/Routes/applications.ts
+++ b/src/api/Routes/applications.ts
@@ -1,5 +1,6 @@
 import type {
 	RESTDeleteAPIApplicationEmojiResult,
+	RESTGetAPIApplicationCommandPermissionsResult,
 	RESTGetAPIApplicationCommandResult,
 	RESTGetAPIApplicationCommandsQuery,
 	RESTGetAPIApplicationCommandsResult,
@@ -32,13 +33,13 @@ import type {
 	RESTPostAPIEntitlementBody,
 	RESTPostAPIEntitlementResult,
 	RESTPutAPIApplicationCommandPermissionsJSONBody,
+	RESTPutAPIApplicationCommandPermissionsResult,
 	RESTPutAPIApplicationCommandsJSONBody,
 	RESTPutAPIApplicationCommandsResult,
 	RESTPutAPIApplicationGuildCommandsJSONBody,
 	RESTPutAPIApplicationGuildCommandsResult,
 	RESTPutAPIApplicationRoleConnectionMetadataJSONBody,
 	RESTPutAPIApplicationRoleConnectionMetadataResult,
-	RESTPutAPIGuildApplicationCommandsPermissionsResult,
 	RestGetAPIApplicationActivityInstanceResult,
 } from '../../types';
 import type { RestArguments, RestArgumentsNoBody } from '../api';
@@ -73,10 +74,10 @@ export interface ApplicationRoutes {
 					): Promise<RESTPatchAPIApplicationGuildCommandResult>;
 					delete(args?: RestArgumentsNoBody): Promise<undefined>;
 					permissions: {
-						get(args?: RestArgumentsNoBody): Promise<RESTGetAPIGuildApplicationCommandsPermissionsResult>;
+						get(args?: RestArgumentsNoBody): Promise<RESTGetAPIApplicationCommandPermissionsResult>;
 						put(
-							args?: RestArguments<RESTPutAPIApplicationCommandPermissionsJSONBody>,
-						): Promise<RESTPutAPIGuildApplicationCommandsPermissionsResult>;
+							args: RestArguments<RESTPutAPIApplicationCommandPermissionsJSONBody>,
+						): Promise<RESTPutAPIApplicationCommandPermissionsResult>;
 					};
 				};
 			};

--- a/src/api/Routes/guilds.ts
+++ b/src/api/Routes/guilds.ts
@@ -31,6 +31,7 @@ import type {
 	RESTGetAPIGuildMembersSearchResult,
 	RESTGetAPIGuildMessagesSearchQuery,
 	RESTGetAPIGuildMessagesSearchResult,
+	RESTGetAPIGuildOnboardingResult,
 	RESTGetAPIGuildPreviewResult,
 	RESTGetAPIGuildPruneCountQuery,
 	RESTGetAPIGuildPruneCountResult,
@@ -118,9 +119,13 @@ import type {
 	RESTPostAPITemplateCreateGuildResult,
 	RESTPutAPIGuildBanJSONBody,
 	RESTPutAPIGuildBanResult,
+	RESTPutAPIGuildIncidentActionsJSONBody,
+	RESTPutAPIGuildIncidentActionsResult,
 	RESTPutAPIGuildMemberJSONBody,
 	RESTPutAPIGuildMemberResult,
 	RESTPutAPIGuildMemberRoleResult,
+	RESTPutAPIGuildOnboardingJSONBody,
+	RESTPutAPIGuildOnboardingResult,
 	RESTPutAPIGuildTemplateSyncResult,
 } from '../../types';
 import type { RestArguments, RestArgumentsNoBody, RestArgumentsRequiredQuery } from '../api';
@@ -235,7 +240,7 @@ export interface GuildRoutes {
 					delete(args?: RestArgumentsNoBody): Promise<RESTDeleteAPIGuildBanResult>;
 				};
 			};
-			'bulk-bans': {
+			'bulk-ban': {
 				post(args: RestArguments<RESTPostAPIGuildBulkBanJSONBody>): Promise<RESTPostAPIGuildBulkBanResult>;
 			};
 			mfa: {
@@ -280,9 +285,13 @@ export interface GuildRoutes {
 					args: RestArguments<RESTPatchAPIGuildWelcomeScreenJSONBody>,
 				): Promise<RESTPatchAPIGuildWelcomeScreenResult>;
 			};
-			// onboarding: {
-			// 	get(args:RestArgumentsNoBody<boarding>);
-			// }
+			onboarding: {
+				get(args?: RestArgumentsNoBody): Promise<RESTGetAPIGuildOnboardingResult>;
+				put(args: RestArguments<RESTPutAPIGuildOnboardingJSONBody>): Promise<RESTPutAPIGuildOnboardingResult>;
+			};
+			'incident-actions': {
+				put(args: RestArguments<RESTPutAPIGuildIncidentActionsJSONBody>): Promise<RESTPutAPIGuildIncidentActionsResult>;
+			};
 			emojis: {
 				get(args?: RestArgumentsNoBody): Promise<RESTGetAPIGuildEmojisResult>;
 				post(args: RestArguments<RESTPostAPIGuildEmojiJSONBody>): Promise<RESTPostAPIGuildEmojiResult>;

--- a/src/api/Routes/index.ts
+++ b/src/api/Routes/index.ts
@@ -4,6 +4,8 @@ import type { GatewayRoutes } from './gateway';
 import type { GuildRoutes } from './guilds';
 import type { InteractionRoutes } from './interactions';
 import type { InviteRoutes } from './invites';
+import type { OAuth2Routes } from './oauth2';
+import type { SKURoutes } from './skus';
 import type { SoundboardRoutes } from './soundboard';
 import type { StageInstanceRoutes } from './stage-instances';
 import type { StickerRoutes } from './stickers';
@@ -20,6 +22,8 @@ export interface APIRoutes
 		GuildRoutes,
 		InteractionRoutes,
 		InviteRoutes,
+		OAuth2Routes,
+		SKURoutes,
 		StageInstanceRoutes,
 		StickerRoutes,
 		UserRoutes,

--- a/src/api/Routes/invites.ts
+++ b/src/api/Routes/invites.ts
@@ -12,7 +12,7 @@ import type { RestArguments, RestArgumentsNoBody } from '../api';
 
 export interface InviteRoutes {
 	invites(id: string): {
-		get(args?: RestArguments<RESTGetAPIInviteQuery>): Promise<RESTGetAPIInviteResult>;
+		get(args?: RestArgumentsNoBody<RESTGetAPIInviteQuery>): Promise<RESTGetAPIInviteResult>;
 		delete(args?: RestArgumentsNoBody): Promise<RESTDeleteAPIInviteResult>;
 		'target-users': {
 			get(args?: RestArgumentsNoBody): Promise<RESTGetTargetUsersResult>;

--- a/src/api/Routes/oauth2.ts
+++ b/src/api/Routes/oauth2.ts
@@ -1,0 +1,12 @@
+import type { RESTGetAPIOAuth2CurrentApplicationResult } from '../../types';
+import type { RestArgumentsNoBody } from '../api';
+
+export interface OAuth2Routes {
+	oauth2: {
+		applications: {
+			'@me': {
+				get(args?: RestArgumentsNoBody): Promise<RESTGetAPIOAuth2CurrentApplicationResult>;
+			};
+		};
+	};
+}

--- a/src/api/Routes/skus.ts
+++ b/src/api/Routes/skus.ts
@@ -3,13 +3,17 @@ import type {
 	RESTGetAPISKUSubscriptionsQuery,
 	RESTGetAPISKUSubscriptionsResult,
 } from '../../types';
-import type { RestArguments, RestArgumentsNoBody } from '../api';
+import type { RestArgumentsNoBody } from '../api';
 
-export interface SKuRoutes {
+export interface SKURoutes {
 	skus(id: string): {
-		get: (args?: RestArguments<RESTGetAPISKUSubscriptionsQuery>) => Promise<RESTGetAPISKUSubscriptionsResult>;
-		subscriptions(id: string): {
-			get: (args?: RestArgumentsNoBody) => Promise<RESTGetAPISKUSubscriptionResult>;
+		subscriptions: {
+			get(args?: RestArgumentsNoBody<RESTGetAPISKUSubscriptionsQuery>): Promise<RESTGetAPISKUSubscriptionsResult>;
+			(
+				id: string,
+			): {
+				get(args?: RestArgumentsNoBody): Promise<RESTGetAPISKUSubscriptionResult>;
+			};
 		};
 	};
 }

--- a/src/api/Routes/voice.ts
+++ b/src/api/Routes/voice.ts
@@ -3,7 +3,7 @@ import type { RestArgumentsNoBody } from '../api';
 
 export interface VoiceRoutes {
 	voice: {
-		region: {
+		regions: {
 			get(args?: RestArgumentsNoBody): Promise<RESTGetAPIVoiceRegionsResult>;
 		};
 	};

--- a/src/api/Routes/webhooks.ts
+++ b/src/api/Routes/webhooks.ts
@@ -36,9 +36,7 @@ export interface WebhookRoutes {
 			token: string,
 		): {
 			get(args?: RestArgumentsNoBody): Promise<RESTGetAPIWebhookWithTokenResult>;
-			patch(
-				args: RestArguments<RESTPatchAPIWebhookWithTokenJSONBody, RESTPatchAPIWebhookWithTokenMessageQuery>,
-			): Promise<RESTPatchAPIWebhookWithTokenResult>;
+			patch(args: RestArguments<RESTPatchAPIWebhookWithTokenJSONBody>): Promise<RESTPatchAPIWebhookWithTokenResult>;
 			delete(args?: RestArgumentsNoBody): Promise<RESTDeleteAPIWebhookWithTokenResult>;
 			post(
 				args: RestArguments<RESTPostAPIWebhookWithTokenJSONBody, RESTPostAPIWebhookWithTokenQuery>,
@@ -58,7 +56,7 @@ export interface WebhookRoutes {
 					args?: RestArgumentsNoBody<RESTGetAPIWebhookWithTokenMessageQuery>,
 				): Promise<RESTGetAPIWebhookWithTokenMessageResult>;
 				patch(
-					args: RestArguments<RESTPatchAPIWebhookWithTokenMessageJSONBody>,
+					args: RestArguments<RESTPatchAPIWebhookWithTokenMessageJSONBody, RESTPatchAPIWebhookWithTokenMessageQuery>,
 				): Promise<RESTPatchAPIWebhookWithTokenMessageResult>;
 				delete(
 					args?: RestArgumentsNoBody<RESTDeleteAPIWebhookWithTokenMessageQuery>,

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -17,6 +17,7 @@ import type { APIRoutes } from './Routes';
 import {
 	type ApiHandlerInternalOptions,
 	type ApiHandlerOptions,
+	type ApiRequestBody,
 	type ApiRequestOptions,
 	DefaultUserAgent,
 	type HttpMethods,
@@ -63,6 +64,9 @@ export class ApiHandler<TClient = unknown> {
 	globalBlock = false;
 	ratelimits = new Map<string, Bucket>();
 	readyQueue: (() => void)[] = [];
+	private bucketAliases = new Map<string, string>();
+	private globalBlocks = new Map<string, (() => void)[]>();
+	private globalTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	cdn = CDNRouter.createProxy();
 	workerPromises?: Map<string, { resolve: (value: any) => any; reject: (error: any) => any }>;
 	onRatelimit?: OnRatelimitCallback;
@@ -141,6 +145,12 @@ export class ApiHandler<TClient = unknown> {
 	}
 
 	globalUnblock() {
+		for (const timer of this.globalTimers.values()) clearTimeout(timer);
+		this.globalTimers.clear();
+		for (const queue of this.globalBlocks.values()) {
+			for (const callback of queue) callback();
+		}
+		this.globalBlocks.clear();
 		this.globalBlock = false;
 		let cb: (() => void) | undefined;
 		while ((cb = this.readyQueue.shift())) {
@@ -320,6 +330,8 @@ export class ApiHandler<TClient = unknown> {
 			});
 		}
 		const route = requestOptions.route || this.routefy(url, method);
+		const provisionalRoute = requestOptions.route || `${method}:${route}`;
+		let bucketRoute = this.bucketAliases.get(provisionalRoute) ?? provisionalRoute;
 
 		const callback = async (next: () => void, resolve: (data: any) => void, reject: (err: unknown) => void) => {
 			const headers = {
@@ -364,89 +376,124 @@ export class ApiHandler<TClient = unknown> {
 			const now = Date.now();
 			const headerNow = Date.parse(response.headers.get('date') ?? '');
 
-			this.setRatelimitsBucket(route, response);
-			this.setResetBucket(route, response, now, headerNow);
+			bucketRoute = this.learnBucket(provisionalRoute, bucketRoute, url, response, requestOptions.route !== undefined);
+			this.setRatelimitsBucket(bucketRoute, response);
+			this.setResetBucket(bucketRoute, response, now, headerNow, route);
+			this.ratelimits.get(bucketRoute)!.process();
 
 			const observerResponse = response.clone();
-			let result: string | Record<string, any> = await response.text();
+			let result: unknown;
+			try {
+				result = await decodeResponse(response);
+			} catch (error) {
+				await this.notifyFailRequest(method, finalUrl, error, response.status, { ...request, auth });
+				next();
+				reject(error);
+				return;
+			}
 
 			if (response.status >= 300) {
+				const errorResult = normalizeErrorResult(result);
 				if (response.status === 429) {
 					const result429 = await this.handle429(
-						route,
+						bucketRoute,
 						method,
 						url,
 						{ ...request, auth },
 						observerResponse,
-						result,
+						typeof errorResult === 'string' ? errorResult : JSON.stringify(errorResult),
 						next,
 						reject,
 						now,
 						finalUrl,
 					);
 					if (result429 !== false) return resolve(result429);
-					await this.notifyFailRequest(method, finalUrl, result, response.status, { ...request, auth });
-					return this.clearResetInterval(route);
+					await this.notifyFailRequest(method, finalUrl, errorResult, response.status, { ...request, auth });
+					return this.clearResetInterval(bucketRoute);
 				}
 				if ([502, 503].includes(response.status) && ++attempts < 4) {
-					this.clearResetInterval(route);
+					this.clearResetInterval(bucketRoute);
 					return this.handle50X(method, url, requestOptions, attempts, next, resolve, reject);
 				}
-				this.clearResetInterval(route);
+				this.clearResetInterval(bucketRoute);
 				next();
-				if (result.length > 0) {
-					if (response.headers.get('content-type')?.includes('application/json')) {
-						try {
-							result = JSON.parse(result);
-						} catch (err) {
-							this.debugger?.warn('SeyfertError parsing result error (', result, ')', err);
-							await this.notifyFailRequest(method, finalUrl, err, response.status, { ...request, auth });
-							reject(err);
-							return;
-						}
-					}
-				}
-				const parsedError = this.parseError(method, route, response, result, originTrace);
+				const parsedError = this.parseError(method, route, response, errorResult, originTrace);
 				this.debugger?.warn(parsedError.message);
 				await this.notifyFailRequest(method, finalUrl, parsedError, response.status, { ...request, auth });
 				reject(parsedError);
 				return;
 			}
 
-			if (result.length > 0) {
-				if (response.headers.get('content-type')?.includes('application/json')) {
-					try {
-						result = JSON.parse(result);
-					} catch (err) {
-						this.debugger?.warn('Failed parsing result (', result, ')', err);
-						await this.notifyFailRequest(method, finalUrl, err, response.status, { ...request, auth });
-						next();
-						reject(err);
-						return;
-					}
-				}
-			}
-
 			await this.notifySuccessRequest(method, finalUrl, observerResponse, { ...request, auth });
 			next();
-			return resolve(result || undefined);
+			return resolve(result);
 		};
 
 		return new Promise((resolve, reject) => {
-			if (this.globalBlock && auth) {
-				this.readyQueue.push(() => {
-					if (!this.ratelimits.has(route)) {
-						this.ratelimits.set(route, new Bucket(1));
-					}
-					this.ratelimits.get(route)!.push({ next: callback, resolve, reject }, request.unshift);
-				});
-			} else {
-				if (!this.ratelimits.has(route)) {
-					this.ratelimits.set(route, new Bucket(1));
+			const dispatch = () => {
+				bucketRoute = this.bucketAliases.get(provisionalRoute) ?? bucketRoute;
+				if (!this.ratelimits.has(bucketRoute)) {
+					this.ratelimits.set(bucketRoute, new Bucket(1));
 				}
-				this.ratelimits.get(route)!.push({ next: callback, resolve, reject }, request.unshift);
+				this.ratelimits.get(bucketRoute)!.push({ next: callback, resolve, reject }, request.unshift);
+			};
+			const globalQueue = this.globalBlocks.get(this.globalRateLimitKey({ ...requestOptions, auth }));
+			if (globalQueue && !url.startsWith('/interactions/')) {
+				globalQueue.push(dispatch);
+			} else {
+				dispatch();
 			}
 		});
+	}
+
+	private learnBucket(
+		provisionalRoute: string,
+		currentRoute: string,
+		url: `/${string}`,
+		response: Response,
+		hasRouteOverride: boolean,
+	) {
+		const hash = response.headers.get('x-ratelimit-bucket');
+		if (!hash || hasRouteOverride) return currentRoute;
+
+		const learnedRoute = `${hash}:${majorParameter(url)}`;
+		this.bucketAliases.set(provisionalRoute, learnedRoute);
+
+		const currentBucket = this.ratelimits.get(currentRoute)!;
+		const learnedBucket = this.ratelimits.get(learnedRoute);
+		if (!learnedBucket) {
+			this.ratelimits.set(learnedRoute, currentBucket);
+			return learnedRoute;
+		}
+		if (learnedBucket !== currentBucket && currentBucket.queue.length) {
+			learnedBucket.queue.push(...currentBucket.queue.splice(0));
+		}
+		return learnedRoute;
+	}
+
+	private globalRateLimitKey(request: ApiRequestOptions) {
+		if (request.auth === false) return 'unauthenticated';
+		return `${this.options.type}:${request.token || this.options.token}`;
+	}
+
+	private blockGlobal(request: ApiRequestOptions, retryAfter: number) {
+		const key = this.globalRateLimitKey(request);
+		if (!this.globalBlocks.has(key)) this.globalBlocks.set(key, []);
+		const previousTimer = this.globalTimers.get(key);
+		if (previousTimer) clearTimeout(previousTimer);
+		this.globalBlock = true;
+		this.globalTimers.set(
+			key,
+			setTimeout(() => this.unblockGlobal(key), retryAfter || 1),
+		);
+	}
+
+	private unblockGlobal(key: string) {
+		this.globalTimers.delete(key);
+		const queue = this.globalBlocks.get(key) ?? [];
+		this.globalBlocks.delete(key);
+		this.globalBlock = this.globalBlocks.size > 0;
+		for (const callback of queue) callback();
 	}
 
 	parseError(
@@ -563,18 +610,27 @@ export class ApiHandler<TClient = unknown> {
 		now: number,
 		notifyUrl: `/${string}`,
 	) {
-		await this.notifyRatelimit(response, request, method, notifyUrl);
-
 		const bucket = this.ratelimits.get(route)!;
 		let retryAfter: number | undefined;
 
-		const data = JSON.parse(result);
-		if (data.retry_after) retryAfter = Math.ceil(data.retry_after * 1000);
+		let data: Record<string, unknown> | undefined;
+		try {
+			const parsed: unknown = JSON.parse(result);
+			if (isPlainObject(parsed)) data = parsed;
+		} catch {}
+		if (typeof data?.retry_after === 'number' && Number.isFinite(data.retry_after) && data.retry_after >= 0) {
+			retryAfter = Math.ceil(data.retry_after * 1000);
+		}
+		for (const header of ['retry-after', 'x-ratelimit-reset-after']) {
+			if (retryAfter !== undefined) break;
+			const raw = response.headers.get(header);
+			if (raw === null || raw.trim() === '') continue;
+			const value = Number(raw) * 1000;
+			if (Number.isFinite(value) && value >= 0) retryAfter = value;
+		}
 
-		retryAfter ??=
-			Number(response.headers.get('x-ratelimit-reset-after') || response.headers.get('retry-after')) * 1000;
-
-		if (Number.isNaN(retryAfter)) {
+		if (retryAfter === undefined) {
+			await this.notifyRatelimit(response, request, method, notifyUrl);
 			this.debugger?.warn(`${route} Could not extract retry_after from 429 response. ${result}`);
 			next();
 			reject(
@@ -592,6 +648,14 @@ export class ApiHandler<TClient = unknown> {
 			);
 			return false;
 		}
+		if (
+			data?.global === true ||
+			response.headers.has('x-ratelimit-global') ||
+			response.headers.get('x-ratelimit-scope') === 'global'
+		) {
+			this.blockGlobal(request, retryAfter);
+		}
+		await this.notifyRatelimit(response, request, method, notifyUrl);
 
 		if (this.debugger) {
 			const content = `${JSON.stringify(request)} `;
@@ -599,19 +663,13 @@ export class ApiHandler<TClient = unknown> {
 				`${response.headers.get('x-ratelimit-global') ? 'Global' : 'Unexpected'} 429: ${result.slice(0, 256)}\n${content} ${now} ${route} ${response.status}: ${bucket.remaining}/${bucket.limit} left | Reset ${retryAfter} (${bucket.reset - now}ms left) | Scope ${response.headers.get('x-ratelimit-scope')}`,
 			);
 		}
-		if (retryAfter) {
-			await delay(retryAfter);
-			next();
-			return this.request(method, url, {
-				...request,
-				unshift: true,
-			});
-		}
-		next();
-		return this.request(method, url, {
+		if (retryAfter) await delay(retryAfter);
+		const retry = this.request(method, url, {
 			...request,
 			unshift: true,
 		});
+		next();
+		return retry.catch(reject);
 	}
 
 	clearResetInterval(route: string) {
@@ -620,19 +678,18 @@ export class ApiHandler<TClient = unknown> {
 		this.ratelimits.get(route)!.resetAfter = 0;
 	}
 
-	setResetBucket(route: string, resp: Response, now: number, headerNow: number) {
-		const retryAfter = Number(resp.headers.get('x-ratelimit-reset-after') || resp.headers.get('retry-after')) * 1000;
+	setResetBucket(route: string, resp: Response, now: number, headerNow: number, normalizedRoute = route) {
+		const retryAfterHeader = resp.headers.get('x-ratelimit-reset-after') ?? resp.headers.get('retry-after');
+		const retryAfter = retryAfterHeader === null ? undefined : Number(retryAfterHeader) * 1000;
 
-		if (retryAfter >= 0) {
-			if (resp.headers.get('x-ratelimit-global')) {
-				this.globalBlock = true;
-				setTimeout(() => this.globalUnblock(), retryAfter || 1);
-			} else {
-				this.ratelimits.get(route)!.reset = (retryAfter || 1) + now;
-			}
+		if (retryAfter !== undefined && Number.isFinite(retryAfter) && retryAfter >= 0) {
+			this.ratelimits.get(route)!.reset = (retryAfter || 1) + now;
 		} else if (resp.headers.get('x-ratelimit-reset')) {
 			let resetTime = +resp.headers.get('x-ratelimit-reset')! * 1000;
-			if (route.endsWith('/reactions/:id') && +resp.headers.get('x-ratelimit-reset')! * 1000 - headerNow === 1000) {
+			if (
+				normalizedRoute.endsWith('/reactions/:id') &&
+				+resp.headers.get('x-ratelimit-reset')! * 1000 - headerNow === 1000
+			) {
 				resetTime = now + 250;
 			}
 			this.ratelimits.get(route)!.reset = Math.max(resetTime, now);
@@ -677,15 +734,18 @@ export class ApiHandler<TClient = unknown> {
 		if (options.request.query) {
 			const params = new URLSearchParams();
 			for (const [key, value] of Object.entries(options.request.query)) {
+				if (value === null || value === undefined) continue;
 				if (Array.isArray(value)) {
 					for (const item of value) {
+						if (item === null || item === undefined) continue;
 						params.append(key, String(item));
 					}
 				} else {
 					params.append(key, String(value));
 				}
 			}
-			finalUrl += `?${params}`;
+			const query = params.toString();
+			if (query) finalUrl += `${finalUrl.includes('?') ? '&' : '?'}${query}`;
 		}
 
 		if (options.request.files?.length || options.request.appendToFormData) {
@@ -761,7 +821,7 @@ export class ApiHandler<TClient = unknown> {
 export type RequestOptions = Pick<ApiRequestOptions, 'reason' | 'auth' | 'appendToFormData' | 'token'>;
 
 export type RestArguments<
-	B extends Record<string, any> | undefined,
+	B extends ApiRequestBody | undefined,
 	Q extends never | Record<string, any> = never,
 	F extends RawFile[] = RawFile[],
 > = (
@@ -820,4 +880,33 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	if (typeof value !== 'object' || value === null) return false;
 	const prototype = Object.getPrototypeOf(value);
 	return prototype === Object.prototype || prototype === null;
+}
+
+function normalizeErrorResult(result: unknown): string | Record<string, any> {
+	if (typeof result === 'string' || isPlainObject(result)) return result;
+	return JSON.stringify(result) ?? String(result);
+}
+
+async function decodeResponse(response: Response) {
+	const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+	if (response.status < 300 && contentType && !contentType.startsWith('text/') && !isJsonContentType(contentType)) {
+		return response.arrayBuffer();
+	}
+	const text = await response.text();
+	if (!text.length) return undefined;
+	return isJsonContentType(contentType) ? JSON.parse(text) : text;
+}
+
+function isJsonContentType(contentType: string | undefined) {
+	return contentType === 'application/json' || contentType?.endsWith('+json') === true;
+}
+
+function majorParameter(url: string) {
+	const channel = url.match(/^\/channels\/([^/]+)/)?.[1];
+	if (channel) return `channels:${channel}`;
+	const guild = url.match(/^\/guilds\/([^/]+)/)?.[1];
+	if (guild) return `guilds:${guild}`;
+	const webhook = url.match(/^\/webhooks\/([^/]+)(?:\/([^/?]+))?/)?.slice(1);
+	if (webhook?.[0]) return `webhooks:${webhook.filter(Boolean).join(':')}`;
+	return '';
 }

--- a/src/api/bucket.ts
+++ b/src/api/bucket.ts
@@ -37,7 +37,7 @@ export class Bucket {
 					this.processing = false;
 					this.process(true);
 				},
-				this.resetAfter ? 0.5 : Math.max(0, (this.reset || 0) - now) + 1,
+				Math.max(0, (this.reset || 0) - now) + 1,
 			);
 			return;
 		}
@@ -68,11 +68,16 @@ export class Bucket {
 	}
 
 	triggerResetAfter() {
-		if (!this.processingResetAfter && this.resetAfter) {
-			this.processingResetAfter = setTimeout(() => {
-				this.remaining++;
-				this.processingResetAfter = undefined;
-			}, this.resetAfter * 1.5);
-		}
+		if (this.processingResetAfter || !this.resetAfter) return;
+
+		this.processingResetAfter = setTimeout(() => {
+			this.remaining++;
+			this.processingResetAfter = undefined;
+			const resetTimer = this.processing;
+			if (!this.queue.length || !resetTimer || resetTimer === true) return;
+			clearTimeout(resetTimer);
+			this.processing = false;
+			this.process(true);
+		}, this.resetAfter * 1.5);
 	}
 }

--- a/src/api/shared.ts
+++ b/src/api/shared.ts
@@ -5,6 +5,9 @@ export * from './utils/constants';
 export * from './utils/types';
 export { calculateUserDefaultAvatarIndex } from './utils/utils';
 
+/** JSON body accepted by the REST transport, including top-level bulk arrays. */
+export type ApiRequestBody = Record<string, any> | readonly unknown[];
+
 export interface ApiHandlerOptions {
 	baseUrl?: string;
 	domain?: string;
@@ -28,7 +31,7 @@ export interface RawFile {
 }
 
 export interface ApiRequestOptions {
-	body?: Record<string, any>;
+	body?: ApiRequestBody;
 	query?: Record<string, any>;
 	files?: RawFile[];
 	auth?: boolean;

--- a/src/client/workerclient.ts
+++ b/src/client/workerclient.ts
@@ -364,7 +364,7 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 					if (!promise) return;
 					this.rest.workerPromises!.delete(data.nonce);
 					if (data.error) return promise.reject(data.error);
-					promise.resolve(data.response);
+					promise.resolve(data.responseType === 'arrayBuffer' ? Uint8Array.from(data.response).buffer : data.response);
 				}
 				break;
 			case 'EXECUTE_EVAL':

--- a/src/common/shorters/bans.ts
+++ b/src/common/shorters/bans.ts
@@ -30,7 +30,7 @@ export class BanShorter extends BaseShorter {
 	 * @param reason The reason for bulk banning members.
 	 */
 	async bulkCreate(guildId: string, body: RESTPostAPIGuildBulkBanJSONBody, reason?: string) {
-		const bans = await this.client.proxy.guilds(guildId)['bulk-bans'].post({ reason, body });
+		const bans = await this.client.proxy.guilds(guildId)['bulk-ban'].post({ reason, body });
 		await Promise.all(
 			bans.banned_users.map(id => this.client.cache.members?.removeIfNI('GuildModeration', id, guildId)),
 		);

--- a/src/common/shorters/interaction.ts
+++ b/src/common/shorters/interaction.ts
@@ -14,6 +14,7 @@ export class InteractionShorter extends BaseShorter {
 		return this.client.proxy
 			.interactions(id)(token)
 			.callback.post({
+				auth: false,
 				body: BaseInteraction.transformBodyRequest(
 					{
 						type: body.type,
@@ -51,6 +52,7 @@ export class InteractionShorter extends BaseShorter {
 			.webhooks(this.client.applicationId)(token)
 			.messages(messageId)
 			.patch({
+				auth: false,
 				body: BaseInteraction.transformBody(data, files, this.client),
 				files: parsedFiles,
 			});
@@ -65,7 +67,7 @@ export class InteractionShorter extends BaseShorter {
 		return this.client.proxy
 			.webhooks(this.client.applicationId)(token)
 			.messages(messageId)
-			.delete()
+			.delete({ auth: false })
 			.then(() => this.client.components.deleteValue(messageId, 'messageDelete'));
 	}
 
@@ -78,6 +80,7 @@ export class InteractionShorter extends BaseShorter {
 		const apiMessage = (await this.client.proxy
 			.webhooks(this.client.applicationId)(token)
 			.post({
+				auth: false,
 				body: BaseInteraction.transformBody(body, files, this.client),
 				files: parsedFiles,
 			})) as RESTPostAPIWebhookWithTokenWaitResult;

--- a/src/common/shorters/webhook.ts
+++ b/src/common/shorters/webhook.ts
@@ -108,7 +108,7 @@ export class WebhookShorter extends BaseShorter {
 		);
 		return this.client.proxy
 			.webhooks(webhookId)(token)
-			.post({ ...payload, files: parsedFiles, body: transformedBody })
+			.post({ ...payload, auth: false, files: parsedFiles, body: transformedBody })
 			.then(m => (m?.id ? Transformers.WebhookMessage(this.client, m, webhookId, token) : null));
 	}
 

--- a/src/structures/Interaction.ts
+++ b/src/structures/Interaction.ts
@@ -627,6 +627,7 @@ export class EntryPointInteraction<FromGuild extends boolean = boolean> extends 
 		const response = await this.client.proxy
 			.interactions(this.id)(this.token)
 			.callback.post({
+				auth: false,
 				body,
 				query: { with_response: true },
 			});

--- a/src/types/rest/oauth2.ts
+++ b/src/types/rest/oauth2.ts
@@ -4,7 +4,7 @@ import type { APIApplication, APIGuild, APIUser, APIWebhook, OAuth2Scopes } from
 /**
  * https://docs.discord.com/developers/topics/oauth2#get-current-bot-application-information
  */
-export type RESTGetAPIOAuth2CurrentApplicationResult = Omit<APIApplication, 'flags'>;
+export type RESTGetAPIOAuth2CurrentApplicationResult = APIApplication;
 
 /**
  * https://docs.discord.com/developers/topics/oauth2#get-current-authorization-information

--- a/src/websocket/discord/workermanager.ts
+++ b/src/websocket/discord/workermanager.ts
@@ -486,9 +486,12 @@ export class WorkerManager extends Map<
 						});
 					}
 					const response = await this.rest.request(message.method, message.url, message.requestOptions);
+					const encodedResponse = response instanceof ArrayBuffer ? Array.from(new Uint8Array(response)) : response;
+					const responseType = response instanceof ArrayBuffer ? 'arrayBuffer' : undefined;
 					this.postMessage(message.workerId, {
 						nonce: message.nonce,
-						response,
+						response: encodedResponse,
+						responseType,
 						type: 'API_RESPONSE',
 					} satisfies ManagerSendApiResponse);
 				}
@@ -752,6 +755,7 @@ export type ManagerSendApiResponse = CreateManagerMessage<
 	'API_RESPONSE',
 	{
 		response: any;
+		responseType?: 'arrayBuffer';
 		error?: any;
 		nonce: string;
 	}

--- a/tests/rest-rate-limit.test.mts
+++ b/tests/rest-rate-limit.test.mts
@@ -1,0 +1,396 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { ApiHandler } from '../src/api/api';
+import { Bucket } from '../src/api/bucket';
+
+function createApi() {
+	return new ApiHandler({ token: 'bot-token', domain: 'https://discord.example' });
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe('Discord REST rate limits', () => {
+	test('waits for X-RateLimit-Reset when relative reset headers are absent', async () => {
+		vi.useFakeTimers();
+		const now = 1_700_000_000_000;
+		vi.setSystemTime(now);
+		const fetchMock = vi.fn<typeof fetch>(async () =>
+			new Response('{}', {
+				headers: {
+					'content-type': 'application/json',
+					'x-ratelimit-limit': '1',
+					'x-ratelimit-remaining': '0',
+					'x-ratelimit-reset': String((now + 1_000) / 1_000),
+				},
+			}),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		const route = '/channels/100000000000000001/messages' as const;
+
+		await api.request('GET', route);
+		const queued = api.request('GET', route);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1_001);
+
+		await expect(queued).resolves.toEqual({});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('separates provisional buckets by HTTP method', async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response('{}', {
+					headers: {
+						'content-type': 'application/json',
+						'x-ratelimit-limit': '1',
+						'x-ratelimit-remaining': '0',
+						'x-ratelimit-reset-after': '1',
+					},
+				}),
+			)
+			.mockResolvedValueOnce(new Response('{}', { headers: { 'content-type': 'application/json' } }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		const route = '/channels/100000000000000001/messages' as const;
+
+		await api.request('POST', route, { body: { content: 'hello' } });
+		await expect(api.request('GET', route)).resolves.toEqual({});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('learns shared bucket hashes while retaining channel major parameters', async () => {
+		vi.useFakeTimers();
+		const headers = {
+			'content-type': 'application/json',
+			'x-ratelimit-bucket': 'shared-hash',
+			'x-ratelimit-limit': '1',
+			'x-ratelimit-remaining': '0',
+			'x-ratelimit-reset-after': '0.05',
+		};
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response('{}', { headers }))
+			.mockResolvedValueOnce(new Response('{}', { headers }))
+			.mockResolvedValueOnce(new Response('{}', { headers: { 'content-type': 'application/json' } }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		const channel = '100000000000000001';
+
+		await api.request('GET', `/channels/${channel}/messages`);
+		await api.request('GET', `/channels/${channel}/pins`);
+		const queued = api.request('GET', `/channels/${channel}/pins`);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		await vi.advanceTimersByTimeAsync(51);
+
+		await expect(queued).resolves.toEqual({});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(api.ratelimits.has(`shared-hash:channels:${channel}`)).toBe(true);
+	});
+
+	test('does not share a learned bucket across different channel majors', async () => {
+		const headers = {
+			'content-type': 'application/json',
+			'x-ratelimit-bucket': 'shared-hash',
+			'x-ratelimit-limit': '1',
+			'x-ratelimit-remaining': '0',
+			'x-ratelimit-reset-after': '1',
+		};
+		const fetchMock = vi.fn<typeof fetch>(async () => new Response('{}', { headers }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+
+		await api.request('GET', '/channels/100000000000000001/messages');
+		await api.request('GET', '/channels/200000000000000002/messages');
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(api.ratelimits.has('shared-hash:channels:100000000000000001')).toBe(true);
+		expect(api.ratelimits.has('shared-hash:channels:200000000000000002')).toBe(true);
+	});
+
+	test.each([
+		['guild', '/guilds/100000000000000001/members', 'shared-hash:guilds:100000000000000001'],
+		[
+			'webhook',
+			'/webhooks/100000000000000001/webhook-token/messages/@original',
+			'shared-hash:webhooks:100000000000000001:webhook-token',
+		],
+	])('retains the %s major parameter in learned buckets', async (_name, url, bucket) => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn<typeof fetch>(async () =>
+				new Response('{}', {
+					headers: {
+						'content-type': 'application/json',
+						'x-ratelimit-bucket': 'shared-hash',
+					},
+				}),
+			),
+		);
+		const api = createApi();
+
+		await api.request('GET', url as `/${string}`, { auth: false });
+
+		expect(api.ratelimits.has(bucket)).toBe(true);
+	});
+
+	test('uses Retry-After when a 429 body is not JSON', async () => {
+		vi.useFakeTimers();
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response('<html>rate limited</html>', {
+					status: 429,
+					headers: { 'retry-after': '0.002' },
+				}),
+			)
+			.mockResolvedValueOnce(new Response('{}', { headers: { 'content-type': 'application/json' } }));
+		vi.stubGlobal('fetch', fetchMock);
+		const request = createApi().request('GET', '/channels/100000000000000001/messages');
+
+		await vi.advanceTimersByTimeAsync(2);
+
+		await expect(request).resolves.toEqual({});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('keeps a 429 retry ahead of later requests in the same bucket', async () => {
+		const bodies: string[] = [];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn<typeof fetch>(async (_input, init) => {
+				bodies.push(JSON.parse(String(init?.body)).content);
+				return bodies.length === 1
+					? new Response('{"retry_after":0}', { status: 429, headers: { 'content-type': 'application/json' } })
+					: new Response('{}', { headers: { 'content-type': 'application/json' } });
+			}),
+		);
+		const api = createApi();
+		const url = '/channels/100000000000000001/messages' as const;
+
+		await Promise.all([
+			api.request('POST', url, { body: { content: 'first' } }),
+			api.request('POST', url, { body: { content: 'second' } }),
+		]);
+
+		expect(bodies).toEqual(['first', 'first', 'second']);
+	});
+
+	test('propagates a failed 429 retry to the original caller', async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response('{"retry_after":0}', {
+					status: 429,
+					headers: { 'content-type': 'application/json' },
+				}),
+			)
+			.mockResolvedValueOnce(
+				new Response('{"code":50035,"message":"retry failed"}', {
+					status: 400,
+					statusText: 'Bad Request',
+					headers: { 'content-type': 'application/json' },
+				}),
+			);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(createApi().request('GET', '/channels/100000000000000001/messages')).rejects.toMatchObject({
+			metadata: expect.objectContaining({ status: 400 }),
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test('scopes a global 429 gate to the authentication identity', async () => {
+		vi.useFakeTimers();
+		let channelAttempts = 0;
+		const paths: string[] = [];
+		const fetchMock = vi.fn<typeof fetch>(async input => {
+			const path = new URL(String(input)).pathname;
+			paths.push(path);
+			if (path.endsWith('/channels/100000000000000001/messages') && channelAttempts++ === 0) {
+				return new Response('{"global":true,"retry_after":0.05}', {
+					status: 429,
+					headers: {
+						'content-type': 'application/json',
+						'x-ratelimit-global': 'true',
+						'x-ratelimit-scope': 'global',
+					},
+				});
+			}
+			return new Response('{}', { headers: { 'content-type': 'application/json' } });
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		const limited = api.request('GET', '/channels/100000000000000001/messages');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(api.globalBlock).toBe(true);
+
+		const unauthenticated = api.request('GET', '/invites/code', { auth: false });
+		const otherBot = api.request('GET', '/gateway/bot', { token: 'other-bot-token' });
+		const sameBot = api.request('GET', '/users/@me');
+		const interaction = api.request('POST', '/interactions/1/token/callback', {
+			auth: false,
+			body: { type: 1 },
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		expect(paths.some(path => path.endsWith('/interactions/1/token/callback'))).toBe(true);
+		expect(paths.some(path => path.endsWith('/invites/code'))).toBe(true);
+		expect(paths.some(path => path.endsWith('/gateway/bot'))).toBe(true);
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+		expect(paths.some(path => path.endsWith('/users/@me'))).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(50);
+
+		await expect(Promise.all([limited, unauthenticated, otherBot, sameBot, interaction])).resolves.toEqual([
+			{},
+			{},
+			{},
+			{},
+			{},
+		]);
+		expect(paths.some(path => path.endsWith('/users/@me'))).toBe(true);
+		expect(api.globalBlock).toBe(false);
+	});
+
+	test('starts a global gate before awaiting rate-limit observers', async () => {
+		vi.useFakeTimers();
+		let releaseObserver: (() => void) | undefined;
+		let attempts = 0;
+		const fetchMock = vi.fn<typeof fetch>(async () => {
+			if (attempts++ === 0) {
+				return new Response('{"global":true,"retry_after":0.05}', {
+					status: 429,
+					headers: { 'content-type': 'application/json', 'x-ratelimit-global': 'true' },
+				});
+			}
+			return new Response('{}', { headers: { 'content-type': 'application/json' } });
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		api.observe({
+			onRatelimit: () =>
+				new Promise<void>(resolve => {
+					releaseObserver = resolve;
+				}),
+		});
+
+		const limited = api.request('GET', '/channels/100000000000000001/messages');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(api.globalBlock).toBe(true);
+
+		const queued = api.request('GET', '/users/@me');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		releaseObserver?.();
+		await vi.advanceTimersByTimeAsync(50);
+
+		await expect(Promise.all([limited, queued])).resolves.toEqual([{}, {}]);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	test('parks an exhausted smart bucket without polling', () => {
+		vi.useFakeTimers();
+		const now = 1_700_000_000_000;
+		vi.setSystemTime(now);
+		const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+		const bucket = new Bucket(1);
+		const dispatch = vi.fn((next: () => void) => next());
+		bucket.remaining = 0;
+		bucket.reset = now + 100;
+		bucket.resetAfter = 100;
+
+		bucket.triggerResetAfter();
+		bucket.push({ next: dispatch, resolve: vi.fn(), reject: vi.fn() });
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+		vi.advanceTimersByTime(100);
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+
+		vi.advanceTimersByTime(1);
+		expect(dispatch).toHaveBeenCalledOnce();
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+	});
+
+	test('wakes a parked smart bucket when its refill arrives first', () => {
+		vi.useFakeTimers();
+		const now = 1_700_000_000_000;
+		vi.setSystemTime(now);
+		const bucket = new Bucket(1);
+		const dispatch = vi.fn((next: () => void) => next());
+		bucket.remaining = 0;
+		bucket.reset = now + 1_000;
+		bucket.resetAfter = 100;
+
+		bucket.triggerResetAfter();
+		bucket.push({ next: dispatch, resolve: vi.fn(), reject: vi.fn() });
+
+		vi.advanceTimersByTime(149);
+		expect(dispatch).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		expect(dispatch).toHaveBeenCalledOnce();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	test('does not dispatch a smart refill during an active callback', () => {
+		vi.useFakeTimers();
+		const now = 1_700_000_000_000;
+		vi.setSystemTime(now);
+		const bucket = new Bucket(1);
+		let release: (() => void) | undefined;
+		const firstDispatch = vi.fn((next: () => void) => {
+			release = next;
+		});
+		const queuedDispatch = vi.fn((next: () => void) => next());
+
+		bucket.push({ next: firstDispatch, resolve: vi.fn(), reject: vi.fn() });
+		bucket.remaining = 0;
+		bucket.reset = now + 1_000;
+		bucket.resetAfter = 100;
+		bucket.triggerResetAfter();
+		bucket.push({ next: queuedDispatch, resolve: vi.fn(), reject: vi.fn() });
+
+		vi.advanceTimersByTime(150);
+		expect(queuedDispatch).not.toHaveBeenCalled();
+
+		release?.();
+		expect(queuedDispatch).toHaveBeenCalledOnce();
+	});
+
+	test('rejects a 429 without a valid retry delay and releases the bucket', async () => {
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const url = '/channels/100000000000000001/messages' as const;
+		const next = vi.fn();
+		const reject = vi.fn();
+		api.ratelimits.set(route, new Bucket(1));
+
+		const result = await api.handle429(
+			route,
+			'GET',
+			url,
+			{},
+			new Response('<html>rate limited</html>', {
+				status: 429,
+				headers: { 'retry-after': 'not-a-number' },
+			}),
+			'<html>rate limited</html>',
+			next,
+			reject,
+			Date.now(),
+			url,
+		);
+
+		expect(result).toBe(false);
+		expect(next).toHaveBeenCalledOnce();
+		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
+	});
+});

--- a/tests/rest-rate-limit.test.mts
+++ b/tests/rest-rate-limit.test.mts
@@ -393,4 +393,30 @@ describe('Discord REST rate limits', () => {
 		expect(next).toHaveBeenCalledOnce();
 		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
 	});
+
+	test('rejects an empty 429 response without a retry delay', async () => {
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const url = '/channels/100000000000000001/messages' as const;
+		const next = vi.fn();
+		const reject = vi.fn();
+		api.ratelimits.set(route, new Bucket(1));
+
+		const result = await api.handle429(
+			route,
+			'GET',
+			url,
+			{},
+			new Response('', { status: 429 }),
+			'',
+			next,
+			reject,
+			Date.now(),
+			url,
+		);
+
+		expect(result).toBe(false);
+		expect(next).toHaveBeenCalledOnce();
+		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
+	});
 });

--- a/tests/rest-routes-contract.ts
+++ b/tests/rest-routes-contract.ts
@@ -1,0 +1,88 @@
+import type {
+	APIApplication,
+	ApiHandler,
+	RESTGetAPIApplicationCommandPermissionsResult,
+	RESTGetAPIGuildOnboardingResult,
+	RESTGetAPIInviteResult,
+	RESTGetAPIOAuth2CurrentApplicationResult,
+	RESTGetAPISKUSubscriptionResult,
+	RESTGetAPISKUSubscriptionsResult,
+	RESTGetAPIVoiceRegionsResult,
+	RESTPatchAPIWebhookWithTokenMessageResult,
+	RESTPatchAPIWebhookWithTokenResult,
+	RESTPostAPIGuildBulkBanResult,
+	RESTPutAPIApplicationCommandPermissionsResult,
+	RESTPutAPIGuildIncidentActionsResult,
+	RESTPutAPIGuildOnboardingResult,
+} from 'seyfert';
+
+declare const api: ApiHandler;
+declare function expectType<T>(value: T): void;
+
+expectType<Promise<RESTPostAPIGuildBulkBanResult>>(
+	api.proxy.guilds('guild-id')['bulk-ban'].post({ body: { user_ids: ['user-id'] } }),
+);
+expectType<Promise<RESTGetAPIGuildOnboardingResult>>(api.proxy.guilds('guild-id').onboarding.get());
+expectType<Promise<RESTPutAPIGuildOnboardingResult>>(
+	api.proxy.guilds('guild-id').onboarding.put({ body: {} }),
+);
+expectType<Promise<RESTPutAPIGuildIncidentActionsResult>>(
+	api.proxy.guilds('guild-id')['incident-actions'].put({ body: { dms_disabled_until: null } }),
+);
+expectType<Promise<RESTGetAPIVoiceRegionsResult>>(api.proxy.voice.regions.get());
+expectType<Promise<RESTGetAPIOAuth2CurrentApplicationResult>>(api.proxy.oauth2.applications['@me'].get());
+api.proxy.oauth2.applications['@me'].get().then(application => {
+	expectType<APIApplication['flags']>(application.flags);
+});
+expectType<Promise<RESTGetAPISKUSubscriptionsResult>>(
+	api.proxy.skus('sku-id').subscriptions.get({ query: { user_id: 'user-id' } }),
+);
+expectType<Promise<RESTGetAPISKUSubscriptionResult>>(
+	api.proxy.skus('sku-id').subscriptions('subscription-id').get(),
+);
+expectType<Promise<RESTGetAPIInviteResult>>(
+	api.proxy.invites('invite-code').get({ query: { with_counts: true } }),
+);
+expectType<Promise<RESTPatchAPIWebhookWithTokenResult>>(
+	api.proxy.webhooks('webhook-id')('webhook-token').patch({ body: { name: 'renamed' } }),
+);
+expectType<Promise<RESTPatchAPIWebhookWithTokenMessageResult>>(
+	api.proxy
+		.webhooks('webhook-id')('webhook-token')
+		.messages('message-id')
+		.patch({ body: { content: 'edited' }, query: { thread_id: 'thread-id' } }),
+);
+expectType<Promise<RESTGetAPIApplicationCommandPermissionsResult>>(
+	api.proxy
+		.applications('application-id')
+		.guilds('guild-id')
+		.commands('command-id')
+		.permissions.get(),
+);
+expectType<Promise<RESTPutAPIApplicationCommandPermissionsResult>>(
+	api.proxy
+		.applications('application-id')
+		.guilds('guild-id')
+		.commands('command-id')
+		.permissions.put({ body: { permissions: [] } }),
+);
+
+// @ts-expect-error The Discord endpoint is singular: /guilds/{guild.id}/bulk-ban.
+api.proxy.guilds('guild-id')['bulk-bans'].post({ body: { user_ids: ['user-id'] } });
+// @ts-expect-error The Discord endpoint is plural: /voice/regions.
+api.proxy.voice.region.get();
+// @ts-expect-error Invite GET parameters belong in the query string.
+api.proxy.invites('invite-code').get({ body: { with_counts: true } });
+// @ts-expect-error SKU subscription list parameters belong in the query string.
+api.proxy.skus('sku-id').subscriptions.get({ body: { user_id: 'user-id' } });
+// @ts-expect-error The documented individual SKU subscription endpoint has no query parameters.
+api.proxy.skus('sku-id').subscriptions('subscription-id').get({ query: { user_id: 'user-id' } });
+// @ts-expect-error Modifying a webhook with a token does not accept message query parameters.
+api.proxy.webhooks('webhook-id')('webhook-token').patch({ query: { thread_id: 'thread-id' } });
+const applicationCommandPermissions = api.proxy
+	.applications('application-id')
+	.guilds('guild-id')
+	.commands('command-id')
+	.permissions;
+// @ts-expect-error Editing command permissions requires a JSON body.
+applicationCommandPermissions.put();

--- a/tests/rest-routes.test.mts
+++ b/tests/rest-routes.test.mts
@@ -1,0 +1,130 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { ApiHandler } from '../src/api/api';
+import { Router } from '../src/api/Router';
+import type { APIRoutes } from '../src/api/Routes';
+import type { ApiRequestOptions, HttpMethods } from '../src/api/shared';
+
+interface RouteCase {
+	name: string;
+	method: HttpMethods;
+	path: `/${string}`;
+	options?: ApiRequestOptions;
+	invoke(routes: APIRoutes): Promise<unknown>;
+}
+
+const routeCases: RouteCase[] = [
+	{
+		name: 'bulk ban',
+		method: 'POST',
+		path: '/guilds/guild-id/bulk-ban',
+		options: { body: { user_ids: ['user-id'] } },
+		invoke: routes => routes.guilds('guild-id')['bulk-ban'].post({ body: { user_ids: ['user-id'] } }),
+	},
+	{
+		name: 'get onboarding',
+		method: 'GET',
+		path: '/guilds/guild-id/onboarding',
+		invoke: routes => routes.guilds('guild-id').onboarding.get(),
+	},
+	{
+		name: 'modify onboarding',
+		method: 'PUT',
+		path: '/guilds/guild-id/onboarding',
+		options: { body: {} },
+		invoke: routes => routes.guilds('guild-id').onboarding.put({ body: {} }),
+	},
+	{
+		name: 'modify incident actions',
+		method: 'PUT',
+		path: '/guilds/guild-id/incident-actions',
+		options: { body: { dms_disabled_until: null } },
+		invoke: routes =>
+			routes.guilds('guild-id')['incident-actions'].put({ body: { dms_disabled_until: null } }),
+	},
+	{
+		name: 'list voice regions',
+		method: 'GET',
+		path: '/voice/regions',
+		invoke: routes => routes.voice.regions.get(),
+	},
+	{
+		name: 'get current OAuth2 application',
+		method: 'GET',
+		path: '/oauth2/applications/@me',
+		invoke: routes => routes.oauth2.applications['@me'].get(),
+	},
+	{
+		name: 'list SKU subscriptions',
+		method: 'GET',
+		path: '/skus/sku-id/subscriptions',
+		options: { query: { user_id: 'user-id' } },
+		invoke: routes => routes.skus('sku-id').subscriptions.get({ query: { user_id: 'user-id' } }),
+	},
+	{
+		name: 'get SKU subscription',
+		method: 'GET',
+		path: '/skus/sku-id/subscriptions/subscription-id',
+		invoke: routes => routes.skus('sku-id').subscriptions('subscription-id').get(),
+	},
+	{
+		name: 'get invite with query',
+		method: 'GET',
+		path: '/invites/invite-code',
+		options: { query: { with_counts: true } },
+		invoke: routes => routes.invites('invite-code').get({ query: { with_counts: true } }),
+	},
+	{
+		name: 'modify webhook with token',
+		method: 'PATCH',
+		path: '/webhooks/webhook-id/webhook-token',
+		options: { body: { name: 'renamed' } },
+		invoke: routes => routes.webhooks('webhook-id')('webhook-token').patch({ body: { name: 'renamed' } }),
+	},
+	{
+		name: 'edit webhook message with query',
+		method: 'PATCH',
+		path: '/webhooks/webhook-id/webhook-token/messages/message-id',
+		options: { body: { content: 'edited' }, query: { thread_id: 'thread-id' } },
+		invoke: routes =>
+			routes
+				.webhooks('webhook-id')('webhook-token')
+				.messages('message-id')
+				.patch({ body: { content: 'edited' }, query: { thread_id: 'thread-id' } }),
+	},
+	{
+		name: 'get application command permissions',
+		method: 'GET',
+		path: '/applications/application-id/guilds/guild-id/commands/command-id/permissions',
+		invoke: routes =>
+			routes
+				.applications('application-id')
+				.guilds('guild-id')
+				.commands('command-id')
+				.permissions.get(),
+	},
+	{
+		name: 'edit application command permissions',
+		method: 'PUT',
+		path: '/applications/application-id/guilds/guild-id/commands/command-id/permissions',
+		options: { body: { permissions: [] } },
+		invoke: routes =>
+			routes
+				.applications('application-id')
+				.guilds('guild-id')
+				.commands('command-id')
+				.permissions.put({ body: { permissions: [] } }),
+	},
+];
+
+describe('REST route proxy', () => {
+	test.each(routeCases)('$name uses $method $path', async ({ method, path, options, invoke }) => {
+		const request = vi.fn().mockResolvedValue(undefined);
+		const routes = new Router({ request } as unknown as ApiHandler).createProxy();
+
+		await invoke(routes);
+
+		expect(request).toHaveBeenCalledOnce();
+		if (options) expect(request).toHaveBeenCalledWith(method, path, options);
+		else expect(request).toHaveBeenCalledWith(method, path);
+	});
+});

--- a/tests/rest-transport.test.mts
+++ b/tests/rest-transport.test.mts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { ApiHandler } from '../src/api/api';
+
+function createApi() {
+	return new ApiHandler({
+		domain: 'https://discord.example',
+		token: 'handler-token',
+	});
+}
+
+function jsonResponse(value: unknown, contentType = 'application/json; charset=utf-8') {
+	return new Response(JSON.stringify(value), { headers: { 'content-type': contentType } });
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe('Discord REST transport', () => {
+	test.each([
+		['false', false],
+		['zero', 0],
+		['null', null],
+		['empty string', ''],
+	])('preserves JSON %s', async (_name, value) => {
+		vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => jsonResponse(value)));
+
+		await expect(createApi().request('GET', '/users/@me')).resolves.toEqual(value);
+	});
+
+	test('decodes documented JSON, text, binary, and empty responses', async () => {
+		const bytes = new Uint8Array([137, 80, 78, 71, 0, 255]);
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(jsonResponse({ detail: 'problem' }, 'application/problem+json'))
+			.mockResolvedValueOnce(new Response('id,name\n1,Seyfert', { headers: { 'content-type': 'text/csv' } }))
+			.mockResolvedValueOnce(new Response(bytes, { headers: { 'content-type': 'image/png' } }))
+			.mockResolvedValueOnce(new Response(null, { status: 204 }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+
+		await expect(api.request('GET', '/responses/problem')).resolves.toEqual({ detail: 'problem' });
+		await expect(api.request('GET', '/applications/1/entitlements')).resolves.toBe('id,name\n1,Seyfert');
+		const binary = await api.request('GET', '/guilds/1/widget.png');
+		expect([...new Uint8Array(binary as ArrayBuffer)]).toEqual([...bytes]);
+		await expect(api.request('DELETE', '/channels/1/messages/2')).resolves.toBeUndefined();
+	});
+
+	test('serializes top-level arrays required by bulk command routes', async () => {
+		const body = [{ name: 'ping' }] as const;
+		const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ ok: true }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await createApi().request('PUT', '/applications/1/commands', { body });
+
+		expect(fetchMock.mock.calls[0]![1]?.body).toBe(JSON.stringify(body));
+	});
+
+	test('omits nullish query values, repeats arrays, and preserves an existing query', async () => {
+		const fetchMock = vi.fn<typeof fetch>(async () => jsonResponse({ ok: true }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await createApi().request('GET', '/invites/code?existing=1', {
+			query: {
+				absent: null,
+				enabled: false,
+				tag: ['a', null, 'b'],
+			},
+		});
+
+		const sent = new URL(String(fetchMock.mock.calls[0]![0]));
+		expect(sent.searchParams.get('existing')).toBe('1');
+		expect(sent.searchParams.getAll('tag')).toEqual(['a', 'b']);
+		expect(sent.searchParams.get('enabled')).toBe('false');
+		expect(sent.searchParams.has('absent')).toBe(false);
+	});
+
+	test('rejects scalar JSON errors and advances the route bucket', async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response('123', {
+					status: 400,
+					statusText: 'Bad Request',
+					headers: { 'content-type': 'application/json' },
+				}),
+			)
+			.mockResolvedValueOnce(jsonResponse({ ok: true }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+
+		const failed = api.request('GET', '/users/@me');
+		const next = api.request('GET', '/users/@me');
+
+		await expect(failed).rejects.toMatchObject({ metadata: expect.objectContaining({ status: 400 }) });
+		await expect(next).resolves.toEqual({ ok: true });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/shorter-token-auth.test.mts
+++ b/tests/shorter-token-auth.test.mts
@@ -1,0 +1,100 @@
+import { describe, expect, test, vi } from 'vitest';
+import { BaseClient } from '../lib/client/base';
+import { EntryPointInteraction } from '../lib/structures/Interaction';
+import { InteractionResponseType } from '../lib/types/payloads/_interactions/responses';
+
+const responseMessage = {
+	id: 'message-id',
+	embeds: [],
+	mentions: [],
+};
+
+function createClient() {
+	const client = new BaseClient();
+	client.applicationId = 'application-id';
+	const request = vi.spyOn(client.rest, 'request').mockResolvedValue(responseMessage as never);
+
+	return { client, request };
+}
+
+const tokenAuthCases = [
+	{
+		name: 'webhook message write',
+		method: 'POST',
+		path: '/webhooks/webhook-id/webhook-token',
+		invoke: (client: BaseClient) =>
+			client.webhooks.writeMessage('webhook-id', 'webhook-token', {
+				body: { content: 'hello' },
+				query: { wait: true },
+			}),
+	},
+	{
+		name: 'interaction callback reply',
+		method: 'POST',
+		path: '/interactions/interaction-id/interaction-token/callback',
+		invoke: (client: BaseClient) =>
+			client.interactions.reply(
+				'interaction-id',
+				'interaction-token',
+				{ type: InteractionResponseType.ChannelMessageWithSource, data: { content: 'hello' } },
+			),
+	},
+	{
+		name: 'interaction message edit',
+		method: 'PATCH',
+		path: '/webhooks/application-id/interaction-token/messages/message-id',
+		invoke: (client: BaseClient) =>
+			client.interactions.editMessage('interaction-token', 'message-id', { content: 'edited' }),
+	},
+	{
+		name: 'interaction message delete',
+		method: 'DELETE',
+		path: '/webhooks/application-id/interaction-token/messages/message-id',
+		invoke: (client: BaseClient) => client.interactions.deleteResponse('interaction-token', 'message-id'),
+	},
+	{
+		name: 'interaction followup',
+		method: 'POST',
+		path: '/webhooks/application-id/interaction-token',
+		invoke: (client: BaseClient) => client.interactions.followup('interaction-token', { content: 'followup' }),
+	},
+] as const;
+
+describe('token-authenticated shorters', () => {
+	test.each(tokenAuthCases)('$name does not send the bot authorization header', async ({ method, path, invoke }) => {
+		const { client, request } = createClient();
+
+		await invoke(client);
+
+		expect(request).toHaveBeenCalledOnce();
+		expect(request).toHaveBeenCalledWith(method, path, expect.objectContaining({ auth: false }));
+	});
+
+	test('entry-point callbacks do not send the bot authorization header', async () => {
+		const { client, request } = createClient();
+		request.mockResolvedValue({ interaction: { id: 'interaction-id' } } as never);
+		const interaction = Object.assign(Object.create(EntryPointInteraction.prototype), {
+			client,
+			id: 'interaction-id',
+			token: 'interaction-token',
+		}) as EntryPointInteraction;
+
+		await interaction.withResponse();
+
+		expect(request).toHaveBeenCalledOnce();
+		expect(request).toHaveBeenCalledWith(
+			'POST',
+			'/interactions/interaction-id/interaction-token/callback',
+			expect.objectContaining({ auth: false }),
+		);
+	});
+
+	test('webhook ID routes retain bot authentication', async () => {
+		const { client, request } = createClient();
+
+		await client.webhooks.delete('webhook-id', {});
+
+		expect(request).toHaveBeenCalledOnce();
+		expect(request).toHaveBeenCalledWith('DELETE', '/webhooks/webhook-id', { reason: undefined });
+	});
+});

--- a/tests/workermanager.test.mts
+++ b/tests/workermanager.test.mts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest';
+import { WorkerClient } from '../lib/client/workerclient';
 import { WorkerManager } from '../lib/websocket/discord/workermanager';
 
 describe('WorkerManager', () => {
@@ -36,6 +37,36 @@ describe('WorkerManager', () => {
 		manager.getWorkerInfo = async () => ({ shards: [] });
 
 		await expect(WorkerManager.prototype.syncLatency.call(manager, { workerId: 0 })).resolves.toBe(0);
+	});
+
+	test('preserves binary REST responses through JSON worker IPC', async () => {
+		const bytes = new Uint8Array([137, 80, 78, 71, 0, 255]);
+		const manager = Object.create(WorkerManager.prototype) as WorkerManager;
+		manager.options = { mode: 'clusters' } as WorkerManager['options'];
+		manager.rest = { request: async () => bytes.buffer } as unknown as WorkerManager['rest'];
+		let wireMessage: unknown;
+		manager.postMessage = ((_workerId: number, message: unknown) => {
+			wireMessage = JSON.parse(JSON.stringify(message));
+		}) as WorkerManager['postMessage'];
+
+		await manager.handleWorkerMessage({
+			type: 'WORKER_API_REQUEST',
+			workerId: 0,
+			nonce: 'binary-response',
+			method: 'GET',
+			url: '/guilds/1/widget.png',
+			requestOptions: {},
+		});
+
+		const client = Object.create(WorkerClient.prototype) as WorkerClient;
+		const response = new Promise<ArrayBuffer>((resolve, reject) => {
+			client.rest = {
+				workerPromises: new Map([['binary-response', { resolve, reject }]]),
+			} as WorkerClient['rest'];
+		});
+		await client.handleManagerMessages(wireMessage as never);
+
+		expect([...new Uint8Array(await response)]).toEqual([...bytes]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Align Seyfert's bot REST surface with Discord's current contract. This adds the missing current-application, onboarding, voice-region, SKU subscription, invite/webhook query, and application-command permission routes and corrects the affected request signatures, response types, and token-authenticated calls.

The transport now preserves Discord's JSON, text, empty, and binary responses, including binary results crossing worker or cluster IPC. The REST limiter learns Discord's bucket hashes while preserving major-parameter and bot-token boundaries, applies global limits to the affected token, and honors retry timing without smart-bucket busy polling.

## Root Cause

The REST surface had drifted from Discord's documented bot API, while rate limits were coordinated only through normalized local route keys. That could split requests belonging to the same Discord bucket, merge requests that must remain independent, and apply global backpressure beyond the affected bot token. Binary responses also lacked a JSON-safe representation for worker IPC.
