### PR TITLE
fix(plugins): support handler transform vetoes

### DIFF
--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -5,10 +5,7 @@ import { isBufferLike } from '../api/utils/utils';
 import type { Adapter, DisabledCache } from '../cache';
 import { Cache, MemoryAdapter } from '../cache';
 import type {
-	Command,
 	CommandContext,
-	ContextMenuCommand,
-	EntryPointCommand,
 	ExtendContext,
 	ExtendedRC,
 	ExtendedRCLocations,
@@ -17,7 +14,7 @@ import type {
 	ResolvedRegisteredMiddlewares,
 	UsingClient,
 } from '../commands';
-import { SubCommand } from '../commands';
+import { Command, ContextMenuCommand, EntryPointCommand, SubCommand } from '../commands';
 import {
 	type AnyMiddlewareContext,
 	IgnoreCommand,
@@ -118,6 +115,7 @@ import {
 	recordContributionMutationDiagnostic,
 } from './plugins/registry';
 import { createSharedRegistry } from './plugins/shared';
+import type { PluginHandlerValueByKind } from './plugins/types';
 import type { MessageStructure } from './transformers';
 
 export type ContextScopeContext = BaseContext & ExtendContext;
@@ -650,6 +648,7 @@ export class BaseClient {
 		this.commands.set(commands, command => {
 			const source = (command as PluginSourced)[pluginSourceKey];
 			const transformed = this.runPluginHandlerTransformers('command', command);
+			if (transformed === false) return false;
 			if (source) (transformed as PluginSourced)[pluginSourceKey] = source;
 			return transformed;
 		});
@@ -805,6 +804,7 @@ export class BaseClient {
 				component instanceof ModalCommand ? 'modal' : 'component',
 				component,
 			);
+			if (transformed === false) return false;
 			if (source) (transformed as PluginSourced)[pluginSourceKey] = source;
 			return transformed;
 		});
@@ -898,14 +898,27 @@ export class BaseClient {
 	}
 
 	/** @internal */
-	runPluginHandlerTransformers<T>(kind: PluginHandlerKind, instance: T): T {
+	runPluginHandlerTransformers<K extends PluginHandlerKind>(
+		kind: K,
+		instance: PluginHandlerValueByKind[K],
+	): PluginHandlerValueByKind[K] | false {
 		let current = instance;
 		const metadata = { kind };
 		for (const contribution of orderedPluginContributions(this.pluginRegistry.handlerTransformers)) {
 			if (!this.matchesPluginHandlerKind(contribution.kinds, kind)) continue;
 			try {
-				const transform = contribution.transformer as (value: unknown, meta: { kind: PluginHandlerKind }) => unknown;
-				current = (transform(current, metadata) ?? current) as T;
+				const transform = contribution.transformer as (
+					value: PluginHandlerValueByKind[K],
+					meta: { kind: K },
+				) => PluginHandlerValueByKind[K] | false | void;
+				const transformed = transform(current, metadata);
+				if (transformed === false) return false;
+				if (transformed !== undefined) {
+					if (!this.isPluginHandlerValue(kind, transformed)) {
+						throw new TypeError(`Transformer returned a value incompatible with handler kind "${kind}".`);
+					}
+					current = transformed;
+				}
 			} catch (error) {
 				throw wrapPluginError(
 					contribution.record.plugin.name,
@@ -922,6 +935,27 @@ export class BaseClient {
 
 	private matchesPluginHandlerKind(kinds: readonly PluginHandlerKind[] | undefined, kind: PluginHandlerKind) {
 		return !kinds?.length || kinds.includes(kind);
+	}
+
+	private isPluginHandlerValue<K extends PluginHandlerKind>(
+		kind: K,
+		value: unknown,
+	): value is PluginHandlerValueByKind[K] {
+		switch (kind) {
+			case 'command':
+				return (
+					value instanceof Command ||
+					value instanceof SubCommand ||
+					value instanceof ContextMenuCommand ||
+					value instanceof EntryPointCommand
+				);
+			case 'component':
+				return value instanceof ComponentCommand && !(value instanceof ModalCommand);
+			case 'modal':
+				return value instanceof ModalCommand;
+			case 'event':
+				return (typeof value === 'object' && value !== null) || typeof value === 'function';
+		}
 	}
 
 	private createPluginLoadedMetadata<TKind extends 'commands' | 'components', TItem>(

--- a/src/client/plugins/api.ts
+++ b/src/client/plugins/api.ts
@@ -27,7 +27,9 @@ import type {
 	PluginCacheResourceConstructor,
 	PluginCommandContributionOptions,
 	PluginContributionOptions,
+	PluginHandlerKindsFromOptions,
 	PluginHandlerOptions,
+	PluginHandlerTransformer,
 	PluginOrderOpt,
 	SeyfertPluginApi,
 	SeyfertPluginOptions,
@@ -262,7 +264,10 @@ export function createPluginApi(
 					sequence: nextPluginContributionSequence(registry),
 				});
 			},
-			transform(transformer, opts) {
+			transform<const Options extends PluginHandlerOptions | undefined = undefined>(
+				transformer: PluginHandlerTransformer<PluginHandlerKindsFromOptions<Options>>,
+				opts?: Options,
+			) {
 				assertCanMutate('handlers.transform');
 				registry.handlerTransformers.push({
 					record,

--- a/src/client/plugins/registry.ts
+++ b/src/client/plugins/registry.ts
@@ -27,7 +27,6 @@ import type {
 	PluginGatewaySendPayloadWrapper,
 	PluginHandlerCreator,
 	PluginHandlerKind,
-	PluginHandlerTransformer,
 	PluginIntentResolvable,
 	PluginLifecycleStatus,
 	PluginModalLoadable,
@@ -258,7 +257,7 @@ export interface PluginHandlerCreatorContribution extends PluginOrderedContribut
 
 export interface PluginHandlerTransformerContribution extends PluginOrderedContribution {
 	record: PluginRuntimeRecord;
-	transformer: PluginHandlerTransformer;
+	transformer: (...args: never[]) => unknown;
 	scope: PluginEventContributionScope;
 	kinds?: readonly PluginHandlerKind[];
 }

--- a/src/client/plugins/types.ts
+++ b/src/client/plugins/types.ts
@@ -331,14 +331,19 @@ export type PluginHandlerCreator = <T extends PluginHandlerConstructor>(
 	next: () => InstanceType<T>,
 	metadata: PluginHandlerMetadata,
 ) => InstanceType<T>;
-export type PluginHandlerTransformer = <K extends PluginHandlerKind = PluginHandlerKind>(
+export type PluginHandlerTransformer<K extends PluginHandlerKind = PluginHandlerKind> = (
 	instance: PluginHandlerValueByKind[K],
 	metadata: PluginHandlerMetadata<K>,
-) => PluginHandlerValueByKind[K] | void;
+) => PluginHandlerValueByKind[K] | false | void;
 export interface PluginHandlerOptions {
 	kinds?: readonly PluginHandlerKind[];
 	order?: PluginOrderOpt;
 }
+export type PluginHandlerKindsFromOptions<Options extends PluginHandlerOptions | undefined> = Options extends {
+	kinds: readonly [infer First extends PluginHandlerKind, ...infer Rest extends readonly PluginHandlerKind[]];
+}
+	? First | Rest[number]
+	: PluginHandlerKind;
 export type PluginDisposer = () => void;
 export type PluginEventErrorHandler = (error: unknown, name: string) => unknown;
 export interface PluginContributionOptions {
@@ -400,7 +405,10 @@ export interface SeyfertPluginApi<M extends PluginMiddlewareMap = PluginMiddlewa
 	};
 	handlers: {
 		construct(creator: PluginHandlerCreator, opts?: PluginHandlerOptions): void;
-		transform(transformer: PluginHandlerTransformer, opts?: PluginHandlerOptions): void;
+		transform<const Options extends PluginHandlerOptions | undefined = undefined>(
+			transformer: PluginHandlerTransformer<PluginHandlerKindsFromOptions<Options>>,
+			opts?: Options,
+		): void;
 	};
 	components: {
 		add(...components: PluginComponentLoadable[]): void;

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -58,8 +58,13 @@ export class CommandHandler extends BaseHandler {
 		let prepared = this.prepareCommand(commandInstance);
 		if (!prepared) return null;
 
-		const wrapped = options.transform?.(prepared) ?? prepared;
-		if (!wrapped) return null;
+		const transformed = options.transform?.(prepared);
+		if (transformed === false) {
+			const index = this.values.indexOf(command);
+			if (index >= 0) this.values.splice(index, 1);
+			return null;
+		}
+		const wrapped = transformed ?? prepared;
 		if (wrapped !== prepared) {
 			wrapped.__filePath ??= command.__filePath;
 			prepared = this.prepareCommand(wrapped);
@@ -76,7 +81,7 @@ export class CommandHandler extends BaseHandler {
 	}
 
 	async reloadAll(stopIfFail = true) {
-		for (const command of this.values) {
+		for (const command of [...this.values]) {
 			try {
 				await this.reload(command.name);
 			} catch (e) {

--- a/src/components/handler.ts
+++ b/src/components/handler.ts
@@ -366,7 +366,7 @@ export class ComponentHandler extends BaseHandler {
 	}
 
 	async reloadAll(stopIfFail = true) {
-		for (const i of this.commands) {
+		for (const i of [...this.commands]) {
 			try {
 				await this.reload(i.__filePath ?? '');
 			} catch (e) {

--- a/src/events/handler.ts
+++ b/src/events/handler.ts
@@ -243,6 +243,8 @@ export class CustomEventHandler extends BaseHandler implements CustomEventRunner
 }
 
 export class EventHandler extends CustomEventHandler {
+	private sourceIndexes = new WeakMap<object, number>();
+
 	constructor(protected client: Client | WorkerClient) {
 		super(client);
 	}
@@ -271,21 +273,30 @@ export class EventHandler extends CustomEventHandler {
 			file: x,
 		}))) {
 			if (!events) continue;
-			for (const i of events) {
-				const instance = this.callback(this.client.runPluginHandlerTransformers('event', i));
+			for (const [index, i] of events.entries()) {
+				const instance = this.transformLoadedEvent(i, file.path, index);
 				if (!instance) continue;
-				if (typeof instance?.run !== 'function') {
-					this.logger.warn(
-						file.path.split(process.cwd()).slice(1).join(process.cwd()),
-						'Missing run function, use `export default {...}` syntax',
-					);
-					continue;
-				}
-				instance.__filePath = file.path;
-				this.values[normalizeEventName(instance.data.name) as CustomEventsKeys | GatewayEvents] =
-					instance as EventValue;
+				this.values[normalizeEventName(instance.data.name) as CustomEventsKeys | GatewayEvents] = instance;
 			}
 		}
+	}
+
+	private transformLoadedEvent(event: object, filePath: string, sourceIndex: number): EventValue | false {
+		const transformed = this.client.runPluginHandlerTransformers('event', event);
+		if (transformed === false) return false;
+		const instance = this.callback(transformed as ClientEvent);
+		if (!instance) return false;
+		if (typeof instance.run !== 'function') {
+			this.logger.warn(
+				filePath.split(process.cwd()).slice(1).join(process.cwd()),
+				'Missing run function, use `export default {...}` syntax',
+			);
+			return false;
+		}
+		instance.__filePath = filePath;
+		const value = instance as EventValue;
+		this.sourceIndexes.set(value, sourceIndex);
+		return value;
 	}
 
 	async execute(raw: GatewayDispatchPayload, client: Client<true> | WorkerClient<true>, shardId: number) {
@@ -435,20 +446,44 @@ export class EventHandler extends CustomEventHandler {
 		}
 		const event = this.values[name];
 		if (!event?.__filePath) return null;
-		delete require.cache[event.__filePath];
-		const imported = this.client.runPluginHandlerTransformers(
-			'event',
-			await magicImport(event.__filePath).then(x => x.default ?? x),
-		);
-		imported.__filePath = event.__filePath;
-		this.values[name] = imported;
-		return imported;
+		const filePath = event.__filePath;
+		const requestedSourceIndex = this.sourceIndexes.get(event);
+		const previous = Object.entries(this.values).filter(([, current]) => current.__filePath === filePath);
+		delete require.cache[filePath];
+		const imported = await magicImport(filePath);
+		const loaded = this.onFile({ default: imported.default ?? imported });
+		const materialized = (loaded ?? []).map((current, index) => {
+			const instance = this.transformLoadedEvent(current, filePath, index);
+			const sourceName =
+				typeof current === 'object' && current !== null && 'data' in current
+					? normalizeEventName((current as ClientEvent).data.name)
+					: undefined;
+			return { index, sourceName, instance };
+		});
+
+		for (const [currentName] of previous) {
+			delete this.values[currentName as keyof EventValues];
+		}
+
+		let reloaded: EventValue | null = null;
+		for (const current of materialized) {
+			if (!current.instance) continue;
+			const currentName = normalizeEventName(current.instance.data.name) as CustomEventsKeys | GatewayEvents;
+			this.values[currentName] = current.instance;
+			if (current.index === requestedSourceIndex || current.sourceName === name || currentName === name) {
+				reloaded = current.instance;
+			}
+		}
+		return reloaded;
 	}
 
 	async reloadAll(stopIfFail = true) {
-		for (const i in this.values) {
+		const files = new Set<string>();
+		for (const [name, event] of Object.entries(this.values)) {
+			if (!event.__filePath || files.has(event.__filePath)) continue;
+			files.add(event.__filePath);
 			try {
-				await this.reload(i as GatewayEvents | CustomEventsKeys);
+				await this.reload(name as GatewayEvents | CustomEventsKeys);
 			} catch (e) {
 				if (stopIfFail) {
 					throw e;

--- a/tests/plugin-api.test.mts
+++ b/tests/plugin-api.test.mts
@@ -396,6 +396,101 @@ describe('plugin api v3', () => {
 		);
 	});
 
+	test('treats false as a terminal veto for only the current plugin command', async () => {
+		const firstTransformer: string[] = [];
+		const secondTransformer: string[] = [];
+		const plugin = createPlugin({
+			name: 'command-veto',
+			register(api) {
+				api.commands.add(PluginPing, HandlerCommand);
+				api.handlers.transform(command => {
+					firstTransformer.push(command.name);
+					if (command.name === 'plugin-ping') return false;
+					return undefined;
+				}, { kinds: ['command'] });
+				api.handlers.transform(command => {
+					secondTransformer.push(command.name);
+				}, { kinds: ['command'] });
+			},
+		});
+		const client = createBaseClient([plugin]);
+		client.loadCommands = async () => {
+			client.commands.values = [];
+		};
+
+		await client.start();
+
+		expect(firstTransformer).toEqual(['plugin-ping', 'handler-command']);
+		expect(secondTransformer).toEqual(['handler-command']);
+		expect(client.commands.values.map(command => command.name)).toEqual(['handler-command']);
+	});
+
+	test('keeps undefined results and continues with compatible replacements', async () => {
+		const replacement = new HandlerInstanceCommand();
+		let original: object | undefined;
+		const preservedInstances: boolean[] = [];
+		const observed: Command[] = [];
+		const plugin = createPlugin({
+			name: 'command-replacement',
+			register(api) {
+				api.commands.add(PluginPing);
+				api.handlers.transform(command => {
+					original = command;
+				}, { kinds: ['command'] });
+				api.handlers.transform(command => {
+					preservedInstances.push(command === original);
+					return replacement;
+				}, { kinds: ['command'] });
+				api.handlers.transform(command => {
+					if (command instanceof Command) observed.push(command);
+				}, { kinds: ['command'] });
+			},
+		});
+		const client = createBaseClient([plugin]);
+		client.loadCommands = async () => {
+			client.commands.values = [];
+		};
+
+		await client.start();
+
+		expect(preservedInstances).toEqual([true]);
+		expect(observed).toEqual([replacement]);
+		expect(client.commands.values).toEqual([replacement]);
+	});
+
+	test('omits vetoed plugin components and modals', async () => {
+		const plugin = createPlugin({
+			name: 'component-veto',
+			register(api) {
+				api.components.add(PluginButton);
+				api.modals.add(PluginModal);
+				api.handlers.transform(() => false, { kinds: ['component', 'modal'] });
+			},
+		});
+		const client = createBaseClient([plugin]);
+		client.loadComponents = async () => {};
+
+		await client.start();
+
+		expect(client.components.commands).toEqual([]);
+	});
+
+	test('rejects replacements incompatible with the current handler kind', async () => {
+		const plugin = createPlugin({
+			name: 'incompatible-replacement',
+			register(api) {
+				api.commands.add(PluginPing);
+				api.handlers.transform(() => new PluginButton(), { kinds: ['command', 'component'] });
+			},
+		});
+		const client = createBaseClient([plugin]);
+		client.loadCommands = async () => {
+			client.commands.values = [];
+		};
+
+		await expect(client.start()).rejects.toThrow(/incompatible with handler kind "command"/);
+	});
+
 	test('preserves props on plugin-added command instances', async () => {
 		const command = new PluginPing();
 		command.props = { existing: true };
@@ -700,6 +795,50 @@ describe('plugin api v3', () => {
 		expect(result.data?.name).toBe('messageCreate');
 	});
 
+	test('omits vetoed file-loaded events without affecting later events', async () => {
+		const transformed: string[] = [];
+		const laterTransformer: string[] = [];
+		const vetoedEvent = { data: { name: 'messageCreate' }, run() {} };
+		const keptEvent = { data: { name: 'messageUpdate' }, run() {} };
+		const plugin = createPlugin({
+			name: 'event-veto',
+			register(api) {
+				api.handlers.transform(event => {
+					const name = 'data' in event ? (event as typeof vetoedEvent).data.name : 'unknown';
+					transformed.push(name);
+					if (name === 'messageCreate') return false;
+					return undefined;
+				}, { kinds: ['event'] });
+				api.handlers.transform(event => {
+					if ('data' in event) laterTransformer.push((event as typeof keptEvent).data.name);
+				}, { kinds: ['event'] });
+			},
+		});
+		const client = createGatewayClient([plugin]);
+		vi.spyOn(client.events as unknown as { getFiles: () => Promise<string[]> }, 'getFiles').mockResolvedValue([
+			'/events/events.js',
+		]);
+		vi.spyOn(
+			client.events as unknown as {
+				loadFilesK: () => Promise<{ name: string; path: string; file: { default: unknown[] } }[]>;
+			},
+			'loadFilesK',
+		).mockResolvedValue([
+			{
+				name: 'events.js',
+				path: '/events/events.js',
+				file: { default: [vetoedEvent, keptEvent] },
+			},
+		]);
+
+		await client.events.load('/events');
+
+		expect(transformed).toEqual(['messageCreate', 'messageUpdate']);
+		expect(laterTransformer).toEqual(['messageUpdate']);
+		expect(client.events.values.MESSAGE_CREATE).toBeUndefined();
+		expect(client.events.values.MESSAGE_UPDATE?.run).toBe(keptEvent.run);
+	});
+
 	test('applies unified handler creators and transformers to file-loaded handlers', async () => {
 		const createKinds: string[] = [];
 		const transformed: string[] = [];
@@ -876,6 +1015,118 @@ describe('plugin api v3', () => {
 		expect(
 			(client.components.commands.find(component => component.customId === 'reload-modal') as { props: { reloadKind?: string } } | undefined)?.props.reloadKind,
 		).toBe('modal');
+	});
+
+	test('removes vetoed commands, components, modals, and events during reload', async () => {
+		class ReloadCommand extends Command {
+			name = 'veto-reload-command';
+			description = 'Veto reload command';
+			run() {}
+		}
+		class SecondReloadCommand extends Command {
+			name = 'second-veto-reload-command';
+			description = 'Second veto reload command';
+			run() {}
+		}
+		class ReloadButton extends ComponentCommand {
+			componentType = 'Button' as const;
+			customId = 'veto-reload-button';
+			run() {}
+		}
+		class ReloadModal extends ModalCommand {
+			customId = 'veto-reload-modal';
+			run() {}
+		}
+		const transformed: string[] = [];
+		let eventReplacement = 0;
+		const plugin = createPlugin({
+			name: 'reload-veto',
+			register(api) {
+				api.handlers.transform((instance, metadata) => {
+					transformed.push(metadata.kind);
+					if (metadata.kind === 'event' && 'data' in instance) {
+						return (instance as { data?: { name?: string } }).data?.name === 'messageCreate' ? false : undefined;
+					}
+					if (metadata.kind === 'event' && typeof instance === 'function') {
+						return { data: { name: 'messageUpdate', once: false }, run() {} };
+					}
+					return false;
+				});
+				api.handlers.transform(event => {
+					if ('data' in event && (event as { data?: { name?: string } }).data?.name === 'messageUpdate') {
+						const name = eventReplacement++ === 0 ? 'guildCreate' : 'guildUpdate';
+						return { data: { name, once: false }, run() {} };
+					}
+					return undefined;
+				}, { kinds: ['event'] });
+			},
+		});
+		const client = createGatewayClient([plugin]);
+		const dir = await mkdtemp(join(tmpdir(), 'seyfert-plugin-veto-reload-'));
+		tempDirs.push(dir);
+		const commandPath = join(dir, 'command.cjs');
+		const secondCommandPath = join(dir, 'second-command.cjs');
+		const buttonPath = join(dir, 'button.cjs');
+		const modalPath = join(dir, 'modal.cjs');
+		const eventPath = join(dir, 'event.cjs');
+		(globalThis as { __SeyfertReloadCommandBase?: typeof Command }).__SeyfertReloadCommandBase = Command;
+		(globalThis as { __SeyfertReloadComponentBase?: typeof ComponentCommand }).__SeyfertReloadComponentBase =
+			ComponentCommand;
+		(globalThis as { __SeyfertReloadModalBase?: typeof ModalCommand }).__SeyfertReloadModalBase = ModalCommand;
+		await writeFile(
+			commandPath,
+			"const Command = globalThis.__SeyfertReloadCommandBase; module.exports = class extends Command { name = 'veto-reload-command'; description = 'Veto reload command'; run() {} };\n",
+		);
+		await writeFile(
+			secondCommandPath,
+			"const Command = globalThis.__SeyfertReloadCommandBase; module.exports = class extends Command { name = 'second-veto-reload-command'; description = 'Second veto reload command'; run() {} };\n",
+		);
+		await writeFile(
+			buttonPath,
+			"const ComponentCommand = globalThis.__SeyfertReloadComponentBase; module.exports = class extends ComponentCommand { componentType = 'Button'; customId = 'veto-reload-button'; run() {} };\n",
+		);
+		await writeFile(
+			modalPath,
+			"const ModalCommand = globalThis.__SeyfertReloadModalBase; module.exports = class extends ModalCommand { customId = 'veto-reload-modal'; run() {} };\n",
+		);
+		await writeFile(
+			eventPath,
+			"module.exports = [{ data: { name: 'messageCreate', once: false }, run() {} }, class InjectableEvent { run() {} }];\n",
+		);
+
+		const command = new ReloadCommand();
+		command.__filePath = commandPath;
+		const secondCommand = new SecondReloadCommand();
+		secondCommand.__filePath = secondCommandPath;
+		const button = new ReloadButton();
+		button.__filePath = buttonPath;
+		const modal = new ReloadModal();
+		modal.__filePath = modalPath;
+		client.commands.values = [command, secondCommand];
+		client.components.commands.splice(0, client.components.commands.length, button, modal);
+		client.events.values.MESSAGE_CREATE = {
+			data: { name: 'messageCreate', once: false },
+			run() {},
+			__filePath: eventPath,
+		};
+		client.events.values.MESSAGE_UPDATE = {
+			data: { name: 'messageUpdate', once: false },
+			run() {},
+			__filePath: eventPath,
+		};
+
+		await expect(client.commands.reloadAll()).resolves.toBeUndefined();
+		await expect(client.components.reloadAll()).resolves.toBeUndefined();
+		await expect(client.events.reloadAll()).resolves.toBeUndefined();
+
+		expect(transformed.sort()).toEqual(['command', 'command', 'component', 'event', 'event', 'modal']);
+		await expect(client.events.reload('GUILD_CREATE')).resolves.toMatchObject({ data: { name: 'guildUpdate' } });
+		expect(client.commands.values).toEqual([]);
+		expect(client.components.commands).toEqual([]);
+		expect(client.events.values.MESSAGE_CREATE).toBeUndefined();
+		expect(client.events.values.MESSAGE_UPDATE).toBeUndefined();
+		expect(client.events.values.GUILD_CREATE).toBeUndefined();
+		expect(client.events.values.GUILD_UPDATE?.data.name).toBe('guildUpdate');
 	});
 
 	test('keeps plugin lang overlays after lang reload', async () => {

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -80,6 +80,7 @@ import {
 	type PluginGatewayDispatchMeta,
 	type PluginGatewayDispatchNext,
 	type PluginHandlerKind,
+	type PluginHandlerOptions,
 	type PluginLoadedMetadata,
 	type PluginMiddlewaresMapOf,
 	type PluginCommandObserver,
@@ -1053,9 +1054,62 @@ const economy = createPlugin({
 		// @ts-expect-error handlers.create was removed before release
 		api.handlers.create((_Ctor, next) => next());
 		api.handlers.transform((instance, metadata) => {
-			expectType<PluginHandlerKind>(metadata.kind);
+			expectType<Command | SubCommand | ContextMenuCommand | EntryPointCommand>(instance);
+			expectType<'command'>(metadata.kind);
+			if (instance instanceof Command || instance instanceof ContextMenuCommand) {
+				expectType<boolean | undefined>(instance.onlyDeveloper);
+				if (instance.onlyDeveloper) return false;
+			}
 			return instance;
 		}, { kinds: ['command'], order: PluginOrder.After });
+		api.handlers.transform((instance, metadata) => {
+			expectType<Command | SubCommand | ContextMenuCommand | EntryPointCommand | ComponentCommand>(instance);
+			expectType<'command' | 'component'>(metadata.kind);
+			if (metadata.kind === 'command') return new ContractCommand();
+			return new ContractComponent();
+		}, { kinds: ['command', 'component'] });
+		// @ts-expect-error command/component transformers cannot return modals
+		api.handlers.transform(() => {
+			return new ContractModal();
+		}, { kinds: ['command', 'component'] });
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return metadata.kind === 'event' ? false : instance;
+		});
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return instance;
+		}, { kinds: [] });
+		const dynamicHandlerKinds: readonly PluginHandlerKind[] = ['command'];
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return instance;
+		}, { kinds: dynamicHandlerKinds });
+		const broadHandlerOptions: PluginHandlerOptions = { kinds: ['command'] };
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return instance;
+		}, broadHandlerOptions);
+		const orderedHandlerOptions: PluginHandlerOptions = { order: PluginOrder.After };
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return instance;
+		}, orderedHandlerOptions);
+		const optionalHandlerOptions = undefined as PluginHandlerOptions | undefined;
+		api.handlers.transform((instance, metadata) => {
+			expectType<object>(instance);
+			expectType<PluginHandlerKind>(metadata.kind);
+			return instance;
+		}, optionalHandlerOptions);
+		// @ts-expect-error command transformers cannot replace commands with components
+		api.handlers.transform(() => {
+			return new ContractComponent();
+		}, { kinds: ['command'] });
 		api.modals.remove('contract-modal');
 		const disposeCommandsLoaded = api.events.once('commandsLoaded', metadata => {
 			expectType<number>(metadata.total);
@@ -1332,6 +1386,14 @@ const transitiveOnlyPlugins = definePlugins(combinedAtomic);
 const emptyPlugins = definePlugins();
 
 declare module 'seyfert' {
+	interface Command {
+		onlyDeveloper?: boolean;
+	}
+
+	interface ContextMenuCommand {
+		onlyDeveloper?: boolean;
+	}
+
 	interface SeyfertRegistry {
 		plugins: typeof plugins;
 		client: ParseClient<Client<true>>;


### PR DESCRIPTION
## Problem

`handlers.transform` could only describe replacement or no-op behavior in its public type. Internally the pipeline also used nullish coalescing:

```ts
current = transform(current, metadata) ?? current;
```

That expression preserves `undefined`, but it does not preserve `false`: `false` became the next `current` value. A transformer trying to reject one handler could therefore pass a boolean into later transformers, reach callers typed as if they still had a handler instance, or leave the previous instance registered during reload.

## Handler contract

A transformer chain now has three explicit outcomes:

```text
undefined             keep the current instance and continue
compatible instance   replace the current instance and continue
false                  veto this instance and stop its remaining transformers
```

The veto only terminates the chain for that handler. The outer command, component, modal, or event loader continues with the next handler. For example:

```ts
api.handlers.transform(command => {
  if (command.name === "developer-only") return false;

  // Later transformers receive this same command.
  return undefined;
}, { kinds: ["command"] });
```

If `developer-only` is followed by `ping`, the first command is omitted, later transformers do not see it, and `ping` is still processed normally. A replacement is fed into the next transformer instead of the original instance.

Literal `kinds` narrow both the callback input and its allowed replacement set:

```ts
api.handlers.transform((_handler, metadata) => {
  if (metadata.kind === "command") return commandReplacement;
  return componentReplacement;
}, { kinds: ["command", "component"] });
```

Returning a modal from that callback is a type error. Empty or dynamic kind arrays, forwarded `PluginHandlerOptions`, options containing only `order`, and `PluginHandlerOptions | undefined` retain the previous broad callback shape. Runtime also checks the returned instance against the current kind, so a multi-kind callback cannot return a component while the active pipeline is processing a command.

## Loading and reload behavior

Commands, components, and modals now narrow `false` before copying plugin source metadata or inserting values into their registries. A veto during reload removes the previous value instead of leaving stale behavior active. `reloadAll()` iterates stable snapshots so removing the current command or component cannot skip the next array entry.

Event files need an additional distinction because one file can export several handlers:

```ts
export default [messageCreateEvent, InjectableGuildEvent];
```

Reload normalizes and transforms each exported event independently. One event can be vetoed without affecting its sibling, replacements are registered under their resulting event name, and a private source-slot identity keeps successive reloads attached to the same raw export even after siblings are vetoed or the event is renamed:

```text
slot 0: MESSAGE_CREATE -> false          omitted
slot 1: injectable event -> GUILD_CREATE registered
slot 1 on next reload -> GUILD_UPDATE    old key removed, new key registered
```

The regressions exercise terminal veto ordering, continuation to the next handler, `undefined`, compatible replacement, incompatible replacement rejection, plugin contributions, all four handler kinds, bulk reload mutation, multi-event exports, DI-style raw event classes, and successive event renames.