### PR TITLE
fix: correct interaction and custom event resolution

### DIFF
--- a/src/client/collectors.ts
+++ b/src/client/collectors.ts
@@ -1,7 +1,13 @@
 import { randomUUID, type UUID } from 'node:crypto';
 import type { UsingClient } from '../commands';
 import { type Awaitable, type CamelCase, ReplaceRegex } from '../common';
-import type { CallbackEventHandler, ClientNameEvents, CustomEventsKeys, GatewayEvents } from '../events';
+import type {
+	CallbackEventHandler,
+	ClientNameEvents,
+	CustomEventsKeys,
+	GatewayEvents,
+	ResolveEventRunParams,
+} from '../events';
 import { resolveRawEventData } from '../events/utils';
 
 export type AllClientEvents = CustomEventsKeys | ClientNameEvents;
@@ -94,14 +100,19 @@ export class Collectors {
 	/**@internal */
 	async run<T extends ClientDispatchEvent>(
 		name: T,
-		raw: Awaited<Parameters<CallbackEventHandler[ParseClientEventName<T>]>[0]>,
+		raw: T extends CustomEventsKeys
+			? ResolveEventRunParams<T>
+			: Awaited<Parameters<CallbackEventHandler[ParseClientEventName<T>]>[0]>,
 		client: UsingClient,
 	) {
 		const event = normalizeCollectorEventName(name);
 		const collectors = this.values.get(event);
 		if (!collectors) return;
 
-		const data = (await resolveRawEventData(name, client, raw)) ?? raw;
+		const resolved = (await resolveRawEventData(name, client, raw)) ?? raw;
+		// Custom events are dispatched as a rest tuple; collectors receive the first argument,
+		// matching CollectorRunParameters. Gateway/raw events pass a single payload object.
+		const data = Array.isArray(resolved) ? resolved[0] : resolved;
 
 		for (const i of [...collectors]) {
 			if (await i.options.filter(data as never)) {

--- a/src/client/collectors.ts
+++ b/src/client/collectors.ts
@@ -14,9 +14,9 @@ export type AllClientEvents = CustomEventsKeys | ClientNameEvents;
 type ClientDispatchEvent = AllClientEvents | GatewayEvents;
 export type ParseClientEventName<T extends ClientDispatchEvent> = T extends GatewayEvents ? CamelCase<T> : T;
 
-export type CollectorRunParameters<T extends AllClientEvents> = Awaited<
-	Parameters<CallbackEventHandler[ParseClientEventName<T>]>[0]
->;
+export type CollectorRunParameters<T extends AllClientEvents> = T extends CustomEventsKeys
+	? ResolveEventRunParams<T>
+	: Awaited<Parameters<CallbackEventHandler[ParseClientEventName<T>]>[0]>;
 
 type RunData<T extends AllClientEvents> = {
 	options: {
@@ -109,10 +109,7 @@ export class Collectors {
 		const collectors = this.values.get(event);
 		if (!collectors) return;
 
-		const resolved = (await resolveRawEventData(name, client, raw)) ?? raw;
-		// Custom events are dispatched as a rest tuple; collectors receive the first argument,
-		// matching CollectorRunParameters. Gateway/raw events pass a single payload object.
-		const data = Array.isArray(resolved) ? resolved[0] : resolved;
+		const data = (await resolveRawEventData(name, client, raw)) ?? raw;
 
 		for (const i of [...collectors]) {
 			if (await i.options.filter(data as never)) {

--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -102,13 +102,13 @@ export class CustomEventHandler extends BaseHandler implements CustomEventRunner
 		const Event = this.values[name];
 		try {
 			if ((!Event || (Event.data.once && Event.fired)) && !listeners.length && !anyListeners.length) {
-				await this.runCollectors(name, args[0]);
+				await this.runCollectors(name, args);
 				return;
 			}
 			this.client.debugger?.debug(`executed a custom event [${name}]`, Event?.data.once ? 'once' : '');
 
 			const tasks: Promise<unknown>[] = [];
-			const collectors = this.runCollectors(name, args[0]);
+			const collectors = this.runCollectors(name, args);
 			if (collectors) tasks.push(Promise.resolve(collectors));
 			if (Event && !(Event.data.once && Event.fired)) {
 				if (Event.data.once) {

--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -102,13 +102,13 @@ export class CustomEventHandler extends BaseHandler implements CustomEventRunner
 		const Event = this.values[name];
 		try {
 			if ((!Event || (Event.data.once && Event.fired)) && !listeners.length && !anyListeners.length) {
-				await this.runCollectors(name, args);
+				await this.runCollectors(name, args[0]);
 				return;
 			}
 			this.client.debugger?.debug(`executed a custom event [${name}]`, Event?.data.once ? 'once' : '');
 
 			const tasks: Promise<unknown>[] = [];
-			const collectors = this.runCollectors(name, args);
+			const collectors = this.runCollectors(name, args[0]);
 			if (collectors) tasks.push(Promise.resolve(collectors));
 			if (Event && !(Event.data.once && Event.fired)) {
 				if (Event.data.once) {

--- a/src/structures/GuildTemplate.ts
+++ b/src/structures/GuildTemplate.ts
@@ -28,7 +28,7 @@ export class GuildTemplate extends Base {
 	}
 
 	fetch(): Promise<GuildTemplateStructure> {
-		return this.client.templates.fetch(this.sourceGuildId);
+		return this.client.templates.fetch(this.code);
 	}
 
 	sync(): Promise<GuildTemplateStructure> {

--- a/src/structures/Interaction.ts
+++ b/src/structures/Interaction.ts
@@ -1050,11 +1050,11 @@ export class ModalSubmitInteraction<FromGuild extends boolean = boolean> extends
 	getFiles(customId: string, required: true): Attachment[];
 	getFiles(customId: string, required?: false): Attachment[] | undefined;
 	getFiles(customId: string, required?: boolean): Attachment[] | undefined {
-		const value = this.getComponent(customId, [ComponentType.FileUpload]);
-		if (value && 'values' in value) {
+		const component = this.getComponent(customId, [ComponentType.FileUpload]);
+		if (component && 'values' in component) {
 			const attachments = this.data.resolved?.attachments;
 			if (attachments) {
-				return value.values
+				return component.values
 					.map(x => attachments[x])
 					.filter((x): x is (typeof attachments)[string] => !!x)
 					.map(x => new Attachment(this.client, { ...x, proxy_url: x.url }));

--- a/src/structures/Interaction.ts
+++ b/src/structures/Interaction.ts
@@ -776,20 +776,17 @@ export class MentionableSelectMenuInteraction extends SelectMenuInteraction {
 	) {
 		super(client, interaction);
 		const resolved = (interaction.data as APIMessageMentionableSelectInteractionData).resolved;
-		this.roles = resolved.roles
-			? this.values.map(x => Transformers.GuildRole(this.client, resolved.roles![x], this.guildId!))
-			: [];
-		this.members = resolved.members
-			? this.values.map(x =>
-					Transformers.InteractionGuildMember(
-						this.client,
-						resolved.members![x],
-						resolved.users![this.values!.find(u => u === x)!]!,
-						this.guildId!,
-					),
-				)
-			: [];
-		this.users = resolved.users ? this.values.map(x => Transformers.User(this.client, resolved.users![x])) : [];
+		this.roles = this.values
+			.filter(x => resolved.roles?.[x])
+			.map(x => Transformers.GuildRole(this.client, resolved.roles![x]!, this.guildId!));
+		this.members = this.values
+			.filter(x => resolved.members?.[x])
+			.map(x =>
+				Transformers.InteractionGuildMember(this.client, resolved.members![x]!, resolved.users![x]!, this.guildId!),
+			);
+		this.users = this.values
+			.filter(x => resolved.users?.[x])
+			.map(x => Transformers.User(this.client, resolved.users![x]!));
 	}
 
 	isMentionableSelectMenu(): this is MentionableSelectMenuInteraction {
@@ -827,16 +824,11 @@ export class UserSelectMenuInteraction extends SelectMenuInteraction {
 		super(client, interaction);
 		const resolved = (interaction.data as APIMessageUserSelectInteractionData).resolved;
 		this.users = this.values.map(x => Transformers.User(this.client, resolved.users[x]));
-		this.members = resolved.members
-			? this.values.map(x =>
-					Transformers.InteractionGuildMember(
-						this.client,
-						resolved.members![x],
-						resolved.users[this.values!.find(u => u === x)!]!,
-						this.guildId!,
-					),
-				)
-			: [];
+		this.members = this.values
+			.filter(x => resolved.members?.[x])
+			.map(x =>
+				Transformers.InteractionGuildMember(this.client, resolved.members![x]!, resolved.users[x]!, this.guildId!),
+			);
 	}
 
 	isUserSelectMenu(): this is UserSelectMenuInteraction {
@@ -1059,16 +1051,13 @@ export class ModalSubmitInteraction<FromGuild extends boolean = boolean> extends
 	getFiles(customId: string, required?: false): Attachment[] | undefined;
 	getFiles(customId: string, required?: boolean): Attachment[] | undefined {
 		const value = this.getComponent(customId, [ComponentType.FileUpload]);
-		if (value) {
+		if (value && 'values' in value) {
 			const attachments = this.data.resolved?.attachments;
 			if (attachments) {
-				return Object.values(attachments).map(
-					x =>
-						new Attachment(this.client, {
-							...x,
-							proxy_url: x.url,
-						}),
-				);
+				return value.values
+					.map(x => attachments[x])
+					.filter((x): x is (typeof attachments)[string] => !!x)
+					.map(x => new Attachment(this.client, { ...x, proxy_url: x.url }));
 			}
 			if (required)
 				throw new SeyfertError('INTERNAL_ERROR', {

--- a/tests/client-collectors.test.mts
+++ b/tests/client-collectors.test.mts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
+import { Client } from '../src/client';
 import { Collectors } from '../src/client/collectors';
 import type { GatewayDispatchPayload } from '../src/types';
 
@@ -31,5 +32,27 @@ describe('client collectors', () => {
 		expect(run).toHaveBeenCalledWith(packet, expect.any(Function));
 		expect(collectors.values.get('raw')).toHaveLength(0);
 		expect(collectors.values.has('RAW' as never)).toBe(false);
+	});
+
+	test('passes the first argument to custom-event collectors', async () => {
+		const client = new Client({ getRC: async () => ({ locations: {} }), plugins: [] } as never);
+		const seen: unknown[] = [];
+		client.collectors.create({
+			event: 'commandsLoaded',
+			filter(arg) {
+				seen.push(arg);
+				return true;
+			},
+			run: () => {},
+		});
+		await client.events.runCustom('commandsLoaded', {
+			kind: 'commands',
+			total: 0,
+			items: [],
+			plugin: { total: 0, sources: {} },
+		});
+		expect(seen).toEqual([
+			{ kind: 'commands', total: 0, items: [], plugin: { total: 0, sources: {} } },
+		]);
 	});
 });

--- a/tests/client-collectors.test.mts
+++ b/tests/client-collectors.test.mts
@@ -34,7 +34,7 @@ describe('client collectors', () => {
 		expect(collectors.values.has('RAW' as never)).toBe(false);
 	});
 
-	test('passes the first argument to custom-event collectors', async () => {
+	test('passes custom-event arguments as a tuple', async () => {
 		const client = new Client({ getRC: async () => ({ locations: {} }), plugins: [] } as never);
 		const seen: unknown[] = [];
 		client.collectors.create({
@@ -52,7 +52,27 @@ describe('client collectors', () => {
 			plugin: { total: 0, sources: {} },
 		});
 		expect(seen).toEqual([
-			{ kind: 'commands', total: 0, items: [], plugin: { total: 0, sources: {} } },
+			[{ kind: 'commands', total: 0, items: [], plugin: { total: 0, sources: {} } }],
 		]);
+	});
+
+	test('preserves tuple payloads from gateway event transformers', async () => {
+		const collectors = new Collectors();
+		const oldUser = { id: 'u1' };
+		const seen: unknown[] = [];
+		collectors.create({
+			event: 'userUpdate',
+			filter(value) {
+				seen.push(value);
+				return true;
+			},
+			run: () => {},
+		});
+		await collectors.run(
+			'USER_UPDATE',
+			{ id: 'u1', username: 'updated', discriminator: '0', avatar: null } as never,
+			{ cache: { users: { get: async () => oldUser } } } as never,
+		);
+		expect(seen).toEqual([[expect.objectContaining({ id: 'u1', username: 'updated' }), oldUser]]);
 	});
 });

--- a/tests/guild-template.test.mts
+++ b/tests/guild-template.test.mts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest';
+import { GuildTemplate } from '../src/structures';
+
+describe('GuildTemplate', () => {
+	test('fetch requests the template code, not the source guild id', async () => {
+		const codes: string[] = [];
+		const template = new GuildTemplate(
+			{
+				templates: {
+					fetch: (code: string) => {
+						codes.push(code);
+						return Promise.resolve({} as never);
+					},
+				},
+			} as never,
+			{
+				code: 'Rr72fMx2pPnz',
+				name: 't',
+				description: null,
+				usage_count: 1,
+				creator_id: '1',
+				created_at: '2020',
+				updated_at: '2020',
+				source_guild_id: '100000000000000000',
+				serialized_source_guild: {},
+				is_dirty: null,
+			} as never,
+		);
+		await template.fetch();
+		expect(codes).toEqual(['Rr72fMx2pPnz']);
+	});
+});

--- a/tests/interaction-structure.test.mts
+++ b/tests/interaction-structure.test.mts
@@ -1,19 +1,34 @@
 import { describe, expect, test } from 'vitest';
 import {
-	GuildTemplate,
 	MentionableSelectMenuInteraction,
 	ModalSubmitInteraction,
 	UserSelectMenuInteraction,
 } from '../src/structures';
 
-const memberData = { user: { id: 'u1' }, roles: [], permissions: '0' };
+const guildId = '100000000000000000';
 
-function interactionData(data: unknown, topMember = memberData) {
+// Top-level guild interaction member, as Discord sends it (the nested user is included).
+const topLevelMember = {
+	user: { id: 'u1', username: 'top' },
+	roles: [],
+	permissions: '0',
+};
+
+// Resolved guild members omit the user; the user is delivered separately in resolved.users.
+const resolvedMember = {
+	roles: [],
+	permissions: '0',
+};
+
+const resolvedUser = { id: 'u1', username: 'u' };
+
+function interactionData(data: unknown, member = topLevelMember) {
 	return {
 		id: '1',
+		guild_id: guildId,
 		token: 't',
 		user: { id: 'u1' },
-		member: topMember,
+		member,
 		entitlements: [],
 		app_permissions: '0',
 		channel: { id: 'c1' },
@@ -33,8 +48,8 @@ describe('interaction structure resolution', () => {
 				values: ['r1', 'u1'],
 				resolved: {
 					roles: { r1: { id: 'r1', name: 'role', permissions: '0' } },
-					members: { u1: memberData },
-					users: { u1: { id: 'u1', username: 'u' } },
+					members: { u1: resolvedMember },
+					users: { u1: resolvedUser },
 				},
 			}),
 		);
@@ -51,7 +66,7 @@ describe('interaction structure resolution', () => {
 				custom_id: 'u',
 				values: ['u1', 'u2'],
 				resolved: {
-					members: { u1: memberData },
+					members: { u1: resolvedMember },
 					users: {
 						u1: { id: 'u1', username: 'a' },
 						u2: { id: 'u2', username: 'b' },
@@ -66,53 +81,22 @@ describe('interaction structure resolution', () => {
 	test('getFiles returns only the attachments of the requested component', () => {
 		const modal = new ModalSubmitInteraction(
 			{ cache: {} } as never,
-			interactionData(
-				{
-					custom_id: 'modal',
-					components: [
-						{ type: 18, component: { type: 19, custom_id: 'uploadA', values: ['a1'] } },
-						{ type: 18, component: { type: 19, custom_id: 'uploadB', values: ['b1'] } },
-					],
-					resolved: {
-						attachments: {
-							a1: { id: 'a1', url: 'http://a', filename: 'a.png', size: 1 },
-							b1: { id: 'b1', url: 'http://b', filename: 'b.png', size: 1 },
-						},
+			interactionData({
+				custom_id: 'modal',
+				components: [
+					{ type: 18, component: { type: 19, custom_id: 'uploadA', values: ['a1'] } },
+					{ type: 18, component: { type: 19, custom_id: 'uploadB', values: ['b1'] } },
+				],
+				resolved: {
+					attachments: {
+						a1: { id: 'a1', url: 'http://a', filename: 'a.png', size: 1 },
+						b1: { id: 'b1', url: 'http://b', filename: 'b.png', size: 1 },
 					},
 				},
-				undefined,
-			),
+			}),
 			undefined as never,
 		);
 		expect(modal.getFiles('uploadA')?.map(f => f.id)).toEqual(['a1']);
 		expect(modal.getFiles('uploadB')?.map(f => f.id)).toEqual(['b1']);
-	});
-
-	test('GuildTemplate.fetch requests the template code, not the source guild id', async () => {
-		const codes: string[] = [];
-		const template = new GuildTemplate(
-			{
-				templates: {
-					fetch: (code: string) => {
-						codes.push(code);
-						return Promise.resolve({} as never);
-					},
-				},
-			} as never,
-			{
-				code: 'Rr72fMx2pPnz',
-				name: 't',
-				description: null,
-				usage_count: 1,
-				creator_id: '1',
-				created_at: '2020',
-				updated_at: '2020',
-				source_guild_id: '100000000000000000',
-				serialized_source_guild: {},
-				is_dirty: null,
-			} as never,
-		);
-		await template.fetch();
-		expect(codes).toEqual(['Rr72fMx2pPnz']);
 	});
 });

--- a/tests/interaction-structure.test.mts
+++ b/tests/interaction-structure.test.mts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'vitest';
+import {
+	GuildTemplate,
+	MentionableSelectMenuInteraction,
+	ModalSubmitInteraction,
+	UserSelectMenuInteraction,
+} from '../src/structures';
+
+const memberData = { user: { id: 'u1' }, roles: [], permissions: '0' };
+
+function interactionData(data: unknown, topMember = memberData) {
+	return {
+		id: '1',
+		token: 't',
+		user: { id: 'u1' },
+		member: topMember,
+		entitlements: [],
+		app_permissions: '0',
+		channel: { id: 'c1' },
+		channel_id: 'c1',
+		message: undefined,
+		data,
+	} as never;
+}
+
+describe('interaction structure resolution', () => {
+	test('mentionable select maps values only to their own resolved maps', () => {
+		const menu = new MentionableSelectMenuInteraction(
+			{ cache: {} } as never,
+			interactionData({
+				component_type: 7,
+				custom_id: 'm',
+				values: ['r1', 'u1'],
+				resolved: {
+					roles: { r1: { id: 'r1', name: 'role', permissions: '0' } },
+					members: { u1: memberData },
+					users: { u1: { id: 'u1', username: 'u' } },
+				},
+			}),
+		);
+		expect(menu.roles.map(r => r.id)).toEqual(['r1']);
+		expect(menu.members.map(m => m.user.id)).toEqual(['u1']);
+		expect(menu.users.map(u => u.id)).toEqual(['u1']);
+	});
+
+	test('user select omits selected users that are not guild members', () => {
+		const menu = new UserSelectMenuInteraction(
+			{ cache: {} } as never,
+			interactionData({
+				component_type: 5,
+				custom_id: 'u',
+				values: ['u1', 'u2'],
+				resolved: {
+					members: { u1: memberData },
+					users: {
+						u1: { id: 'u1', username: 'a' },
+						u2: { id: 'u2', username: 'b' },
+					},
+				},
+			}),
+		);
+		expect(menu.users.map(u => u.id)).toEqual(['u1', 'u2']);
+		expect(menu.members.map(m => m.user.id)).toEqual(['u1']);
+	});
+
+	test('getFiles returns only the attachments of the requested component', () => {
+		const modal = new ModalSubmitInteraction(
+			{ cache: {} } as never,
+			interactionData(
+				{
+					custom_id: 'modal',
+					components: [
+						{ type: 18, component: { type: 19, custom_id: 'uploadA', values: ['a1'] } },
+						{ type: 18, component: { type: 19, custom_id: 'uploadB', values: ['b1'] } },
+					],
+					resolved: {
+						attachments: {
+							a1: { id: 'a1', url: 'http://a', filename: 'a.png', size: 1 },
+							b1: { id: 'b1', url: 'http://b', filename: 'b.png', size: 1 },
+						},
+					},
+				},
+				undefined,
+			),
+			undefined as never,
+		);
+		expect(modal.getFiles('uploadA')?.map(f => f.id)).toEqual(['a1']);
+		expect(modal.getFiles('uploadB')?.map(f => f.id)).toEqual(['b1']);
+	});
+
+	test('GuildTemplate.fetch requests the template code, not the source guild id', async () => {
+		const codes: string[] = [];
+		const template = new GuildTemplate(
+			{
+				templates: {
+					fetch: (code: string) => {
+						codes.push(code);
+						return Promise.resolve({} as never);
+					},
+				},
+			} as never,
+			{
+				code: 'Rr72fMx2pPnz',
+				name: 't',
+				description: null,
+				usage_count: 1,
+				creator_id: '1',
+				created_at: '2020',
+				updated_at: '2020',
+				source_guild_id: '100000000000000000',
+				serialized_source_guild: {},
+				is_dirty: null,
+			} as never,
+		);
+		await template.fetch();
+		expect(codes).toEqual(['Rr72fMx2pPnz']);
+	});
+});

--- a/tests/interaction-structure.test.mts
+++ b/tests/interaction-structure.test.mts
@@ -27,7 +27,6 @@ function interactionData(data: unknown, member = topLevelMember) {
 		id: '1',
 		guild_id: guildId,
 		token: 't',
-		user: { id: 'u1' },
 		member,
 		entitlements: [],
 		app_permissions: '0',

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -1397,6 +1397,12 @@ collectorClient.collectors.create({
 const exportedCollectorsContract = new Collectors();
 expectType<Collectors>(exportedCollectorsContract);
 expectType<MessageStructure>(undefined as never as CollectorRunParameters<'messageCreate'>);
+expectType<CollectorRunParameters<'commandsLoaded'>>(
+	undefined as never as [CommandsLoadedCallbackParams[0]],
+);
+expectType<[CommandsLoadedCallbackParams[0]]>(
+	undefined as never as CollectorRunParameters<'commandsLoaded'>,
+);
 // @ts-expect-error collector run parameters are keyed by camelCase event names.
 type ScreamingCollectorRunParameters = CollectorRunParameters<'MESSAGE_CREATE'>;
 // @ts-expect-error typo alias is intentionally not exported.


### PR DESCRIPTION
- GuildTemplate.fetch() requests the template code instead of sourceGuildId
- mentionable and user select menus only map values present in their resolved data, avoiding crashes on mixed or non-guild selections
- ModalSubmitInteraction.getFiles() returns only the requested component's attachments instead of every resolved attachment
- custom-event collectors receive the first argument, matching their declared CollectorRunParameters contract