### PR TITLE
feat(client): expose WorkerClient gateway sends

### DIFF
--- a/src/client/workerclient.ts
+++ b/src/client/workerclient.ts
@@ -225,19 +225,12 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				break;
 			case 'SEND_PAYLOAD':
 				{
-					const shard = this.shards.get(data.shardId);
-					if (!shard) {
+					const { nonce: _nonce, shardId: _shardId, type: _type, ...payload } = data;
+					const result = await this.sendGatewayPayloadOnShard(data.shardId, payload as GatewaySendPayload, true);
+					if (result === 'missing') {
 						this.logger.fatal(`Worker trying to send payload by non-existent shard (#${data.shardId})`);
 						return;
 					}
-
-					const { nonce: _nonce, shardId: _shardId, type: _type, ...payload } = data;
-					const pluginPayload = await applyPluginGatewaySendPayloadWrappers(
-						this,
-						data.shardId,
-						payload as GatewaySendPayload,
-					);
-					if (pluginPayload !== null) await shard.send(true, pluginPayload);
 
 					this.postMessage({
 						type: 'RESULT_PAYLOAD',
@@ -435,6 +428,32 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 
 	calculateShardId(guildId: string) {
 		return calculateShardId(guildId, this.workerData.totalShards);
+	}
+
+	/**
+	 * Sends a Gateway payload through the worker client's plugin wrappers and shard rate limiter.
+	 *
+	 * @returns `false` when a plugin wrapper vetoes the payload, otherwise `true` after it is sent.
+	 */
+	async sendGatewayPayload<T extends GatewaySendPayload>(shardId: number, payload: T): Promise<boolean> {
+		const result = await this.sendGatewayPayloadOnShard(shardId, payload, false);
+		if (result === 'missing') {
+			throw new SeyfertError('INTERNAL_ERROR', { metadata: { detail: `Shard #${shardId} doesn't exist` } });
+		}
+		return result === 'sent';
+	}
+
+	private async sendGatewayPayloadOnShard(
+		shardId: number,
+		payload: GatewaySendPayload,
+		force: boolean,
+	): Promise<'missing' | 'sent' | 'vetoed'> {
+		const pluginPayload = await applyPluginGatewaySendPayloadWrappers(this, shardId, payload);
+		if (pluginPayload === null) return 'vetoed';
+		const shard = this.shards.get(shardId);
+		if (!shard) return 'missing';
+		await shard.send(force, pluginPayload);
+		return 'sent';
 	}
 
 	private generateNonce(): UUID {

--- a/tests/plugin-api.test.mts
+++ b/tests/plugin-api.test.mts
@@ -1623,6 +1623,164 @@ describe('plugin api v3', () => {
 		expect(sent).toEqual([{ op: GatewayOpcodes.Heartbeat, d: 'wrapped' }]);
 	});
 
+	test('sends worker gateway payloads through plugin wrappers and the target shard', async () => {
+		const sent: { force: boolean; payload: GatewaySendPayload }[] = [];
+		const plugin = createPlugin({
+			name: 'worker-gateway-wrapper',
+			register(api) {
+				api.gateway.wrapSendPayload(({ payload }) => ({
+					...payload,
+					d: 'wrapped' as never,
+				}));
+			},
+		});
+		const client = new WorkerClient({ getRC: runtimeConfig, plugins: [plugin], postMessage: () => {} });
+		setWorkerData(client);
+		client.shards.set(0, {
+			send: async (force: boolean, payload: GatewaySendPayload) => {
+				sent.push({ force, payload });
+			},
+		} as never);
+
+		await expect(client.sendGatewayPayload(0, { op: GatewayOpcodes.Heartbeat, d: null })).resolves.toBe(true);
+
+		expect(sent).toEqual([{ force: false, payload: { op: GatewayOpcodes.Heartbeat, d: 'wrapped' } }]);
+	});
+
+	test('resolves the current worker shard after asynchronous gateway wrappers finish', async () => {
+		let releaseWrapper!: () => void;
+		const wrapperBlocked = new Promise<void>(resolve => {
+			releaseWrapper = resolve;
+		});
+		const plugin = createPlugin({
+			name: 'worker-gateway-async-wrapper',
+			register(api) {
+				api.gateway.wrapSendPayload(async ({ payload }) => {
+					await wrapperBlocked;
+					return payload;
+				});
+			},
+		});
+		const client = new WorkerClient({ getRC: runtimeConfig, plugins: [plugin], postMessage: () => {} });
+		setWorkerData(client);
+		const oldSend = vi.fn(async () => {});
+		const currentSend = vi.fn(async () => {});
+		client.shards.set(0, { send: oldSend } as never);
+
+		const sending = client.sendGatewayPayload(0, { op: GatewayOpcodes.Heartbeat, d: null });
+		await flushMicrotasks();
+		client.shards.set(0, { send: currentSend } as never);
+		releaseWrapper();
+
+		await expect(sending).resolves.toBe(true);
+		expect(oldSend).not.toHaveBeenCalled();
+		expect(currentSend).toHaveBeenCalledExactlyOnceWith(false, {
+			op: GatewayOpcodes.Heartbeat,
+			d: null,
+		});
+	});
+
+	test('wraps manager-requested worker sends before forcing the current shard', async () => {
+		const messages: unknown[] = [];
+		const plugin = createPlugin({
+			name: 'worker-manager-gateway-wrapper',
+			register(api) {
+				api.gateway.wrapSendPayload(({ payload }) => ({ ...payload, d: 'wrapped' as never }));
+			},
+		});
+		const client = new WorkerClient({
+			getRC: runtimeConfig,
+			plugins: [plugin],
+			postMessage: message => messages.push(message),
+		});
+		setWorkerData(client, 9);
+		const sent = vi.fn(async () => {});
+		client.shards.set(0, { send: sent } as never);
+
+		await client.handleManagerMessages({
+			type: 'SEND_PAYLOAD',
+			shardId: 0,
+			nonce: 'request-one',
+			op: GatewayOpcodes.Heartbeat,
+			d: null,
+		});
+
+		expect(sent).toHaveBeenCalledExactlyOnceWith(true, {
+			op: GatewayOpcodes.Heartbeat,
+			d: 'wrapped',
+		});
+		expect(messages).toEqual([{ type: 'RESULT_PAYLOAD', nonce: 'request-one', workerId: 9 }]);
+	});
+
+	test('logs and returns when a manager-requested worker shard disappears', async () => {
+		const messages: unknown[] = [];
+		const wrapper = vi.fn(({ payload }: { payload: GatewaySendPayload }) => payload);
+		const client = new WorkerClient({
+			getRC: runtimeConfig,
+			plugins: [
+				createPlugin({
+					name: 'worker-manager-missing-shard',
+					register(api) {
+						api.gateway.wrapSendPayload(wrapper);
+					},
+				}),
+			],
+			postMessage: message => messages.push(message),
+		});
+		setWorkerData(client);
+		const fatal = vi.spyOn(client.logger, 'fatal').mockImplementation(() => {});
+
+		await expect(
+			client.handleManagerMessages({
+				type: 'SEND_PAYLOAD',
+				shardId: 0,
+				nonce: 'missing-shard',
+				op: GatewayOpcodes.Heartbeat,
+				d: null,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(wrapper).toHaveBeenCalledOnce();
+		expect(fatal).toHaveBeenCalledExactlyOnceWith('Worker trying to send payload by non-existent shard (#0)');
+		expect(messages).toEqual([]);
+	});
+
+	test('reports vetoed and unavailable worker gateway sends', async () => {
+		const sent = vi.fn();
+		const plugin = createPlugin({
+			name: 'worker-gateway-veto',
+			register(api) {
+				api.gateway.wrapSendPayload(() => null);
+			},
+		});
+		const client = new WorkerClient({ getRC: runtimeConfig, plugins: [plugin], postMessage: () => {} });
+		setWorkerData(client);
+		client.shards.set(0, { send: sent } as never);
+
+		await expect(client.sendGatewayPayload(0, { op: GatewayOpcodes.Heartbeat, d: null })).resolves.toBe(false);
+		expect(sent).not.toHaveBeenCalled();
+
+		const availableWrapper = vi.fn(({ payload }: { payload: GatewaySendPayload }) => payload);
+		const missingClient = new WorkerClient({
+			getRC: runtimeConfig,
+			plugins: [
+				createPlugin({
+					name: 'worker-gateway-missing-shard',
+					register(api) {
+						api.gateway.wrapSendPayload(availableWrapper);
+					},
+				}),
+			],
+			postMessage: () => {},
+		});
+		setWorkerData(missingClient);
+		await expect(missingClient.sendGatewayPayload(1, { op: GatewayOpcodes.Heartbeat, d: null })).rejects.toMatchObject({
+			code: 'INTERNAL_ERROR',
+			metadata: expect.objectContaining({ detail: `Shard #1 doesn't exist` }),
+		});
+		expect(availableWrapper).toHaveBeenCalledOnce();
+	});
+
 	test('runs gateway dispatch interceptors before cache and events', async () => {
 		const calls: string[] = [];
 		const packets: GatewayDispatchPayload[] = [];

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -139,6 +139,7 @@ import {
 	type VoiceStateStructure,
 	PresenceUpdateStatus,
 	createEvent,
+	WorkerClient,
 	type ModalSubmitInteraction,
 } from 'seyfert';
 import type { APIRoutes } from '../lib/api/Routes';
@@ -162,6 +163,10 @@ import type { ShardManagerOptions, WorkerManagerOptions } from '../lib/websocket
 import type { ManagerAllowConnect, ManagerAllowConnectResharding } from '../lib/websocket/discord/workermanager';
 
 declare function expectType<T>(value: T): void;
+declare const publicWorkerClient: WorkerClient;
+declare const publicGatewayPayload: GatewaySendPayload;
+expectType<Promise<boolean>>(publicWorkerClient.sendGatewayPayload(0, publicGatewayPayload));
+
 type IsAny<T> = 0 extends 1 & T ? true : false;
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
 	? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2


### PR DESCRIPTION
Expose `WorkerClient.sendGatewayPayload()` to align worker clients with the Gateway send capability already available through `Client`. This lets plugins send wrapped, rate-limited Gateway payloads consistently regardless of which client runtime they are attached to.