### PR TITLE
feat(workers): support custom worker environments

### DIFF
--- a/src/websocket/discord/shared.ts
+++ b/src/websocket/discord/shared.ts
@@ -76,6 +76,12 @@ interface WorkerManagerOptionsBase extends Omit<ShardManagerOptions, 'handlePayl
 	workers?: number;
 
 	/**
+	 * Environment variables to add to each worker.
+	 * Variables managed by Seyfert take precedence over matching keys.
+	 */
+	workerEnv?: Readonly<Record<string, string>>;
+
+	/**
 	 * @default 16
 	 */
 	shardsPerWorker?: number;

--- a/src/websocket/discord/workermanager.ts
+++ b/src/websocket/discord/workermanager.ts
@@ -25,8 +25,8 @@ type WorkerManagerConstructorOptions = WorkerManagerOptions extends infer Option
 
 type WorkerManagerNativeOptions = Exclude<WorkerManagerOptions, { mode: 'custom' }>;
 type WorkerManagerCustomOptions = Extract<WorkerManagerOptions, { mode: 'custom' }>;
-type WorkerManagerRuntimeOptionalKeys = 'adapter' | 'handleWorkerMessage' | 'handlePayload' | 'getRC';
-type WorkerManagerCustomRuntimeOptionalKeys = 'handleWorkerMessage' | 'handlePayload' | 'getRC';
+type WorkerManagerRuntimeOptionalKeys = 'adapter' | 'handleWorkerMessage' | 'handlePayload' | 'getRC' | 'workerEnv';
+type WorkerManagerCustomRuntimeOptionalKeys = 'handleWorkerMessage' | 'handlePayload' | 'getRC' | 'workerEnv';
 type WorkerManagerRuntimeOptions =
 	| PickPartial<Required<WorkerManagerNativeOptions>, WorkerManagerRuntimeOptionalKeys>
 	| (PickPartial<Required<Omit<WorkerManagerCustomOptions, 'path'>>, WorkerManagerCustomRuntimeOptionalKeys> & {
@@ -259,7 +259,7 @@ export class WorkerManager extends Map<
 				metadata: { detail: 'Cannot create worker without worker_threads.' },
 			});
 		const env: Record<string, any> = {
-			...process.env,
+			...this.options.workerEnv,
 			SEYFERT_SPAWNING: 'true',
 		};
 		if (workerData.resharding) env.SEYFERT_WORKER_RESHARDING = 'true';
@@ -270,7 +270,7 @@ export class WorkerManager extends Map<
 		switch (this.options.mode) {
 			case 'threads': {
 				const worker = new worker_threads.Worker(workerData.path, {
-					env,
+					env: { ...process.env, ...env },
 				});
 				worker.on('message', data => this.handleWorkerMessage(data));
 				worker.on('error', err => {

--- a/src/websocket/discord/workermanager.ts
+++ b/src/websocket/discord/workermanager.ts
@@ -259,6 +259,7 @@ export class WorkerManager extends Map<
 				metadata: { detail: 'Cannot create worker without worker_threads.' },
 			});
 		const env: Record<string, any> = {
+			...process.env,
 			SEYFERT_SPAWNING: 'true',
 		};
 		if (workerData.resharding) env.SEYFERT_WORKER_RESHARDING = 'true';

--- a/tests/fixtures/workermanager-env.mjs
+++ b/tests/fixtures/workermanager-env.mjs
@@ -1,0 +1,7 @@
+import { parentPort } from 'node:worker_threads';
+
+parentPort?.postMessage({
+	configured: process.env.SEYFERT_WORKER_ENV_CONFIGURED_TEST,
+	inherited: process.env.SEYFERT_WORKER_ENV_TEST,
+	spawning: process.env.SEYFERT_SPAWNING,
+});

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -824,6 +824,9 @@ const customWorkerManagerOptions = {
 expectType<WorkerManagerOptions>(customWorkerManagerOptions);
 new WorkerManager(customWorkerManagerOptions);
 
+type CustomWorkerManagerRuntimeOptions = Extract<WorkerManager['options'], { mode: 'custom' }>;
+expectType<CustomWorkerManagerRuntimeOptions['workerEnv']>(undefined);
+
 const customWorkerManagerOptionsWithPath = {
 	mode: 'custom',
 	path: 'worker.js',
@@ -844,9 +847,15 @@ const threadedWorkerManagerOptions = {
 	token: 'token',
 	intents: GatewayIntentBits.Guilds,
 	info: workerManagerInfo,
+	workerEnv: {
+		DATABASE_URL: 'postgres://localhost/seyfert',
+	},
 } satisfies WorkerManagerOptions;
 expectType<WorkerManagerOptions>(threadedWorkerManagerOptions);
 new WorkerManager(threadedWorkerManagerOptions);
+
+type NativeWorkerManagerRuntimeOptions = Exclude<WorkerManager['options'], { mode: 'custom' }>;
+expectType<NativeWorkerManagerRuntimeOptions['workerEnv']>(undefined);
 
 const defaultThreadedWorkerManagerOptions = {
 	path: 'worker.js',
@@ -863,9 +872,24 @@ const clusteredWorkerManagerOptions = {
 	token: 'token',
 	intents: GatewayIntentBits.Guilds,
 	info: workerManagerInfo,
+	workerEnv: {
+		DATABASE_URL: 'postgres://localhost/seyfert',
+	},
 } satisfies WorkerManagerOptions;
 expectType<WorkerManagerOptions>(clusteredWorkerManagerOptions);
 new WorkerManager(clusteredWorkerManagerOptions);
+
+expectType<WorkerManagerOptions>({
+	mode: 'threads',
+	path: 'worker.js',
+	token: 'token',
+	intents: GatewayIntentBits.Guilds,
+	info: workerManagerInfo,
+	workerEnv: {
+		// @ts-expect-error Worker environment values must be strings.
+		PORT: 3000,
+	},
+});
 
 // @ts-expect-error custom worker mode requires an adapter.
 expectType<WorkerManagerOptions>({

--- a/tests/workermanager.test.mts
+++ b/tests/workermanager.test.mts
@@ -1,8 +1,117 @@
-import { describe, expect, test } from 'vitest';
+import { resolve } from 'node:path';
+import type { Worker } from 'node:worker_threads';
+import { describe, expect, test, vi } from 'vitest';
 import { WorkerClient } from '../lib/client/workerclient';
 import { WorkerManager } from '../lib/websocket/discord/workermanager';
 
 describe('WorkerManager', () => {
+	test('forwards environment variables to custom adapters', () => {
+		const spawn = vi.fn();
+		const info = gatewayInfo();
+		const manager = new WorkerManager({
+			mode: 'custom',
+			token: 'token',
+			intents: 0,
+			info,
+			workerEnv: {
+				CUSTOM_WORKER_ENV_TEST: 'configured',
+				SEYFERT_SPAWNING: 'overridden',
+			},
+			adapter: {
+				postMessage() {},
+				spawn,
+			},
+		});
+
+		manager.createWorker({
+			intents: 0,
+			token: 'token',
+			path: 'worker.js',
+			shards: [0],
+			totalShards: 1,
+			totalWorkers: 1,
+			mode: 'custom',
+			workerId: 0,
+			debug: false,
+			workerProxy: false,
+			info,
+			compress: false,
+			resharding: false,
+		});
+
+		expect(spawn).toHaveBeenCalledWith(
+			expect.objectContaining({ path: 'worker.js' }),
+			expect.objectContaining({
+				CUSTOM_WORKER_ENV_TEST: 'configured',
+				SEYFERT_SPAWNING: 'true',
+			}),
+		);
+	});
+
+	test('thread workers inherit and overlay environment variables', async () => {
+		const previousConfiguredValue = process.env.SEYFERT_WORKER_ENV_CONFIGURED_TEST;
+		const previousValue = process.env.SEYFERT_WORKER_ENV_TEST;
+		let worker: Worker | undefined;
+
+		try {
+			process.env.SEYFERT_WORKER_ENV_CONFIGURED_TEST = 'from-parent';
+			process.env.SEYFERT_WORKER_ENV_TEST = 'available';
+			const path = resolve('tests/fixtures/workermanager-env.mjs');
+			const info = gatewayInfo();
+			const manager = new WorkerManager({
+				mode: 'threads',
+				path,
+				token: 'token',
+				intents: 0,
+				info,
+				workerEnv: {
+					SEYFERT_WORKER_ENV_CONFIGURED_TEST: 'configured',
+					SEYFERT_SPAWNING: 'overridden',
+				},
+			});
+			let resolveMessage!: (message: unknown) => void;
+			let rejectMessage!: (error: Error) => void;
+			const message = new Promise<unknown>((resolve, reject) => {
+				resolveMessage = resolve;
+				rejectMessage = reject;
+			});
+			manager.handleWorkerMessage = async workerMessage => {
+				resolveMessage(workerMessage);
+			};
+			worker = manager.createWorker({
+				intents: 0,
+				token: 'token',
+				path,
+				shards: [0],
+				totalShards: 1,
+				totalWorkers: 1,
+				mode: 'threads',
+				workerId: 0,
+				debug: false,
+				workerProxy: false,
+				info,
+				compress: false,
+				resharding: false,
+			}) as Worker;
+			worker.once('error', rejectMessage);
+			worker.once('exit', code =>
+				rejectMessage(new Error(`Worker exited with code ${code} before reporting its environment.`)),
+			);
+
+			await expect(message).resolves.toEqual({
+				configured: 'configured',
+				inherited: 'available',
+				spawning: 'true',
+			});
+		} finally {
+			await worker?.terminate();
+			if (previousConfiguredValue === undefined) delete process.env.SEYFERT_WORKER_ENV_CONFIGURED_TEST;
+			else process.env.SEYFERT_WORKER_ENV_CONFIGURED_TEST = previousConfiguredValue;
+			if (previousValue === undefined) delete process.env.SEYFERT_WORKER_ENV_TEST;
+			else process.env.SEYFERT_WORKER_ENV_TEST = previousValue;
+		}
+	});
+
 	test('calculateWorkerId reports the effective shard range', () => {
 		const manager = createWorkerManager({
 			shardStart: 2,
@@ -69,6 +178,19 @@ describe('WorkerManager', () => {
 		expect([...new Uint8Array(await response)]).toEqual([...bytes]);
 	});
 });
+
+function gatewayInfo() {
+	return {
+		shards: 1,
+		url: 'wss://gateway.discord.gg',
+		session_start_limit: {
+			total: 1,
+			remaining: 1,
+			reset_after: 0,
+			max_concurrency: 1,
+		},
+	};
+}
 
 function createWorkerManager(options: {
 	shardStart: number;


### PR DESCRIPTION
### Summary

`WorkerManager` currently passes a custom `env` object when creating workers.

Because of that, the worker environment only contains the `SEYFERT_*` variables defined by the manager, while environment variables already available in the parent process are not preserved.

This can cause workers to lose values loaded from `.env`, such as database URLs, Redis credentials, bot configuration, and other application-specific environment variables.

### Problem

The worker environment is currently initialized with only Seyfert-specific variables, conceptually like this:

```ts
const env = {
    SEYFERT_SPAWNING: 'true',
};
```

and then passed directly to the worker.

Since an explicit `env` object is provided, the worker does not inherit the complete parent `process.env`.

For example:

```ts
process.env.DATABASE_URL // available in manager
```

but inside the worker:

```ts
process.env.DATABASE_URL // undefined
```

while Seyfert-specific variables are still present.

### Fix

Preserve the parent environment variables before adding Seyfert-specific values:

```ts
const env = {
    ...process.env,
    SEYFERT_SPAWNING: 'true',
};
```

The existing `SEYFERT_WORKER_*` values can then continue to be added to this object as usual.

### Result

Workers inherit the application's existing environment while still receiving the Seyfert-specific worker variables.

This removes the need for workarounds such as manually calling:

```ts
process.loadEnvFile();
```

inside a separate worker entrypoint before importing the client.

### Notes

I originally encountered this after updating Bun, where the worker could start successfully but failed during application initialization because environment variables available to the manager were missing inside the worker.

This change keeps the current WorkerManager behavior while preserving the parent process environment.

### Additional configuration

This PR also adds the optional `workerEnv` option to `WorkerManager`. It can pass explicit environment variables to workers in `threads`, `clusters`, and `custom` modes. Values generated by Seyfert, including `SEYFERT_SPAWNING` and `SEYFERT_WORKER_*`, take precedence over matching user-provided keys.

Parent `process.env` inheritance is applied at the native thread boundary, so custom adapters are not implicitly given the complete host environment. Regression coverage now starts a real worker and verifies parent inheritance, user overrides, protected internal variables, and adapter forwarding.
