### PR TITLE
fix(websocket): prevent shards from creating zero-capacity request buckets

### DIFF
--- a/src/websocket/discord/shard.ts
+++ b/src/websocket/discord/shard.ts
@@ -723,9 +723,8 @@ export class Shard {
 			this.options.ratelimitOptions.maxRequestsPerRateLimitTick -
 			Math.ceil(this.options.ratelimitOptions.rateLimitResetInterval / this.heart.interval) * 2;
 
-		if (safeRequests < 0) {
-			return 0;
-		}
-		return safeRequests;
+		// A shard must retain capacity for at least one gateway request. A zero
+		// capacity bucket leaves every send promise queued indefinitely.
+		return Math.max(safeRequests, 1);
 	}
 }

--- a/tests/gateway-reconnect.test.mts
+++ b/tests/gateway-reconnect.test.mts
@@ -14,6 +14,26 @@ afterEach(() => {
 });
 
 describe('gateway reconnect stability', () => {
+	test('keeps the gateway request bucket usable when the safe budget is exhausted', async () => {
+		const shard = new Shard(
+			0,
+			{
+				token: 'token',
+				intents: 0,
+				info: gatewayInfo(),
+				handlePayload: vi.fn(),
+				ratelimitOptions: {
+					maxRequestsPerRateLimitTick: 1,
+					rateLimitResetInterval: 60_000,
+				},
+			} as unknown as ShardOptions,
+		);
+
+		await expect(shard.bucket.acquire()).resolves.toBeUndefined();
+		expect(shard.bucket.options.limit).toBe(1);
+		shard.bucket.refill();
+	});
+
 	test('disconnect closes sockets that are still handshaking', () => {
 		const shard = new Shard(0, {
 			token: 'token',


### PR DESCRIPTION
## Summary

Ensure gateway shards always retain capacity for at least one request when calculating their safe request budget.

## Problem

Under restrictive rate-limit settings, `calculateSafeRequests()` could return `0`. This created a zero-capacity `DynamicBucket`, leaving gateway send promises queued indefinitely.

A shard could therefore appear connected while gateway requests never completed.

## Changes

- Clamp the calculated safe request capacity to a minimum of one.
- Add a regression test covering an exhausted safe budget.
- Preserve the existing rate-limit calculation for normal configurations.

## Testing

- Added coverage proving the first gateway request resolves when the calculated budget would otherwise be zero.
- Confirmed the change is isolated to the WebSocket shard request bucket.
- Full test suite passes: 413 tests across 51 files.
TypeScript build and consumer type contracts pass.
- Biome source checks pass.
