### PR TITLE
ci: modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,8 @@ permissions:
   contents: read
 
 jobs:
-  linter:
+  tooling:
+    name: Tooling & Test (Bun)
     runs-on: ubuntu-latest
 
     steps:
@@ -70,6 +71,9 @@ jobs:
         run: bunx pkg-pr-new publish
         if: github.repository == 'tiramisulabs/seyfert'
 
+      - name: Test suites
+        run: bun --bun ./node_modules/vitest/vitest.mjs run --config ./tests/vitest.config.mts ./tests/
+
   test:
     name: Test (${{ matrix.runtime }})
     runs-on: ubuntu-latest
@@ -78,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime: [node, bun, deno]
+        runtime: [node, deno]
 
     steps:
       - name: check out code
@@ -87,19 +91,16 @@ jobs:
           ref: ${{ github.ref }}
           persist-credentials: false
 
-      # --- Node and shared pnpm install ---
+      # --- Shared Node and pnpm install ---
       - name: Install Node
-        if: matrix.runtime != 'bun'
         uses: actions/setup-node@v7
         with:
           node-version: '22.x'
 
       - name: Install pnpm
-        if: matrix.runtime != 'bun'
         uses: pnpm/action-setup@v6
 
       - name: Install dependencies (Node and Deno)
-        if: matrix.runtime != 'bun'
         run: pnpm install --frozen-lockfile
 
       - name: Test suites (Node)
@@ -111,27 +112,6 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: node ./tests/bot.js
-
-      # --- Bun ---
-      - name: Install Bun
-        if: matrix.runtime == 'bun'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Install dependencies (Bun)
-        if: matrix.runtime == 'bun'
-        run: bun install --frozen-lockfile --ignore-scripts
-        env:
-          HUSKY: 0
-
-      - name: Build (Bun)
-        if: matrix.runtime == 'bun'
-        run: bun run build
-
-      - name: Test suites (Bun)
-        if: matrix.runtime == 'bun'
-        run: bun --bun ./node_modules/vitest/vitest.mjs run --config ./tests/vitest.config.mts ./tests/
 
       # --- Deno ---
       - name: Install Deno

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           persist-credentials: false
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           persist-credentials: false
@@ -90,13 +90,13 @@ jobs:
       # --- Node and shared pnpm install ---
       - name: Install Node
         if: matrix.runtime != 'bun'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
 
       - name: Install pnpm
         if: matrix.runtime != 'bun'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies (Node and Deno)
         if: matrix.runtime != 'bun'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,15 +18,15 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out pull request branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,15 +13,15 @@ jobs:
       id-token: write
     steps:
       - name: check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Several workflows still referenced action majors backed by the deprecated Node 20 runtime, which produced GitHub migration warnings even though the runtime used to exercise Seyfert was unaffected.

Update checkout, setup-node, and pnpm action setup to their current Node 24-backed majors across checks, formatting, dev publishing, and releases. The check workflow also stops provisioning Bun twice: its tooling job now owns Biome, build, type contracts, the preview publication, and the Bun runtime suite, while the remaining matrix covers Node and Deno.

The explicit `node-version: 22.x` pins remain unchanged because they control the Seyfert runtime rather than JavaScript action internals. Preview publication still follows lint, build, and type contracts without being gated by the Bun runtime suite.

Stacked on #436.