### PR TITLE
fix(api): handle non-JSON 429 retry responses

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -568,13 +568,30 @@ export class ApiHandler<TClient = unknown> {
 		const bucket = this.ratelimits.get(route)!;
 		let retryAfter: number | undefined;
 
-		const data = JSON.parse(result);
-		if (data.retry_after) retryAfter = Math.ceil(data.retry_after * 1000);
+		try {
+			const data: unknown = JSON.parse(result);
+			if (
+				typeof data === 'object' &&
+				data !== null &&
+				'retry_after' in data &&
+				typeof data.retry_after === 'number' &&
+				Number.isFinite(data.retry_after) &&
+				data.retry_after >= 0
+			) {
+				retryAfter = Math.ceil(data.retry_after * 1000);
+			}
+		} catch (error) {
+			this.debugger?.warn('Failed parsing 429 result (', result, ')', error);
+		}
 
-		retryAfter ??=
-			Number(response.headers.get('x-ratelimit-reset-after') || response.headers.get('retry-after')) * 1000;
+		if (retryAfter === undefined) {
+			const retryAfterHeader = response.headers.get('x-ratelimit-reset-after') ?? response.headers.get('retry-after');
+			if (retryAfterHeader !== null && retryAfterHeader.trim() !== '') {
+				retryAfter = Number(retryAfterHeader) * 1000;
+			}
+		}
 
-		if (Number.isNaN(retryAfter)) {
+		if (retryAfter === undefined || !Number.isFinite(retryAfter) || retryAfter < 0) {
 			this.debugger?.warn(`${route} Could not extract retry_after from 429 response. ${result}`);
 			next();
 			reject(

--- a/tests/rest-retry-options.test.mts
+++ b/tests/rest-retry-options.test.mts
@@ -133,4 +133,57 @@ describe('REST retry request options', () => {
 			vi.useRealTimers();
 		}
 	});
+
+	test('handle429 falls back to the Retry-After header for a non-JSON response', async () => {
+		vi.useFakeTimers();
+		try {
+			const { api, next, request, requestSpy, retried } = createRetryScenario();
+			api.ratelimits.set(route, new Bucket(1));
+			const response = new Response('rate limited', {
+				status: 429,
+				headers: { 'retry-after': '0.001' },
+			});
+			const retry = api.handle429(
+				route,
+				method,
+				url,
+				request,
+				response,
+				'rate limited',
+				next,
+				vi.fn(),
+				Date.now(),
+				url,
+			);
+
+			await flushRetryContinuations();
+			expect(requestSpy).not.toHaveBeenCalled();
+			expect(next).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(1);
+
+			await expect(retry).resolves.toBe(retried);
+			expect(next).toHaveBeenCalledTimes(1);
+			expectRequestOptionsPreserved(requestSpy, request);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test('handle429 rejects cleanly when a non-JSON response has no retry delay', async () => {
+		const { api, next, request } = createRetryScenario();
+		api.ratelimits.set(route, new Bucket(1));
+		const reject = vi.fn();
+		const response = new Response('', { status: 429 });
+		const retry = api.handle429(route, method, url, request, response, '', next, reject, Date.now(), url);
+
+		await expect(retry).resolves.toBe(false);
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(reject).toHaveBeenCalledOnce();
+		expect(reject).toHaveBeenCalledWith(
+			expect.objectContaining({
+				code: 'INVALID_RETRY_AFTER',
+			}),
+		);
+	});
 });


### PR DESCRIPTION
## Summary

- Safely handle malformed, empty, and non-JSON Discord 429 response bodies.
- Fall back to `x-ratelimit-reset-after` and `Retry-After` headers when the response body does not provide a usable delay.
- Preserve zero-delay retries and existing request options.
- Return `INVALID_RETRY_AFTER` when no valid retry delay can be determined.

## Testing

- TypeScript build and consumer type contracts
- Full Node test suite: 46 files, 333 tests
- REST retry regression tests
- Biome source checks
- Bun build and test suite