### PR TITLE
fix(api): prevent malformed rate-limit headers from bypassing throttling

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -699,24 +699,35 @@ export class ApiHandler<TClient = unknown> {
 	}
 
 	setRatelimitsBucket(route: string, resp: Response) {
-		if (resp.headers.has('x-ratelimit-limit')) {
-			this.ratelimits.get(route)!.limit = +resp.headers.get('x-ratelimit-limit')!;
+		const bucket = this.ratelimits.get(route)!;
+		const rawLimit = resp.headers.get('x-ratelimit-limit');
+		const limit = rawLimit === null ? undefined : Number(rawLimit);
+		if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+			bucket.limit = limit;
 		}
 
 		const raw = resp.headers.get('x-ratelimit-remaining');
-		this.ratelimits.get(route)!.remaining = raw != null ? +raw : 1;
+		if (raw === null) {
+			bucket.remaining = 1;
+		} else {
+			const remaining = Number(raw);
+			if (Number.isFinite(remaining) && remaining >= 0) {
+				bucket.remaining = Math.min(remaining, bucket.limit);
+			}
+		}
 
 		if (this.options.smartBucket) {
 			if (
 				resp.headers.has('x-ratelimit-reset-after') &&
-				!this.ratelimits.get(route)!.resetAfter &&
+				!bucket.resetAfter &&
 				Number(resp.headers.get('x-ratelimit-limit')) === Number(resp.headers.get('x-ratelimit-remaining')) + 1
 			) {
-				this.ratelimits.get(route)!.resetAfter = +resp.headers.get('x-ratelimit-reset-after')! * 1000;
+				const resetAfter = Number(resp.headers.get('x-ratelimit-reset-after'));
+				if (Number.isFinite(resetAfter) && resetAfter >= 0) bucket.resetAfter = resetAfter * 1000;
 			}
 
-			if (this.ratelimits.get(route)!.resetAfter && !this.ratelimits.get(route)!.remaining) {
-				this.ratelimits.get(route)!.triggerResetAfter();
+			if (bucket.resetAfter && !bucket.remaining) {
+				bucket.triggerResetAfter();
 			}
 		}
 	}
@@ -828,7 +839,7 @@ export type RestArguments<
 	| {
 			body: B;
 			files?: F;
-	  }
+		}
 	| (Q extends never | undefined
 			? {}
 			: {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -59,6 +59,24 @@ export type OnFailRequestCallback = (
 ) => Awaitable<any>;
 type InternalApiRequestOptions = ApiRequestOptions & { _50xRetries?: number };
 
+// JavaScript timers use a signed 32-bit millisecond delay.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MAX_BUCKET_RESET_DELAY_MS = MAX_TIMER_DELAY_MS - 1;
+const MAX_SMART_BUCKET_RESET_AFTER_MS = Math.floor(MAX_TIMER_DELAY_MS / 1.5);
+
+function parseRateLimitCount(raw: string | null, minimum: number): null | number | undefined {
+	if (raw === null) return;
+	if (!/^\d+$/.test(raw)) return null;
+	const value = Number(raw);
+	return Number.isSafeInteger(value) && value >= minimum ? value : null;
+}
+
+function parseRateLimitDelay(value: number | string | null): number | undefined {
+	if (value === null || (typeof value === 'string' && value.trim() === '')) return;
+	const milliseconds = Number(value) * 1000;
+	return Number.isFinite(milliseconds) && milliseconds >= 0 ? milliseconds : undefined;
+}
+
 export class ApiHandler<TClient = unknown> {
 	options: ApiHandlerInternalOptions;
 	globalBlock = false;
@@ -618,15 +636,14 @@ export class ApiHandler<TClient = unknown> {
 			const parsed: unknown = JSON.parse(result);
 			if (isPlainObject(parsed)) data = parsed;
 		} catch {}
-		if (typeof data?.retry_after === 'number' && Number.isFinite(data.retry_after) && data.retry_after >= 0) {
-			retryAfter = Math.ceil(data.retry_after * 1000);
+		if (typeof data?.retry_after === 'number') {
+			const value = parseRateLimitDelay(data.retry_after);
+			if (value !== undefined && value <= MAX_TIMER_DELAY_MS) retryAfter = Math.ceil(value);
 		}
 		for (const header of ['retry-after', 'x-ratelimit-reset-after']) {
 			if (retryAfter !== undefined) break;
-			const raw = response.headers.get(header);
-			if (raw === null || raw.trim() === '') continue;
-			const value = Number(raw) * 1000;
-			if (Number.isFinite(value) && value >= 0) retryAfter = value;
+			const value = parseRateLimitDelay(response.headers.get(header));
+			if (value !== undefined && value <= MAX_TIMER_DELAY_MS) retryAfter = value;
 		}
 
 		if (retryAfter === undefined) {
@@ -679,51 +696,48 @@ export class ApiHandler<TClient = unknown> {
 	}
 
 	setResetBucket(route: string, resp: Response, now: number, headerNow: number, normalizedRoute = route) {
+		const bucket = this.ratelimits.get(route)!;
 		const retryAfterHeader = resp.headers.get('x-ratelimit-reset-after') ?? resp.headers.get('retry-after');
-		const retryAfter = retryAfterHeader === null ? undefined : Number(retryAfterHeader) * 1000;
+		const retryAfter = parseRateLimitDelay(retryAfterHeader);
 
-		if (retryAfter !== undefined && Number.isFinite(retryAfter) && retryAfter >= 0) {
-			this.ratelimits.get(route)!.reset = (retryAfter || 1) + now;
-		} else if (resp.headers.get('x-ratelimit-reset')) {
-			let resetTime = +resp.headers.get('x-ratelimit-reset')! * 1000;
-			if (
-				normalizedRoute.endsWith('/reactions/:id') &&
-				+resp.headers.get('x-ratelimit-reset')! * 1000 - headerNow === 1000
-			) {
+		if (retryAfter !== undefined) {
+			bucket.reset = Math.min(retryAfter || 1, MAX_BUCKET_RESET_DELAY_MS) + now;
+		} else {
+			const resetHeader = resp.headers.get('x-ratelimit-reset');
+			const parsedReset = parseRateLimitDelay(resetHeader);
+			if (parsedReset === undefined) {
+				if (retryAfterHeader === null && resetHeader === null) bucket.reset = now;
+				return;
+			}
+
+			let resetTime = parsedReset;
+			if (normalizedRoute.endsWith('/reactions/:id') && resetTime - headerNow === 1000) {
 				resetTime = now + 250;
 			}
-			this.ratelimits.get(route)!.reset = Math.max(resetTime, now);
-		} else {
-			this.ratelimits.get(route)!.reset = now;
+			bucket.reset = Math.min(Math.max(resetTime, now), now + MAX_BUCKET_RESET_DELAY_MS);
 		}
 	}
 
 	setRatelimitsBucket(route: string, resp: Response) {
 		const bucket = this.ratelimits.get(route)!;
-		const rawLimit = resp.headers.get('x-ratelimit-limit');
-		const limit = rawLimit === null ? undefined : Number(rawLimit);
-		if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+		const limit = parseRateLimitCount(resp.headers.get('x-ratelimit-limit'), 1);
+		const remaining = parseRateLimitCount(resp.headers.get('x-ratelimit-remaining'), 0);
+		if (limit !== null && limit !== undefined) {
 			bucket.limit = limit;
+			bucket.remaining = Math.min(bucket.remaining, limit);
 		}
-
-		const raw = resp.headers.get('x-ratelimit-remaining');
-		if (raw === null) {
-			bucket.remaining = 1;
-		} else {
-			const remaining = Number(raw);
-			if (Number.isFinite(remaining) && remaining >= 0) {
-				bucket.remaining = Math.min(remaining, bucket.limit);
-			}
+		if (remaining === undefined) {
+			bucket.remaining = Math.min(1, bucket.limit);
+		} else if (remaining !== null) {
+			bucket.remaining = Math.min(remaining, bucket.limit);
 		}
 
 		if (this.options.smartBucket) {
-			if (
-				resp.headers.has('x-ratelimit-reset-after') &&
-				!bucket.resetAfter &&
-				Number(resp.headers.get('x-ratelimit-limit')) === Number(resp.headers.get('x-ratelimit-remaining')) + 1
-			) {
-				const resetAfter = Number(resp.headers.get('x-ratelimit-reset-after'));
-				if (Number.isFinite(resetAfter) && resetAfter >= 0) bucket.resetAfter = resetAfter * 1000;
+			if (typeof limit === 'number' && typeof remaining === 'number' && !bucket.resetAfter && limit === remaining + 1) {
+				const resetAfter = parseRateLimitDelay(resp.headers.get('x-ratelimit-reset-after'));
+				if (resetAfter !== undefined && resetAfter <= MAX_SMART_BUCKET_RESET_AFTER_MS) {
+					bucket.resetAfter = resetAfter;
+				}
 			}
 
 			if (bucket.resetAfter && !bucket.remaining) {
@@ -839,7 +853,7 @@ export type RestArguments<
 	| {
 			body: B;
 			files?: F;
-		}
+	  }
 	| (Q extends never | undefined
 			? {}
 			: {

--- a/tests/rest-rate-limit.test.mts
+++ b/tests/rest-rate-limit.test.mts
@@ -365,34 +365,37 @@ describe('Discord REST rate limits', () => {
 		expect(queuedDispatch).toHaveBeenCalledOnce();
 	});
 
-	test('rejects a 429 without a valid retry delay and releases the bucket', async () => {
-		const api = createApi();
-		const route = 'GET:/channels/100000000000000001/messages';
-		const url = '/channels/100000000000000001/messages' as const;
-		const next = vi.fn();
-		const reject = vi.fn();
-		api.ratelimits.set(route, new Bucket(1));
+	test.each(['not-a-number', String(Number.MAX_VALUE)])(
+		'rejects a 429 without a valid retry delay (%s) and releases the bucket',
+		async retryAfter => {
+			const api = createApi();
+			const route = 'GET:/channels/100000000000000001/messages';
+			const url = '/channels/100000000000000001/messages' as const;
+			const next = vi.fn();
+			const reject = vi.fn();
+			api.ratelimits.set(route, new Bucket(1));
 
-		const result = await api.handle429(
-			route,
-			'GET',
-			url,
-			{},
-			new Response('<html>rate limited</html>', {
-				status: 429,
-				headers: { 'retry-after': 'not-a-number' },
-			}),
-			'<html>rate limited</html>',
-			next,
-			reject,
-			Date.now(),
-			url,
-		);
+			const result = await api.handle429(
+				route,
+				'GET',
+				url,
+				{},
+				new Response('<html>rate limited</html>', {
+					status: 429,
+					headers: { 'retry-after': retryAfter },
+				}),
+				'<html>rate limited</html>',
+				next,
+				reject,
+				Date.now(),
+				url,
+			);
 
-		expect(result).toBe(false);
-		expect(next).toHaveBeenCalledOnce();
-		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
-	});
+			expect(result).toBe(false);
+			expect(next).toHaveBeenCalledOnce();
+			expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
+		},
+	);
 
 	test('rejects an empty 429 response without a retry delay', async () => {
 		const api = createApi();
@@ -420,11 +423,75 @@ describe('Discord REST rate limits', () => {
 		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
 	});
 
-	test('does not disable throttling when rate-limit headers are malformed', () => {
+	test('keeps queued requests throttled when bucket counts are malformed', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_700_000_000_000);
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response('{}', {
+					headers: {
+						'content-type': 'application/json',
+						'x-ratelimit-limit': 'not-a-number',
+						'x-ratelimit-remaining': 'not-a-number',
+						'x-ratelimit-reset-after': '0.05',
+					},
+				}),
+			)
+			.mockResolvedValue(new Response('{}', { headers: { 'content-type': 'application/json' } }));
+		vi.stubGlobal('fetch', fetchMock);
+		const api = createApi();
+		const route = '/channels/100000000000000001/messages' as const;
+
+		const first = api.request('GET', route);
+		const queued = api.request('GET', route);
+		await first;
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(50);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1);
+		await expect(queued).resolves.toEqual({});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test.each([
+		['2', 'not-a-number', 2, 2],
+		['1.5', '0', 10, 0],
+		['2', '', 2, 2],
+		[String(Number.MAX_SAFE_INTEGER + 1), '0', 10, 0],
+	])('applies the valid rate-limit counts from (%s, %s)', (limit, remaining, expectedLimit, expectedRemaining) => {
 		const api = createApi();
 		const route = 'GET:/channels/100000000000000001/messages';
-		const bucket = new Bucket(1);
-		bucket.remaining = 0;
+		const bucket = new Bucket(10);
+		bucket.remaining = 8;
+		api.ratelimits.set(route, bucket);
+
+		api.setRatelimitsBucket(
+			route,
+			new Response('{}', {
+				headers: {
+					'x-ratelimit-limit': limit,
+					'x-ratelimit-remaining': remaining,
+				},
+			}),
+		);
+
+		expect(bucket.limit).toBe(expectedLimit);
+		expect(bucket.remaining).toBe(expectedRemaining);
+	});
+
+	test('honors an exhausted remaining count when its limit is malformed', () => {
+		vi.useFakeTimers();
+		const now = 1_700_000_000_000;
+		vi.setSystemTime(now);
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const bucket = new Bucket(10);
+		const dispatch = vi.fn((next: () => void) => next());
+		bucket.remaining = 8;
+		bucket.reset = now + 100;
 		api.ratelimits.set(route, bucket);
 
 		api.setRatelimitsBucket(
@@ -432,18 +499,20 @@ describe('Discord REST rate limits', () => {
 			new Response('{}', {
 				headers: {
 					'x-ratelimit-limit': 'not-a-number',
-					'x-ratelimit-remaining': 'not-a-number',
-					'x-ratelimit-reset-after': 'not-a-number',
+					'x-ratelimit-remaining': '0',
 				},
 			}),
 		);
+		bucket.push({ next: dispatch, resolve: vi.fn(), reject: vi.fn() });
 
-		expect(bucket.limit).toBe(1);
-		expect(bucket.remaining).toBe(0);
-		expect(bucket.resetAfter).toBe(0);
+		expect(dispatch).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(100);
+		expect(dispatch).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(dispatch).toHaveBeenCalledOnce();
 	});
 
-	test('caps an invalid remaining value above the advertised limit', () => {
+	test('caps a remaining count above the advertised limit', () => {
 		const api = createApi();
 		const route = 'GET:/channels/100000000000000001/messages';
 		const bucket = new Bucket(1);
@@ -461,5 +530,51 @@ describe('Discord REST rate limits', () => {
 
 		expect(bucket.limit).toBe(2);
 		expect(bucket.remaining).toBe(2);
+	});
+
+	test('ignores smart-bucket reset durations that overflow the timer range', () => {
+		const api = new ApiHandler({ token: 'bot-token', domain: 'https://discord.example', smartBucket: true });
+		const route = 'GET:/channels/100000000000000001/messages';
+		const bucket = new Bucket(1);
+		bucket.remaining = 0;
+		api.ratelimits.set(route, bucket);
+
+		api.setRatelimitsBucket(
+			route,
+			new Response('{}', {
+				headers: {
+					'x-ratelimit-limit': '1',
+					'x-ratelimit-remaining': '0',
+					'x-ratelimit-reset-after': String(Number.MAX_VALUE),
+				},
+			}),
+		);
+
+		expect(bucket.resetAfter).toBe(0);
+	});
+
+	test('preserves malformed absolute resets and caps oversized timestamps', () => {
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const now = 1_700_000_000_000;
+		const bucket = new Bucket(1);
+		bucket.reset = now + 100;
+		api.ratelimits.set(route, bucket);
+
+		api.setResetBucket(
+			route,
+			new Response('{}', { headers: { 'x-ratelimit-reset': 'not-a-number' } }),
+			now,
+			Number.NaN,
+		);
+		expect(bucket.reset).toBe(now + 100);
+
+		api.setResetBucket(
+			route,
+			new Response('{}', { headers: { 'x-ratelimit-reset': String(Number.MAX_SAFE_INTEGER) } }),
+			now,
+			Number.NaN,
+		);
+		expect(bucket.reset).toBe(now + 2_147_483_646);
 	});
 });

--- a/tests/rest-rate-limit.test.mts
+++ b/tests/rest-rate-limit.test.mts
@@ -419,4 +419,47 @@ describe('Discord REST rate limits', () => {
 		expect(next).toHaveBeenCalledOnce();
 		expect(reject).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_RETRY_AFTER' }));
 	});
+
+	test('does not disable throttling when rate-limit headers are malformed', () => {
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const bucket = new Bucket(1);
+		bucket.remaining = 0;
+		api.ratelimits.set(route, bucket);
+
+		api.setRatelimitsBucket(
+			route,
+			new Response('{}', {
+				headers: {
+					'x-ratelimit-limit': 'not-a-number',
+					'x-ratelimit-remaining': 'not-a-number',
+					'x-ratelimit-reset-after': 'not-a-number',
+				},
+			}),
+		);
+
+		expect(bucket.limit).toBe(1);
+		expect(bucket.remaining).toBe(0);
+		expect(bucket.resetAfter).toBe(0);
+	});
+
+	test('caps an invalid remaining value above the advertised limit', () => {
+		const api = createApi();
+		const route = 'GET:/channels/100000000000000001/messages';
+		const bucket = new Bucket(1);
+		api.ratelimits.set(route, bucket);
+
+		api.setRatelimitsBucket(
+			route,
+			new Response('{}', {
+				headers: {
+					'x-ratelimit-limit': '2',
+					'x-ratelimit-remaining': '99',
+				},
+			}),
+		);
+
+		expect(bucket.limit).toBe(2);
+		expect(bucket.remaining).toBe(2);
+	});
 });


### PR DESCRIPTION
## Summary

Harden REST rate-limit bucket updates against malformed or unsafe Discord API headers.

## What changed

- Ignore non-finite or non-positive `x-ratelimit-limit` values.
- Preserve the existing remaining count when `x-ratelimit-remaining` is malformed.
- Cap remaining requests to the advertised bucket limit.
- Ignore malformed smart-bucket reset durations.

## Why

Malformed rate-limit headers could be converted to `NaN`. Since `NaN <= 0` is false, this could cause the bucket to continue dispatching requests instead of throttling them. That creates an avoidable risk of rate-limit violations and request failures.

## Testing

- Added regression coverage for malformed rate-limit headers.
- Added coverage for remaining values above the advertised limit.
- Full test suite passes: 404 tests across 51 files.
- TypeScript build and consumer type contracts pass.
- Biome source checks pass.