### PR TITLE
refactor(cache)!: make adapter writes atomic

### DIFF
--- a/benchmarks/limited-cache.mjs
+++ b/benchmarks/limited-cache.mjs
@@ -1,0 +1,829 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repository = join(dirname(fileURLToPath(import.meta.url)), '..');
+const requireFromRepository = createRequire(join(repository, 'package.json'));
+const defaultBaselineRef = 'faf60b4a0fc85bb40943f7c871c9d9d5bb9abbc2';
+const baselineArgument = process.argv.indexOf('--baseline');
+const baselineRef =
+	process.env.SEYFERT_CACHE_BENCH_BASELINE ??
+	(baselineArgument === -1 ? defaultBaselineRef : process.argv[baselineArgument + 1]);
+if (!baselineRef) throw new Error('Expected a git ref after --baseline');
+const baselineSha = execFileSync('git', ['rev-parse', '--verify', `${baselineRef}^{commit}`], {
+	cwd: repository,
+	encoding: 'utf8',
+}).trim();
+const mebibyte = 1024 * 1024;
+const minimumRepetitions = 7;
+const maximumRepetitions = 11;
+const minimumMeasuredMilliseconds = 1_000;
+const warmupWrites = 20_000;
+const expectedRelationships = new WeakMap();
+let trackExpectedRelationships = false;
+const arms = [
+	{ id: 'memory-head', label: 'Memory baseline' },
+	{ id: 'memory-final', label: 'Memory working tree' },
+	{ id: 'limited-head', label: 'Limited baseline' },
+	{ id: 'limited-final', label: 'Limited working tree' },
+];
+const comparisons = [
+	{ baseline: 'memory-head', candidate: 'memory-final', label: 'Memory working tree compared with Memory baseline' },
+	{ baseline: 'limited-head', candidate: 'limited-final', label: 'Limited working tree compared with Limited baseline' },
+	{
+		baseline: 'limited-final',
+		candidate: 'memory-final',
+		label: 'Memory working tree compared with Limited working tree',
+	},
+];
+
+const scenarios = [
+	{
+		id: 'no-ttl',
+		label: 'No TTL',
+		description: '250k adapter sets with one relationship each and unlimited retention',
+		writes: 250_000,
+		expectedEntries: 250_000,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.125000', relationship: 'user' },
+			{ key: 'user.249999', relationship: 'user' },
+		],
+		write: writeUser,
+	},
+	{
+		id: 'many-buckets',
+		label: 'Many buckets',
+		description: '200k channel inserts, each in a separate guild bucket, without TTL',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: [
+			{ key: 'channel.0', relationship: 'channel.guild-0' },
+			{ key: 'channel.100000', relationship: 'channel.guild-100000' },
+			{ key: 'channel.199999', relationship: 'channel.guild-199999' },
+		],
+		write: writeChannel,
+	},
+	{
+		id: 'bounded',
+		label: 'Bounded retention',
+		description: '250k adapter sets with one relationship each, with Limited variants capped at 50k',
+		writes: 250_000,
+		expectedEntries: 250_000,
+		expectedLimitedEntries: 50_000,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.249999', relationship: 'user' },
+		],
+		limitedProbes: [
+			{ key: 'user.0', relationship: 'user', present: false },
+			{ key: 'user.200000', relationship: 'user' },
+			{ key: 'user.249999', relationship: 'user' },
+		],
+		write: writeUser,
+		adapterOptions: { default: { limit: 50_000 } },
+	},
+	{
+		id: 'ttl-wave',
+		label: 'TTL expiration wave',
+		description: '200k adapter sets with one relationship each, with Limited variants expiring after 3s',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		expectedLimitedEntries: 0,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.199999', relationship: 'user' },
+		],
+		limitedProbes: [
+			{ key: 'user.0', relationship: 'user', present: false },
+			{ key: 'user.199999', relationship: 'user', present: false },
+		],
+		write: writeUser,
+		adapterOptions: { default: { expire: 3_000 } },
+		waitForCleanup: true,
+	},
+	{
+		id: 'mixed',
+		label: 'Mixed reads and writes',
+		description: '200k inserts followed by 800k deterministic operations: 80% reads and 20% writes',
+		writes: 200_000,
+		expectedEntries: 220_000,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.200000', relationship: 'user' },
+			{ key: 'user.299995', relationship: 'user' },
+		],
+		write: writeUser,
+		mixedOperations: 800_000,
+	},
+	{
+		id: 'reads',
+		label: 'Steady reads',
+		description: '200k retained user entries followed by 1m deterministic reads',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 1_000_000,
+		expectedEntries: 200_000,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.100000', relationship: 'user' },
+			{ key: 'user.199999', relationship: 'user' },
+		],
+		write: writeUser,
+	},
+	{
+		id: 'bulk',
+		label: 'Bulk writes',
+		description: '200k user writes in 1k-entry batches, with one repeated ID per batch',
+		writes: 200_000,
+		expectedEntries: 199_800,
+		probes: [
+			{ key: 'user.0', relationship: 'user' },
+			{ key: 'user.998', relationship: 'user' },
+			{ key: 'user.999', relationship: 'user', present: false },
+			{ key: 'user.199998', relationship: 'user' },
+			{ key: 'user.199999', relationship: 'user', present: false },
+		],
+		batchSize: 1_000,
+		writeBatch: writeUserBatch,
+	},
+];
+
+function evaluateCommonJs(source, filename, dependencies) {
+	const typescript = requireFromRepository('typescript');
+	const output = typescript.transpileModule(source, {
+		compilerOptions: {
+			module: typescript.ModuleKind.CommonJS,
+			target: typescript.ScriptTarget.ES2022,
+		},
+		fileName: filename,
+	}).outputText;
+	const module = { exports: {} };
+	const localRequire = specifier => {
+		if (specifier in dependencies) return dependencies[specifier];
+		throw new Error(`Unexpected dependency ${specifier} from ${filename}`);
+	};
+	new Function('require', 'module', 'exports', `${output}\n//# sourceURL=${filename}`)(
+		localRequire,
+		module,
+		module.exports,
+	);
+	return module.exports;
+}
+
+function loadBaseline(path, dependencies) {
+	return evaluateCommonJs(
+		execFileSync('git', ['show', `${baselineSha}:${path}`], { cwd: repository, encoding: 'utf8' }),
+		`baseline/${path}`,
+		dependencies,
+	);
+}
+
+function baselineHas(path) {
+	return spawnSync('git', ['cat-file', '-e', `${baselineSha}:${path}`], { cwd: repository }).status === 0;
+}
+
+function loadAdapters() {
+	const current = requireFromRepository(join(repository, 'lib/index.js'));
+	const common = requireFromRepository(join(repository, 'lib/common/index.js'));
+	const legacyCollection = loadBaseline('src/collection.ts', { './common': common });
+	const baselineShared = baselineHas('src/cache/adapters/shared.ts')
+		? loadBaseline('src/cache/adapters/shared.ts', { '../../common': common })
+		: undefined;
+	const legacyMemoryAdapter = loadBaseline('src/cache/adapters/default.ts', { './shared': baselineShared });
+	const legacyLimitedAdapter = loadBaseline('src/cache/adapters/limited.ts', {
+		'../..': { LimitedCollection: legacyCollection.LimitedCollection },
+		'../../collection': legacyCollection,
+		'../../common': common,
+		'./shared': baselineShared,
+	});
+
+	return {
+		FinalMemoryAdapter: current.MemoryAdapter,
+		HeadMemoryAdapter: legacyMemoryAdapter.MemoryAdapter,
+		FinalLimitedMemoryAdapter: current.LimitedMemoryAdapter,
+		HeadLimitedMemoryAdapter: legacyLimitedAdapter.LimitedMemoryAdapter,
+	};
+}
+
+function isMemoryArm(arm) {
+	return arm.startsWith('memory-');
+}
+
+function createAdapter(arm, scenario, adapters) {
+	if (arm === 'memory-head') return new adapters.HeadMemoryAdapter();
+	if (arm === 'memory-final') return new adapters.FinalMemoryAdapter();
+	const Adapter = arm === 'limited-head' ? adapters.HeadLimitedMemoryAdapter : adapters.FinalLimitedMemoryAdapter;
+	return new Adapter(scenario.adapterOptions);
+}
+
+function disposeAdapter(adapter, arm) {
+	if (!isMemoryArm(arm)) {
+		for (const bucket of [...adapter.storage.values()]) bucket.clear();
+	}
+	adapter.flush();
+}
+
+async function warmUp(arm, scenario, adapters) {
+	const adapter = createAdapter(arm, scenario, adapters);
+	const warmupScenario = {
+		...scenario,
+		writes: Math.min(scenario.writes, warmupWrites),
+		preloadWrites: scenario.preloadWrites ? Math.min(scenario.preloadWrites, warmupWrites) : undefined,
+		readOperations: scenario.readOperations ? Math.min(scenario.readOperations, warmupWrites * 4) : undefined,
+		mixedOperations: scenario.mixedOperations ? Math.min(scenario.mixedOperations, warmupWrites * 4) : undefined,
+		waitForCleanup: false,
+	};
+	await prepareWorkload(adapter, warmupScenario, () => {});
+	await executeWorkload(
+		adapter,
+		warmupScenario,
+		() => {},
+	);
+	disposeAdapter(adapter, arm);
+	await immediate();
+}
+
+function hasBucketedStorage(adapter) {
+	return 'keyToStorage' in adapter;
+}
+
+function countEntries(adapter, arm) {
+	if (isMemoryArm(arm) && !hasBucketedStorage(adapter)) return adapter.storage.size;
+	let entries = 0;
+	for (const bucket of adapter.storage.values()) entries += bucket.size;
+	return entries;
+}
+
+function countRelationshipIds(adapter, arm) {
+	let count = 0;
+	if (isMemoryArm(arm) && !hasBucketedStorage(adapter)) {
+		for (const values of adapter.relationships.values()) count += values.size;
+	} else if (usesAtomicWrites(adapter)) {
+		for (const [namespace, storage] of adapter.storage) {
+			for (const key of storage.keys()) {
+				if (adapter.keyToRelationship?.has(key) || namespace === 'message' || namespace.startsWith('message.')) continue;
+				count++;
+			}
+		}
+		if (adapter.relationships) {
+			for (const relationships of adapter.relationships.values()) {
+				for (const ids of relationships.values()) count += ids.size;
+			}
+		}
+	} else {
+		for (const relation of adapter.relationships.values()) {
+			for (const values of relation.values()) count += values.size;
+		}
+	}
+	return count;
+}
+
+function trackRelationship(adapter, key, relationship) {
+	if (!trackExpectedRelationships) return;
+	let relationships = expectedRelationships.get(adapter);
+	if (!relationships) {
+		relationships = new Map();
+		expectedRelationships.set(adapter, relationships);
+	}
+	relationships.set(key, relationship);
+}
+
+function countVerifiedRelationships(adapter) {
+	let count = 0;
+	for (const [key, [to, id]] of expectedRelationships.get(adapter) ?? []) {
+		if (adapter.get(key) === null) continue;
+		if (!adapter.contains(to, id)) throw new Error(`${key} is retained without its expected relationship ${to}:${id}`);
+		count++;
+	}
+	return count;
+}
+
+function countBuckets(adapter, arm) {
+	return isMemoryArm(arm) && !hasBucketedStorage(adapter) ? 1 : adapter.storage.size;
+}
+
+function usesAtomicWrites(adapter) {
+	return adapter.set.length >= 3;
+}
+
+function setWithRelationship(adapter, key, value, relationship) {
+	if (usesAtomicWrites(adapter)) {
+		adapter.set(key, value, relationship);
+		trackRelationship(adapter, key, relationship);
+		return;
+	}
+	adapter.addToRelationship(relationship[0], relationship[1]);
+	adapter.set(key, value);
+	trackRelationship(adapter, key, relationship);
+}
+
+function writeUser(adapter, id) {
+	const stringId = String(id);
+	setWithRelationship(
+		adapter,
+		`user.${stringId}`,
+		{ id: stringId, username: `member-${stringId}`, flags: id & 31 },
+		['user', stringId],
+	);
+}
+
+function writeChannel(adapter, id) {
+	const stringId = String(id);
+	setWithRelationship(
+		adapter,
+		`channel.${stringId}`,
+		{
+			id: stringId,
+			guild_id: `guild-${stringId}`,
+			name: `channel-${stringId}`,
+		},
+		[`channel.guild-${stringId}`, stringId],
+	);
+}
+
+function writeUserBatch(adapter, start, end) {
+	const ids = [];
+	const entries = [];
+	for (let index = start; index < end; index++) {
+		const id = String(index === end - 1 ? index - 1 : index);
+		ids.push(id);
+		entries.push([`user.${id}`, { id, username: `member-${id}`, flags: index & 31 }, ['user', id]]);
+	}
+	if (usesAtomicWrites(adapter)) {
+		adapter.bulkSet(entries);
+		for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+		return;
+	}
+	adapter.bulkAddToRelationShip({ user: ids });
+	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
+	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+}
+
+const immediate = () => new Promise(resolve => setImmediate(resolve));
+const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function executeInChunks(total, operation, observe, chunkSize = 2_000) {
+	for (let start = 0; start < total; start += chunkSize) {
+		const end = Math.min(total, start + chunkSize);
+		for (let index = start; index < end; index++) operation(index);
+		observe();
+		await immediate();
+	}
+}
+
+async function prepareWorkload(adapter, scenario, observe) {
+	if (!scenario.preloadWrites) return;
+	await executeInChunks(scenario.preloadWrites, index => scenario.write(adapter, index), observe);
+}
+
+async function executeWorkload(adapter, scenario, observe) {
+	const operationStart = performance.now();
+	let operations = scenario.writes;
+	let expectedReads = 0;
+	let validatedReads = 0;
+	if (scenario.writeBatch) {
+		for (let start = 0; start < scenario.writes; start += scenario.batchSize) {
+			scenario.writeBatch(adapter, start, Math.min(scenario.writes, start + scenario.batchSize));
+			observe();
+			await immediate();
+		}
+	} else {
+		await executeInChunks(scenario.writes, index => scenario.write(adapter, index), observe);
+	}
+
+	if (scenario.mixedOperations) {
+		let randomState = 0x5eedc0de;
+		operations += scenario.mixedOperations;
+		await executeInChunks(
+			scenario.mixedOperations,
+			index => {
+				randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
+				if (index % 5 === 0) writeUser(adapter, scenario.writes + (index % 100_000));
+				else {
+					const id = String(randomState % scenario.writes);
+					expectedReads++;
+					if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				}
+			},
+			observe,
+		);
+	}
+	if (scenario.readOperations) {
+		let randomState = 0x5eedc0de;
+		operations += scenario.readOperations;
+		await executeInChunks(
+			scenario.readOperations,
+			() => {
+				randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
+				const id = String(randomState % scenario.preloadWrites);
+				expectedReads++;
+				if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+			},
+			observe,
+		);
+	}
+	if (validatedReads !== expectedReads) {
+		throw new Error(`validated ${validatedReads.toLocaleString()} of ${expectedReads.toLocaleString()} cache reads`);
+	}
+
+	const operationMilliseconds = performance.now() - operationStart;
+	return { operations, operationMilliseconds, throughputOpsPerSecond: operations / (operationMilliseconds / 1_000) };
+}
+
+async function waitForCleanup(adapter, arm, scenario, observe) {
+	if (!scenario.waitForCleanup || isMemoryArm(arm)) return null;
+	const cleanupStart = performance.now();
+	const cleanupDeadline = cleanupStart + 15_000;
+	while (countEntries(adapter, arm) !== 0 && performance.now() < cleanupDeadline) {
+		observe();
+		await delay(5);
+	}
+	if (countEntries(adapter, arm) !== 0) throw new Error(`${arm} did not drain its TTL wave`);
+	return performance.now() - cleanupStart;
+}
+
+function assertRetainedState(adapter, arm, scenario, retained) {
+	const expectedEntries =
+		!isMemoryArm(arm) && scenario.expectedLimitedEntries !== undefined
+			? scenario.expectedLimitedEntries
+			: scenario.expectedEntries;
+	if (retained.entries !== expectedEntries || retained.relationshipIds !== expectedEntries) {
+		throw new Error(
+			`${arm} retained ${retained.entries.toLocaleString()} entries and ${retained.relationshipIds.toLocaleString()} relationships; expected ${expectedEntries.toLocaleString()} of each`,
+		);
+	}
+	const probes = !isMemoryArm(arm) && scenario.limitedProbes ? scenario.limitedProbes : scenario.probes;
+	for (const probe of probes) {
+		const id = probe.key.slice(probe.key.lastIndexOf('.') + 1);
+		const expectedPresent = probe.present ?? true;
+		const valuePresent = adapter.get(probe.key)?.id === id;
+		const relationshipPresent = adapter.contains(probe.relationship, id);
+		if (valuePresent !== expectedPresent || relationshipPresent !== expectedPresent) {
+			throw new Error(
+				`${arm} probe ${probe.key} expected present=${expectedPresent}; get=${valuePresent}, contains=${relationshipPresent}`,
+			);
+		}
+	}
+}
+
+async function verifyScenarioRelationships(arm, scenario, adapters) {
+	const adapter = createAdapter(arm, scenario, adapters);
+	trackExpectedRelationships = true;
+	try {
+		await prepareWorkload(adapter, scenario, () => {});
+		await executeWorkload(adapter, scenario, () => {});
+		await waitForCleanup(adapter, arm, scenario, () => {});
+		const retained = {
+			entries: countEntries(adapter, arm),
+			buckets: countBuckets(adapter, arm),
+			relationshipIds: countRelationshipIds(adapter, arm),
+			indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
+		};
+		assertRetainedState(adapter, arm, scenario, retained);
+		const verifiedRelationships = countVerifiedRelationships(adapter);
+		if (verifiedRelationships !== retained.relationshipIds) {
+			throw new Error(
+				`${arm} verified ${verifiedRelationships.toLocaleString()} retained relationships; found ${retained.relationshipIds.toLocaleString()} in adapter state`,
+			);
+		}
+	} finally {
+		trackExpectedRelationships = false;
+		adapter.flush();
+	}
+}
+
+async function runChild(arm, scenarioId) {
+	const scenario = scenarios.find(candidate => candidate.id === scenarioId);
+	if (!scenario) throw new Error(`Unknown scenario ${scenarioId}`);
+	const adapters = loadAdapters();
+	await warmUp(arm, scenario, adapters);
+	globalThis.gc?.();
+	await immediate();
+	const adapter = createAdapter(arm, scenario, adapters);
+	const baselineRss = process.memoryUsage().rss;
+	let peakRss = baselineRss;
+	const observe = () => {
+		peakRss = Math.max(peakRss, process.memoryUsage().rss);
+	};
+	await prepareWorkload(adapter, scenario, observe);
+	globalThis.gc?.();
+	await immediate();
+	observe();
+	const eventLoopDelay = monitorEventLoopDelay({ resolution: 1 });
+	eventLoopDelay.enable();
+	await immediate();
+	const cpuStart = process.cpuUsage();
+	const workload = await executeWorkload(adapter, scenario, observe);
+	const cleanupMilliseconds = await waitForCleanup(adapter, arm, scenario, observe);
+
+	await immediate();
+	observe();
+	eventLoopDelay.disable();
+	const cpu = process.cpuUsage(cpuStart);
+	const retained = {
+		entries: countEntries(adapter, arm),
+		buckets: countBuckets(adapter, arm),
+		relationshipIds: countRelationshipIds(adapter, arm),
+		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
+	};
+	assertRetainedState(adapter, arm, scenario, retained);
+	adapter.flush();
+	if (process.env.SEYFERT_CACHE_BENCH_VERIFY_RELATIONSHIPS === '1') {
+		await verifyScenarioRelationships(arm, scenario, adapters);
+	}
+
+	return {
+		arm,
+		scenario: scenario.id,
+		...workload,
+		cleanupMilliseconds,
+		cpuMilliseconds: (cpu.user + cpu.system) / 1_000,
+		peakRssDeltaMiB: (peakRss - baselineRss) / mebibyte,
+		eventLoopP95Milliseconds: eventLoopDelay.percentile(95) / 1e6,
+		eventLoopMaxMilliseconds: eventLoopDelay.max / 1e6,
+		retained,
+	};
+}
+
+function median(values) {
+	const sorted = [...values].sort((left, right) => left - right);
+	const middle = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function medianAbsoluteDeviation(values, middle = median(values)) {
+	return median(values.map(value => Math.abs(value - middle)));
+}
+
+function summarize(runs) {
+	const numericFields = [
+		'throughputOpsPerSecond',
+		'cpuMilliseconds',
+		'peakRssDeltaMiB',
+		'eventLoopP95Milliseconds',
+		'eventLoopMaxMilliseconds',
+	];
+	const summary = {
+		retained: runs.at(-1).retained,
+		repetitions: runs.length,
+		measuredMilliseconds: runs.reduce((total, run) => total + run.operationMilliseconds, 0),
+		medianAbsoluteDeviations: {},
+		medianAbsoluteDeviationPercentages: {},
+	};
+	for (const field of numericFields) {
+		const values = runs.map(run => run[field]);
+		const middle = median(values);
+		const deviation = medianAbsoluteDeviation(values, middle);
+		summary[field] = middle;
+		summary.medianAbsoluteDeviations[field] = deviation;
+		summary.medianAbsoluteDeviationPercentages[field] =
+			middle === 0 ? 0 : (deviation / Math.abs(middle)) * 100;
+	}
+	const cleanup = runs.map(run => run.cleanupMilliseconds).filter(value => value !== null);
+	summary.cleanupMilliseconds = cleanup.length ? median(cleanup) : null;
+	const cleanupDeviation = cleanup.length ? medianAbsoluteDeviation(cleanup, summary.cleanupMilliseconds) : 0;
+	summary.medianAbsoluteDeviations.cleanupMilliseconds = cleanupDeviation;
+	summary.medianAbsoluteDeviationPercentages.cleanupMilliseconds =
+		summary.cleanupMilliseconds === null || summary.cleanupMilliseconds === 0
+			? 0
+			: (cleanupDeviation / Math.abs(summary.cleanupMilliseconds)) * 100;
+	return summary;
+}
+
+function formatNumber(value, fractionDigits = 1) {
+	return value.toLocaleString('en-US', {
+		minimumFractionDigits: fractionDigits,
+		maximumFractionDigits: fractionDigits,
+	});
+}
+
+function formatMetric(value, unit, fractionDigits = 1) {
+	return `${formatNumber(value, fractionDigits)} ${unit}`;
+}
+
+function formatMeasuredMetric(summary, field, unit, fractionDigits = 1) {
+	return `${formatMetric(summary[field], unit, fractionDigits)} ±${formatNumber(
+		summary.medianAbsoluteDeviationPercentages[field],
+	)}%`;
+}
+
+function describeRelativeChange(candidate, baseline) {
+	const percentage = ((candidate - baseline) / baseline) * 100;
+	if (Math.abs(percentage) < 0.05) return 'unchanged';
+	return `${formatNumber(Math.abs(percentage))}% ${percentage > 0 ? 'higher' : 'lower'}`;
+}
+
+function describeAbsoluteChange(candidate, baseline, unit) {
+	const difference = candidate - baseline;
+	if (Math.abs(difference) < 0.05) return 'unchanged';
+	return `${formatMetric(Math.abs(difference), unit)} ${difference > 0 ? 'higher' : 'lower'}`;
+}
+
+function describeCleanupChange(candidate, baseline) {
+	if (candidate === null || baseline === null) return 'not applicable';
+	const difference = candidate - baseline;
+	if (Math.abs(difference) < 0.05) return 'unchanged';
+	return `${formatMetric(Math.abs(difference), 'ms')} ${difference > 0 ? 'later' : 'earlier'}`;
+}
+
+function madBandsOverlap(candidate, baseline, field) {
+	if (candidate[field] === null || baseline[field] === null) return false;
+	return (
+		Math.abs(candidate[field] - baseline[field]) <=
+		candidate.medianAbsoluteDeviations[field] + baseline.medianAbsoluteDeviations[field]
+	);
+}
+
+function markInconclusive(description, candidate, baseline, field) {
+	if (description === 'unchanged' || description === 'not applicable') return description;
+	return madBandsOverlap(candidate, baseline, field)
+		? `${description} (inconclusive: MAD bands overlap)`
+		: description;
+}
+
+function printMetricTable(summary) {
+	console.table(
+		arms.map(arm => {
+			const value = summary[arm.id];
+			return {
+				Adapter: arm.label,
+				'Throughput ↑': formatMeasuredMetric(value, 'throughputOpsPerSecond', 'ops/s', 0),
+				'CPU ↓': formatMeasuredMetric(value, 'cpuMilliseconds', 'ms'),
+				'RSS growth ↓': formatMeasuredMetric(value, 'peakRssDeltaMiB', 'MiB'),
+				'Loop p95 ↓': formatMeasuredMetric(value, 'eventLoopP95Milliseconds', 'ms', 2),
+				'Loop max ↓': formatMeasuredMetric(value, 'eventLoopMaxMilliseconds', 'ms', 2),
+				'Cleanup wait ↓':
+					value.cleanupMilliseconds === null
+						? '-'
+						: formatMeasuredMetric(value, 'cleanupMilliseconds', 'ms'),
+			};
+		}),
+	);
+}
+
+function printComparison(summary, comparison) {
+	const baseline = summary[comparison.baseline];
+	const candidate = summary[comparison.candidate];
+	console.log(`\n${comparison.label}:`);
+	console.log(
+		`  Throughput ↑     ${markInconclusive(
+			describeRelativeChange(candidate.throughputOpsPerSecond, baseline.throughputOpsPerSecond),
+			candidate,
+			baseline,
+			'throughputOpsPerSecond',
+		)}`,
+	);
+	console.log(
+		`  CPU time ↓       ${markInconclusive(
+			describeRelativeChange(candidate.cpuMilliseconds, baseline.cpuMilliseconds),
+			candidate,
+			baseline,
+			'cpuMilliseconds',
+		)}`,
+	);
+	console.log(
+		`  RSS growth ↓     ${markInconclusive(
+			describeAbsoluteChange(candidate.peakRssDeltaMiB, baseline.peakRssDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'peakRssDeltaMiB',
+		)}`,
+	);
+	console.log(
+		`  Event-loop max ↓ ${markInconclusive(
+			describeRelativeChange(candidate.eventLoopMaxMilliseconds, baseline.eventLoopMaxMilliseconds),
+			candidate,
+			baseline,
+			'eventLoopMaxMilliseconds',
+		)}`,
+	);
+	console.log(
+		`  Cleanup wait ↓   ${markInconclusive(
+			describeCleanupChange(candidate.cleanupMilliseconds, baseline.cleanupMilliseconds),
+			candidate,
+			baseline,
+			'cleanupMilliseconds',
+		)}`,
+	);
+}
+
+function printRetainedState(summary) {
+	console.log('\nRetained state after the workload:');
+	console.table(
+		arms.map(arm => {
+			const retained = summary[arm.id].retained;
+			return {
+				Adapter: arm.label,
+				Entries: retained.entries,
+				Buckets: retained.buckets,
+				'Logical relationships': retained.relationshipIds,
+				Indexes: retained.indexes,
+			};
+		}),
+	);
+}
+
+function runIsolated(arm, scenario, repetition) {
+	process.stderr.write(`${scenario.label}: ${arm.label}, sample ${repetition}\n`);
+	const child = spawnSync(
+		process.execPath,
+		['--expose-gc', fileURLToPath(import.meta.url), 'child', arm.id, scenario.id],
+		{
+			cwd: repository,
+			encoding: 'utf8',
+			env: {
+				...process.env,
+				SEYFERT_CACHE_BENCH_BASELINE: baselineSha,
+				SEYFERT_CACHE_BENCH_VERIFY_RELATIONSHIPS: repetition === 1 ? '1' : '0',
+			},
+			maxBuffer: 10 * 1024 * 1024,
+		},
+	);
+	if (child.status !== 0) {
+		throw new Error(`${arm.label}, ${scenario.label}, run ${repetition} failed:\n${child.stderr || child.stdout}`);
+	}
+	return { repetition, ...JSON.parse(child.stdout) };
+}
+
+function balancedArms(repetition) {
+	const offset = repetition - 1;
+	return arms.map((_, index) => arms[(index + offset) % arms.length]);
+}
+
+function measuredMillisecondsFor(runs, scenarioId, armId) {
+	return runs
+		.filter(run => run.scenario === scenarioId && run.arm === armId)
+		.reduce((total, run) => total + run.operationMilliseconds, 0);
+}
+
+function hasEnoughMeasuredTime(runs, scenarioId) {
+	return arms.every(arm => measuredMillisecondsFor(runs, scenarioId, arm.id) >= minimumMeasuredMilliseconds);
+}
+
+function printSampleSummary(summary) {
+	const repetitions = summary[arms[0].id].repetitions;
+	console.log(`Samples: ${repetitions} isolated runs per adapter`);
+	console.log(
+		`Measured workload: ${arms
+			.map(arm => `${arm.label} ${formatNumber(summary[arm.id].measuredMilliseconds / 1_000, 3)} s`)
+			.join('; ')}`,
+	);
+	const belowTarget = arms.filter(arm => summary[arm.id].measuredMilliseconds < minimumMeasuredMilliseconds);
+	if (belowTarget.length) {
+		console.log(
+			`Signal warning: ${belowTarget.map(arm => arm.label).join(', ')} did not reach the ${formatNumber(
+				minimumMeasuredMilliseconds / 1_000,
+				1,
+			)} s measured-workload target before the sample cap`,
+		);
+	}
+}
+
+async function runCoordinator() {
+	const runs = [];
+	console.log('Seyfert cache adapter benchmark');
+	console.log('===============================');
+	console.log(`Runtime:    Node ${process.versions.node}`);
+	console.log(`Baseline:   ${baselineRef} (${baselineSha})`);
+	console.log('Candidates: MemoryAdapter and LimitedMemoryAdapter from the current working tree');
+	console.log(
+		`Method:     ${minimumRepetitions}-${maximumRepetitions} isolated samples with warm-up and balanced adapter order`,
+	);
+	console.log(`Target:     at least ${formatNumber(minimumMeasuredMilliseconds / 1_000)} s cumulative measured workload per adapter`);
+	console.log('Integrity:  relationships are checked in one separate untimed run per adapter and scenario');
+	console.log('Direction:  ↑ higher is better; ↓ lower is better; retained-state counts are descriptive');
+	console.log('Metrics:    values are medians; ± is median absolute deviation as a percentage; loop values are event-loop delays\n');
+
+	for (const scenario of scenarios) {
+		for (let repetition = 1; repetition <= maximumRepetitions; repetition++) {
+			for (const arm of balancedArms(repetition)) runs.push(runIsolated(arm, scenario, repetition));
+			if (repetition >= minimumRepetitions && hasEnoughMeasuredTime(runs, scenario.id)) break;
+		}
+	}
+
+	for (const scenario of scenarios) {
+		const summary = Object.fromEntries(
+			arms.map(arm => [
+				arm.id,
+				summarize(runs.filter(run => run.scenario === scenario.id && run.arm === arm.id)),
+			]),
+		);
+		console.log(`\n${scenario.label}`);
+		console.log('-'.repeat(scenario.label.length));
+		console.log(scenario.description);
+		printSampleSummary(summary);
+		console.log();
+		printMetricTable(summary);
+		for (const comparison of comparisons) printComparison(summary, comparison);
+		printRetainedState(summary);
+	}
+}
+
+if (process.argv[2] === 'child') {
+	process.stdout.write(JSON.stringify(await runChild(process.argv[3], process.argv[4])));
+} else {
+	await runCoordinator();
+}

--- a/benchmarks/limited-cache.mjs
+++ b/benchmarks/limited-cache.mjs
@@ -38,6 +38,11 @@ const comparisons = [
 		label: 'Memory working tree compared with Limited working tree',
 	},
 ];
+const messageProbes = [
+	{ key: 'message.0', relationship: 'message.channel-0' },
+	{ key: 'message.100000', relationship: 'message.channel-0' },
+	{ key: 'message.199999', relationship: 'message.channel-19999' },
+];
 
 const scenarios = [
 	{
@@ -134,6 +139,22 @@ const scenarios = [
 		write: writeUser,
 	},
 	{
+		id: 'indexed-misses',
+		label: 'Indexed cache misses',
+		description: '6,680 retained channel buckets followed by 10k missing channel reads',
+		writes: 0,
+		preloadWrites: 6_680,
+		readOperations: 10_000,
+		expectedEntries: 6_680,
+		probes: [
+			{ key: 'channel.0', relationship: 'channel.guild-0' },
+			{ key: 'channel.3339', relationship: 'channel.guild-3339' },
+			{ key: 'channel.6679', relationship: 'channel.guild-6679' },
+		],
+		write: writeChannel,
+		read: readMissingChannel,
+	},
+	{
 		id: 'bulk',
 		label: 'Bulk writes',
 		description: '200k user writes in 1k-entry batches, with one repeated ID per batch',
@@ -149,7 +170,68 @@ const scenarios = [
 		batchSize: 1_000,
 		writeBatch: writeUserBatch,
 	},
+	{
+		id: 'message-writes',
+		label: 'Message writes',
+		description: '200k individual message writes distributed across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+	},
+	{
+		id: 'message-bulk',
+		label: 'Message bulk writes',
+		description: '200k message writes in 1k-entry batches across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		batchSize: 1_000,
+		writeBatch: writeMessageBatch,
+	},
+	{
+		id: 'message-hits',
+		label: 'Message cache hits',
+		description: '200k retained messages followed by 1m deterministic cache hits',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 1_000_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMessage,
+	},
+	{
+		id: 'message-misses',
+		label: 'Message cache misses',
+		description: '200k retained messages followed by 300k deterministic cache misses',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 300_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMissingMessage,
+	},
+	{
+		id: 'message-ttl',
+		label: 'Message TTL expiration wave',
+		description: '200k message writes across 6,680 guild buckets, expiring after 3s',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		expectedLimitedEntries: 0,
+		probes: messageProbes,
+		limitedProbes: messageProbes.map(probe => ({ ...probe, present: false })),
+		write: writeMessage,
+		adapterOptions: { message: { expire: 3_000 } },
+		waitForCleanup: true,
+	},
 ];
+
+const scenarioArgument = process.argv.indexOf('--scenario');
+const selectedScenarios =
+	scenarioArgument === -1 ? scenarios : scenarios.filter(scenario => scenario.id === process.argv[scenarioArgument + 1]);
+if (selectedScenarios.length === 0) throw new Error(`Unknown scenario ${process.argv[scenarioArgument + 1]}`);
 
 function evaluateCommonJs(source, filename, dependencies) {
 	const typescript = requireFromRepository('typescript');
@@ -258,10 +340,9 @@ function countEntries(adapter, arm) {
 }
 
 function countRelationshipIds(adapter, arm) {
+	if (isMemoryArm(arm)) return countEntries(adapter, arm);
 	let count = 0;
-	if (isMemoryArm(arm) && !hasBucketedStorage(adapter)) {
-		for (const values of adapter.relationships.values()) count += values.size;
-	} else if (usesAtomicWrites(adapter)) {
+	if (usesAtomicWrites(adapter)) {
 		for (const [namespace, storage] of adapter.storage) {
 			for (const key of storage.keys()) {
 				if (adapter.keyToRelationship?.has(key) || namespace === 'message' || namespace.startsWith('message.')) continue;
@@ -305,6 +386,25 @@ function countBuckets(adapter, arm) {
 	return isMemoryArm(arm) && !hasBucketedStorage(adapter) ? 1 : adapter.storage.size;
 }
 
+function countSchedules(adapter, arm) {
+	if (isMemoryArm(arm) || !hasBucketedStorage(adapter)) return 0;
+	let schedules = 0;
+	for (const bucket of adapter.storage.values()) {
+		if (bucket.expirationSchedule !== undefined) schedules++;
+	}
+	return schedules;
+}
+
+function retainedState(adapter, arm) {
+	return {
+		entries: countEntries(adapter, arm),
+		buckets: countBuckets(adapter, arm),
+		relationshipIds: countRelationshipIds(adapter, arm),
+		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
+		schedules: countSchedules(adapter, arm),
+	};
+}
+
 function usesAtomicWrites(adapter) {
 	return adapter.set.length >= 3;
 }
@@ -344,6 +444,34 @@ function writeChannel(adapter, id) {
 	);
 }
 
+function messageEntry(id) {
+	const stringId = String(id);
+	const guildId = `guild-${id % 6_680}`;
+	const channelId = `channel-${id % 20_000}`;
+	return [
+		`message.${stringId}`,
+		{ id: stringId, guild_id: guildId, channel_id: channelId, content: `message-${stringId}` },
+		[`message.${channelId}`, stringId],
+	];
+}
+
+function writeMessage(adapter, id) {
+	setWithRelationship(adapter, ...messageEntry(id));
+}
+
+function readMessage(adapter, randomState, scenario) {
+	const id = String(randomState % scenario.preloadWrites);
+	return adapter.get(`message.${id}`)?.id === id;
+}
+
+function readMissingMessage(adapter, randomState) {
+	return adapter.get(`message.missing-${randomState}`) === null;
+}
+
+function readMissingChannel(adapter, randomState) {
+	return adapter.get(`channel.missing-${randomState}`) === null;
+}
+
 function writeUserBatch(adapter, start, end) {
 	const ids = [];
 	const entries = [];
@@ -358,6 +486,21 @@ function writeUserBatch(adapter, start, end) {
 		return;
 	}
 	adapter.bulkAddToRelationShip({ user: ids });
+	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
+	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+}
+
+function writeMessageBatch(adapter, start, end) {
+	const entries = [];
+	for (let index = start; index < end; index++) entries.push(messageEntry(index));
+	if (usesAtomicWrites(adapter)) {
+		adapter.bulkSet(entries);
+		for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+		return;
+	}
+	const relationships = {};
+	for (const [, , [to, id]] of entries) (relationships[to] ??= []).push(id);
+	adapter.bulkAddToRelationShip(relationships);
 	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
 	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
 }
@@ -418,9 +561,13 @@ async function executeWorkload(adapter, scenario, observe) {
 			scenario.readOperations,
 			() => {
 				randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
-				const id = String(randomState % scenario.preloadWrites);
 				expectedReads++;
-				if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				if (scenario.read) {
+					if (scenario.read(adapter, randomState, scenario)) validatedReads++;
+				} else {
+					const id = String(randomState % scenario.preloadWrites);
+					if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				}
 			},
 			observe,
 		);
@@ -476,12 +623,7 @@ async function verifyScenarioRelationships(arm, scenario, adapters) {
 		await prepareWorkload(adapter, scenario, () => {});
 		await executeWorkload(adapter, scenario, () => {});
 		await waitForCleanup(adapter, arm, scenario, () => {});
-		const retained = {
-			entries: countEntries(adapter, arm),
-			buckets: countBuckets(adapter, arm),
-			relationshipIds: countRelationshipIds(adapter, arm),
-			indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-		};
+		const retained = retainedState(adapter, arm);
 		assertRetainedState(adapter, arm, scenario, retained);
 		const verifiedRelationships = countVerifiedRelationships(adapter);
 		if (verifiedRelationships !== retained.relationshipIds) {
@@ -503,8 +645,8 @@ async function runChild(arm, scenarioId) {
 	globalThis.gc?.();
 	await immediate();
 	const adapter = createAdapter(arm, scenario, adapters);
-	const baselineRss = process.memoryUsage().rss;
-	let peakRss = baselineRss;
+	const baselineMemory = process.memoryUsage();
+	let peakRss = baselineMemory.rss;
 	const observe = () => {
 		peakRss = Math.max(peakRss, process.memoryUsage().rss);
 	};
@@ -523,13 +665,11 @@ async function runChild(arm, scenarioId) {
 	observe();
 	eventLoopDelay.disable();
 	const cpu = process.cpuUsage(cpuStart);
-	const retained = {
-		entries: countEntries(adapter, arm),
-		buckets: countBuckets(adapter, arm),
-		relationshipIds: countRelationshipIds(adapter, arm),
-		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-	};
+	const retained = retainedState(adapter, arm);
 	assertRetainedState(adapter, arm, scenario, retained);
+	globalThis.gc?.();
+	await immediate();
+	const retainedMemory = process.memoryUsage();
 	adapter.flush();
 	if (process.env.SEYFERT_CACHE_BENCH_VERIFY_RELATIONSHIPS === '1') {
 		await verifyScenarioRelationships(arm, scenario, adapters);
@@ -541,7 +681,9 @@ async function runChild(arm, scenarioId) {
 		...workload,
 		cleanupMilliseconds,
 		cpuMilliseconds: (cpu.user + cpu.system) / 1_000,
-		peakRssDeltaMiB: (peakRss - baselineRss) / mebibyte,
+		peakRssDeltaMiB: (peakRss - baselineMemory.rss) / mebibyte,
+		rssAfterGcDeltaMiB: (retainedMemory.rss - baselineMemory.rss) / mebibyte,
+		heapAfterGcDeltaMiB: (retainedMemory.heapUsed - baselineMemory.heapUsed) / mebibyte,
 		eventLoopP95Milliseconds: eventLoopDelay.percentile(95) / 1e6,
 		eventLoopMaxMilliseconds: eventLoopDelay.max / 1e6,
 		retained,
@@ -563,6 +705,8 @@ function summarize(runs) {
 		'throughputOpsPerSecond',
 		'cpuMilliseconds',
 		'peakRssDeltaMiB',
+		'rssAfterGcDeltaMiB',
+		'heapAfterGcDeltaMiB',
 		'eventLoopP95Milliseconds',
 		'eventLoopMaxMilliseconds',
 	];
@@ -653,6 +797,8 @@ function printMetricTable(summary) {
 				'Throughput ↑': formatMeasuredMetric(value, 'throughputOpsPerSecond', 'ops/s', 0),
 				'CPU ↓': formatMeasuredMetric(value, 'cpuMilliseconds', 'ms'),
 				'RSS growth ↓': formatMeasuredMetric(value, 'peakRssDeltaMiB', 'MiB'),
+				'RSS after GC ↓': formatMeasuredMetric(value, 'rssAfterGcDeltaMiB', 'MiB'),
+				'Heap after GC ↓': formatMeasuredMetric(value, 'heapAfterGcDeltaMiB', 'MiB'),
 				'Loop p95 ↓': formatMeasuredMetric(value, 'eventLoopP95Milliseconds', 'ms', 2),
 				'Loop max ↓': formatMeasuredMetric(value, 'eventLoopMaxMilliseconds', 'ms', 2),
 				'Cleanup wait ↓':
@@ -693,6 +839,22 @@ function printComparison(summary, comparison) {
 		)}`,
 	);
 	console.log(
+		`  RSS after GC ↓   ${markInconclusive(
+			describeAbsoluteChange(candidate.rssAfterGcDeltaMiB, baseline.rssAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'rssAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
+		`  Heap after GC ↓  ${markInconclusive(
+			describeAbsoluteChange(candidate.heapAfterGcDeltaMiB, baseline.heapAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'heapAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
 		`  Event-loop max ↓ ${markInconclusive(
 			describeRelativeChange(candidate.eventLoopMaxMilliseconds, baseline.eventLoopMaxMilliseconds),
 			candidate,
@@ -721,6 +883,7 @@ function printRetainedState(summary) {
 				Buckets: retained.buckets,
 				'Logical relationships': retained.relationshipIds,
 				Indexes: retained.indexes,
+				Schedules: retained.schedules,
 			};
 		}),
 	);
@@ -797,14 +960,14 @@ async function runCoordinator() {
 	console.log('Direction:  ↑ higher is better; ↓ lower is better; retained-state counts are descriptive');
 	console.log('Metrics:    values are medians; ± is median absolute deviation as a percentage; loop values are event-loop delays\n');
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		for (let repetition = 1; repetition <= maximumRepetitions; repetition++) {
 			for (const arm of balancedArms(repetition)) runs.push(runIsolated(arm, scenario, repetition));
 			if (repetition >= minimumRepetitions && hasEnoughMeasuredTime(runs, scenario.id)) break;
 		}
 	}
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		const summary = Object.fromEntries(
 			arms.map(arm => [
 				arm.id,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	],
 	"scripts": {
 		"build": "tsc --outDir ./lib",
+		"bench:limited-cache": "pnpm run build && node --expose-gc ./benchmarks/limited-cache.mjs",
 		"prepublishOnly": "npm run build",
 		"prepare": "npm run build && husky",
 		"lint": "biome lint --write ./src",

--- a/src/cache/adapters/default.ts
+++ b/src/cache/adapters/default.ts
@@ -1,4 +1,5 @@
-import type { Adapter } from './types';
+import { needsCacheStorageIndex } from './shared';
+import type { Adapter, AdapterEntry, AdapterRelationship } from './types';
 
 export interface MemoryAdapterOptions<T> {
 	encode(data: any): T;
@@ -8,8 +9,8 @@ export interface MemoryAdapterOptions<T> {
 export class MemoryAdapter<T> implements Adapter {
 	isAsync = false;
 
-	readonly storage = new Map<string, T>();
-	readonly relationships = new Map<string, Set<string>>();
+	readonly storage = new Map<string, Map<string, T>>();
+	readonly keyToStorage = new Map<string, string>();
 
 	constructor(
 		public options: MemoryAdapterOptions<T> = {
@@ -31,13 +32,15 @@ export class MemoryAdapter<T> implements Adapter {
 	scan(query: string, keys = false) {
 		const values: (string | unknown)[] = [];
 		const sq = query.split('.');
-		for (const [key, value] of this.storage.entries()) {
-			const keySplit = key.split('.');
-			if (
-				keySplit.length === sq.length &&
-				keySplit.every((segment, i) => (sq[i] === '*' ? !!segment : sq[i] === segment))
-			) {
-				values.push(keys ? key : this.options.decode(value));
+		for (const storageEntry of this.storage.values()) {
+			for (const [key, value] of storageEntry) {
+				const keySplit = key.split('.');
+				if (
+					keySplit.length === sq.length &&
+					keySplit.every((segment, i) => (sq[i] === '*' ? !!segment : sq[i] === segment))
+				) {
+					values.push(keys ? key : this.options.decode(value));
+				}
 			}
 		}
 
@@ -47,117 +50,148 @@ export class MemoryAdapter<T> implements Adapter {
 	bulkGet(keys: string[]) {
 		const result: unknown[] = [];
 		for (const key of keys) {
-			const data = this.storage.get(key);
-			if (data !== undefined) result.push(this.options.decode(data));
+			const storageEntry = this._getStorageEntry(key);
+			if (!storageEntry) continue;
+			const data = storageEntry.get(key);
+			if (data !== undefined || storageEntry.has(key)) result.push(this.options.decode(data!));
 		}
 		return result;
 	}
 
-	get(keys: string) {
-		if (!this.storage.has(keys)) return null;
-		return this.options.decode(this.storage.get(keys)!);
+	get(key: string) {
+		const storageEntry = this._getStorageEntry(key);
+		if (!storageEntry) return null;
+		const data = storageEntry.get(key);
+		if (data === undefined && !storageEntry.has(key)) return null;
+		return this.options.decode(data!);
 	}
 
-	bulkSet(keys: [string, any][]) {
-		for (const [key, value] of keys) {
-			this.storage.set(key, this.options.encode(value));
+	private _getStorageNamespace(key: string) {
+		const indexed = this.keyToStorage.get(key);
+		if (indexed !== undefined) return indexed;
+		const resourceEnd = key.indexOf('.');
+		if (resourceEnd === -1) return undefined;
+		const idStart = key.lastIndexOf('.');
+		return key.slice(0, resourceEnd === idStart ? resourceEnd : idStart);
+	}
+
+	private _getStorageEntry(key: string) {
+		const namespace = this._getStorageNamespace(key);
+		if (namespace === undefined) return undefined;
+		const storageEntry = this.storage.get(namespace);
+		if (!storageEntry && this.keyToStorage.get(key) === namespace) this.keyToStorage.delete(key);
+		return storageEntry;
+	}
+
+	private _moveIndexedEntry(key: string, namespace: string) {
+		const previousNamespace = this.keyToStorage.get(key);
+		if (previousNamespace === undefined || previousNamespace === namespace) return;
+		const previousStorage = this.storage.get(previousNamespace);
+		previousStorage?.delete(key);
+		if (previousStorage?.size === 0) this.storage.delete(previousNamespace);
+	}
+
+	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
+		const data = patch && !Array.isArray(value) ? { ...(this.get(key) ?? {}), ...value } : value;
+		const encoded = this.options.encode(data);
+		const namespace = relationship[0];
+		let storageEntry = this.storage.get(namespace);
+		if (!storageEntry) {
+			storageEntry = new Map();
+			this.storage.set(namespace, storageEntry);
 		}
+		const indexed = needsCacheStorageIndex(key, namespace);
+		if (indexed) this._moveIndexedEntry(key, namespace);
+		storageEntry.set(key, encoded);
+		if (indexed) this.keyToStorage.set(key, namespace);
 	}
 
-	set(key: string, data: any) {
-		this.storage.set(key, this.options.encode(data));
+	set(key: string, value: any, relationship: AdapterRelationship) {
+		this._set(key, value, relationship, false);
 	}
 
-	bulkPatch(keys: [string, any][]) {
-		for (const [key, value] of keys) {
-			const oldData = this.get(key);
-			this.storage.set(
-				key,
-				Array.isArray(value) ? this.options.encode(value) : this.options.encode({ ...(oldData ?? {}), ...value }),
-			);
-		}
+	bulkSet(entries: AdapterEntry[]) {
+		for (const [key, value, relationship] of entries) this._set(key, value, relationship, false);
 	}
 
-	patch(keys: string, data: any) {
-		const oldData = this.get(keys);
-		this.storage.set(
-			keys,
-			Array.isArray(data) ? this.options.encode(data) : this.options.encode({ ...(oldData ?? {}), ...data }),
-		);
+	patch(key: string, value: any, relationship: AdapterRelationship) {
+		this._set(key, value, relationship, true);
+	}
+
+	bulkPatch(entries: AdapterEntry[]) {
+		for (const [key, value, relationship] of entries) this._set(key, value, relationship, true);
 	}
 
 	values(to: string) {
-		const array: any[] = [];
-		const data = this.keys(to);
-
-		for (const key of data) {
-			if (this.storage.has(key)) array.push(this.options.decode(this.storage.get(key)!));
-		}
-
-		return array;
+		const storageEntry = this.storage.get(to);
+		if (!storageEntry) return [];
+		const values: any[] = [];
+		for (const value of storageEntry.values()) values.push(this.options.decode(value));
+		return values;
 	}
 
 	keys(to: string) {
-		return this.getToRelationship(to).map(id => `${to}.${id}`);
+		return [...(this.storage.get(to)?.keys() ?? [])];
 	}
 
 	count(to: string) {
-		return this.relationships.get(to)?.size ?? 0;
+		return this.storage.get(to)?.size ?? 0;
 	}
 
 	bulkRemove(keys: string[]) {
-		for (const i of keys) {
-			this.storage.delete(i);
-		}
+		for (const key of keys) this.remove(key);
 	}
 
 	remove(key: string) {
-		this.storage.delete(key);
+		const namespace = this._getStorageNamespace(key);
+		if (namespace === undefined) return;
+		const storageEntry = this.storage.get(namespace);
+		storageEntry?.delete(key);
+		this.keyToStorage.delete(key);
+		if (storageEntry?.size === 0) this.storage.delete(namespace);
 	}
 
 	flush(): void {
 		this.storage.clear();
-		this.relationships.clear();
+		this.keyToStorage.clear();
 	}
 
-	contains(to: string, keys: string): boolean {
-		return this.relationships.get(to)?.has(keys) ?? false;
+	private _getRelationshipKey(to: string, id: string) {
+		const storageEntry = this.storage.get(to);
+		if (!storageEntry) return undefined;
+		const scopedKey = `${to}.${id}`;
+		if (storageEntry.has(scopedKey)) return scopedKey;
+		const separator = to.indexOf('.');
+		if (separator === -1) return undefined;
+		const globalKey = `${to.slice(0, separator)}.${id}`;
+		return storageEntry.has(globalKey) ? globalKey : undefined;
+	}
+
+	contains(to: string, id: string): boolean {
+		return this._getRelationshipKey(to, id) !== undefined;
 	}
 
 	getToRelationship(to: string): string[] {
-		return [...(this.relationships.get(to) ?? [])];
-	}
-
-	bulkAddToRelationShip(data: Record<string, string[]>) {
-		for (const i in data) {
-			this.addToRelationship(i, data[i]);
-		}
-	}
-
-	addToRelationship(to: string, keys: string | string[]) {
-		if (!this.relationships.has(to)) {
-			this.relationships.set(to, new Set());
-		}
-
-		const data = this.relationships.get(to)!;
-
-		for (const key of Array.isArray(keys) ? keys : [keys]) {
-			data.add(key);
-		}
+		const storageEntry = this.storage.get(to);
+		if (!storageEntry) return [];
+		const ids: string[] = [];
+		for (const key of storageEntry.keys()) ids.push(key.slice(key.lastIndexOf('.') + 1));
+		return ids;
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
-		const data = this.relationships.get(to);
-		if (data) {
-			for (const key of Array.isArray(keys) ? keys : [keys]) {
-				data.delete(key);
-			}
+		for (const id of Array.isArray(keys) ? keys : [keys]) {
+			const key = this._getRelationshipKey(to, id);
+			if (key) this.remove(key);
 		}
 	}
 
 	removeRelationship(to: string | string[]) {
-		for (const i of Array.isArray(to) ? to : [to]) {
-			this.relationships.delete(i);
+		for (const relationship of Array.isArray(to) ? to : [to]) {
+			const storageEntry = this.storage.get(relationship);
+			if (!storageEntry) continue;
+			for (const key of storageEntry.keys()) this.keyToStorage.delete(key);
+			this.storage.delete(relationship);
 		}
 	}
 }

--- a/src/cache/adapters/default.ts
+++ b/src/cache/adapters/default.ts
@@ -83,14 +83,6 @@ export class MemoryAdapter<T> implements Adapter {
 		return storageEntry;
 	}
 
-	private _moveIndexedEntry(key: string, namespace: string) {
-		const previousNamespace = this.keyToStorage.get(key);
-		if (previousNamespace === undefined || previousNamespace === namespace) return;
-		const previousStorage = this.storage.get(previousNamespace);
-		previousStorage?.delete(key);
-		if (previousStorage?.size === 0) this.storage.delete(previousNamespace);
-	}
-
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
 		const data = patch && !Array.isArray(value) ? { ...(this.get(key) ?? {}), ...value } : value;
 		const encoded = this.options.encode(data);
@@ -101,7 +93,6 @@ export class MemoryAdapter<T> implements Adapter {
 			this.storage.set(namespace, storageEntry);
 		}
 		const indexed = needsCacheStorageIndex(key, namespace);
-		if (indexed) this._moveIndexedEntry(key, namespace);
 		storageEntry.set(key, encoded);
 		if (indexed) this.keyToStorage.set(key, namespace);
 	}

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -31,13 +31,16 @@ export interface LimitedMemoryAdapterOptions<T> {
 	decode?(data: T): unknown;
 }
 
+export type LimitedMemoryStorageIndex<T> =
+	| LimitedCollection<string, T>
+	| readonly [storage: LimitedCollection<string, T>, relationship: AdapterRelationship];
+
 export class LimitedMemoryAdapter<T> implements Adapter {
 	isAsync = false;
 
 	readonly storage = new Map<string, LimitedCollection<string, T>>();
 	readonly relationships = new Map<string, Map<string, Set<string>>>();
-	readonly keyToStorage = new Map<string, LimitedCollection<string, T>>();
-	private readonly keyToRelationship = new Map<string, AdapterRelationship>();
+	readonly keyToStorage = new Map<string, LimitedMemoryStorageIndex<T>>();
 
 	options: MakeRequired<LimitedMemoryAdapterOptions<T>, 'default' | 'encode' | 'decode'>;
 
@@ -102,11 +105,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return key.indexOf('.', resource.length + 1) !== -1;
 	}
 
-	private _setIndexedStorage(key: string, namespace: string, storageEntry: LimitedCollection<string, T>) {
-		if (needsCacheStorageIndex(key, namespace)) this.keyToStorage.set(key, storageEntry);
+	private _getIndexedStorage(index: LimitedMemoryStorageIndex<T>) {
+		return Array.isArray(index) ? index[0] : index;
 	}
 
-	private _deleteIndexedStorage(key: string) {
+	private _deleteIndexedStorage(key: string, storageEntry: LimitedCollection<string, T>) {
+		const index = this.keyToStorage.get(key);
+		if (!index || this._getIndexedStorage(index) !== storageEntry) return;
+		this._removeExplicitRelationship(index);
 		this.keyToStorage.delete(key);
 	}
 
@@ -119,39 +125,26 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return scopeEnd === -1 ? resource : key.slice(0, scopeEnd);
 	}
 
-	private _isResourceNamespace(resource: string, namespace: string) {
-		return namespace === resource || namespace.startsWith(`${resource}.`);
-	}
-
-	private _findNamespaceByStorage(resource: string, storageEntry: LimitedCollection<string, T>) {
-		for (const [namespace, candidate] of this.storage) {
-			if (candidate === storageEntry && this._isResourceNamespace(resource, namespace)) return namespace;
-		}
-		return undefined;
-	}
-
 	private _getMessageNamespace(data: any) {
 		const scope = Array.isArray(data) ? data[0]?.guild_id : data?.guild_id;
 		return scope ? `message.${scope}` : 'message';
 	}
 
 	private _getStorageEntry(key: string) {
+		const index = this.keyToStorage.get(key);
+		if (index) {
+			const indexedStorage = this._getIndexedStorage(index);
+			if (indexedStorage.has(key)) return { storageEntry: indexedStorage };
+			this._deleteIndexedStorage(key, indexedStorage);
+			return undefined;
+		}
+
 		const resource = this._getKeyResource(key);
 		const layout = getCacheResourceLayout(resource);
-		const indexedStorage = this.keyToStorage.get(key);
-		if (indexedStorage?.has(key)) return { resource, layout, storageEntry: indexedStorage };
-		if (indexedStorage) this.keyToStorage.delete(key);
-
 		if (layout !== 'guild-indexed' && layout !== 'message') {
 			const namespace = this._getStorageNamespaceFromKey(resource, layout, key);
 			const storageEntry = this.storage.get(namespace);
-			if (storageEntry?.has(key)) return { resource, layout, namespace, storageEntry };
-		}
-
-		for (const [namespace, storageEntry] of this.storage) {
-			if (!this._isResourceNamespace(resource, namespace) || !storageEntry.has(key)) continue;
-			this._setIndexedStorage(key, namespace, storageEntry);
-			return { resource, layout, namespace, storageEntry };
+			if (storageEntry?.has(key)) return { storageEntry };
 		}
 		return undefined;
 	}
@@ -192,39 +185,19 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return ids;
 	}
 
-	private _removeExplicitRelationship(key: string) {
-		const relationship = this.keyToRelationship.get(key);
-		if (!relationship) return;
-		const [to, id] = relationship;
+	private _removeExplicitRelationship(index: LimitedMemoryStorageIndex<T>) {
+		if (!Array.isArray(index)) return;
+		const [to, id] = index[1];
 		const [resource, scope] = this._getRelationshipData(to);
 		const relationships = this.relationships.get(resource);
 		const ids = relationships?.get(scope);
 		ids?.delete(id);
 		if (ids?.size === 0) relationships?.delete(scope);
 		if (relationships?.size === 0) this.relationships.delete(resource);
-		this.keyToRelationship.delete(key);
 	}
 
-	private _setExplicitRelationship(key: string, relationship: AdapterRelationship) {
-		const previous = this.keyToRelationship.get(key);
-		if (previous && (previous[0] !== relationship[0] || previous[1] !== relationship[1])) {
-			this._removeExplicitRelationship(key);
-		}
+	private _syncMessageRelationship(relationship: AdapterRelationship) {
 		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
-		this.keyToRelationship.set(key, relationship);
-	}
-
-	private _syncRelationship(
-		key: string,
-		layout: CacheResourceLayout,
-		namespace: string,
-		relationship: AdapterRelationship,
-	) {
-		if (layout !== 'message' && namespace === relationship[0]) {
-			this._removeExplicitRelationship(key);
-			return;
-		}
-		this._setExplicitRelationship(key, relationship);
 	}
 
 	private _deleteEmptyStorage(namespace: string, storageEntry: LimitedCollection<string, T>) {
@@ -240,8 +213,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 			limit: resourceOptions?.limit ?? this.options.default.limit,
 			resetOnDemand: (expire ?? 0) > 0,
 			onDelete: key => {
-				this._deleteIndexedStorage(key);
-				this._removeExplicitRelationship(key);
+				this._deleteIndexedStorage(key, bucket);
 				if (bucket.size === 1 && bucket.has(key) && this.storage.get(namespace) === bucket) {
 					this.storage.delete(namespace);
 				}
@@ -249,19 +221,6 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		});
 		this.storage.set(namespace, bucket);
 		return bucket;
-	}
-
-	private _moveStoredEntry(
-		resource: string,
-		key: string,
-		storageEntry: LimitedCollection<string, T>,
-		previousStorageEntry: LimitedCollection<string, T> | undefined,
-	) {
-		if (!previousStorageEntry || previousStorageEntry === storageEntry) return;
-		previousStorageEntry.delete(key);
-		if (previousStorageEntry.size !== 0) return;
-		const previousNamespace = this._findNamespaceByStorage(resource, previousStorageEntry);
-		if (previousNamespace) this.storage.delete(previousNamespace);
 	}
 
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
@@ -274,12 +233,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 		const storageEntry = this.storage.get(namespace) ?? this._createStorageEntry(resource, namespace);
 		const usesIndex = layout === 'message' || needsCacheStorageIndex(key, namespace);
-		this._moveStoredEntry(resource, key, storageEntry, this.keyToStorage.get(key));
-		storageEntry.set(key, encoded);
-
-		if (storageEntry.has(key)) {
-			if (usesIndex) this.keyToStorage.set(key, storageEntry);
-			this._syncRelationship(key, layout, namespace, relationship);
+		const previousMessageIndex = layout === 'message' ? this.keyToStorage.get(key) : undefined;
+		const previousMessageStorage = previousMessageIndex ? this._getIndexedStorage(previousMessageIndex) : undefined;
+		if (storageEntry.set(key, encoded)) {
+			if (previousMessageStorage && previousMessageStorage !== storageEntry) previousMessageStorage.delete(key);
+			if (usesIndex) {
+				this.keyToStorage.set(key, layout === 'message' ? [storageEntry, relationship] : storageEntry);
+			}
+			if (layout === 'message') this._syncMessageRelationship(relationship);
 		}
 		this._deleteEmptyStorage(namespace, storageEntry);
 	}
@@ -317,8 +278,8 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		const bucket = this._getRelationshipBucket(to);
 		if (bucket) return [...bucket.keys()];
 		const keys: string[] = [];
-		for (const [key, relationship] of this.keyToRelationship) {
-			if (relationship[0] === to) keys.push(key);
+		for (const [key, index] of this.keyToStorage) {
+			if (Array.isArray(index) && index[1][0] === to) keys.push(key);
 		}
 		return keys;
 	}
@@ -359,16 +320,17 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		const entry = this._getStorageEntry(key);
 		if (!entry) return;
 		entry.storageEntry.delete(key);
-		this._deleteIndexedStorage(key);
-		if (entry.storageEntry.size !== 0) return;
-		const namespace = entry.namespace ?? this._findNamespaceByStorage(entry.resource, entry.storageEntry);
-		if (namespace) this.storage.delete(namespace);
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
+		const bucket = this._getRelationshipBucket(to);
+		if (bucket) {
+			for (const id of Array.isArray(keys) ? keys : [keys]) bucket.delete(this._getBucketKey(to, id, bucket));
+			return;
+		}
 		const ids = new Set(Array.isArray(keys) ? keys : [keys]);
-		for (const key of this.keys(to)) {
-			if (ids.has(key.slice(key.lastIndexOf('.') + 1))) this.remove(key);
+		for (const [key, index] of this.keyToStorage) {
+			if (Array.isArray(index) && index[1][0] === to && ids.has(index[1][1])) this.remove(key);
 		}
 	}
 
@@ -381,6 +343,5 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		this.storage.clear();
 		this.relationships.clear();
 		this.keyToStorage.clear();
-		this.keyToRelationship.clear();
 	}
 }

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -1,18 +1,8 @@
-import { LimitedCollection } from '../..';
+import { LimitedCollection } from '../../collection';
 import { type MakeRequired, MergeOptions } from '../../common';
-import type { Adapter } from './types';
+import { type CacheResourceLayout, getCacheResourceLayout, needsCacheStorageIndex } from './shared';
+import type { Adapter, AdapterEntry, AdapterRelationship } from './types';
 
-const namespaceIndexedResources = new Set([
-	'channel',
-	'emoji',
-	'presence',
-	'role',
-	'stage_instance',
-	'sticker',
-	'overwrite',
-	'message',
-]);
-const scopeDerivedResources = new Set(['ban', 'member', 'voice_state']);
 export interface ResourceLimitedMemoryAdapter {
 	expire?: number;
 	limit?: number;
@@ -47,6 +37,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	readonly storage = new Map<string, LimitedCollection<string, T>>();
 	readonly relationships = new Map<string, Map<string, Set<string>>>();
 	readonly keyToStorage = new Map<string, LimitedCollection<string, T>>();
+	private readonly keyToRelationship = new Map<string, AdapterRelationship>();
 
 	options: MakeRequired<LimitedMemoryAdapterOptions<T>, 'default' | 'encode' | 'decode'>;
 
@@ -83,7 +74,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 				const keySplit = key.split('.');
 				if (
 					keySplit.length === sq.length &&
-					keySplit.every((segment, i) => (sq[i] === '*' ? !!segment : sq[i] === segment))
+					keySplit.every((segment, index) => (sq[index] === '*' ? !!segment : sq[index] === segment))
 				) {
 					values.push(keys ? key : this.options.decode(entry.value));
 				}
@@ -103,48 +94,29 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	private _getKeyResource(key: string) {
-		const separatorIndex = key.indexOf('.');
-		return separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+		const separator = key.indexOf('.');
+		return separator === -1 ? key : key.slice(0, separator);
 	}
 
-	private _getKeyScope(key: string) {
-		const separatorIndex = key.indexOf('.');
-		if (separatorIndex === -1) {
-			return '';
-		}
-
-		const scopeStart = separatorIndex + 1;
-		const scopeEnd = key.indexOf('.', scopeStart);
-		return scopeEnd === -1 ? key.slice(scopeStart) : key.slice(scopeStart, scopeEnd);
+	private _hasScopedStorageKey(resource: string, key: string) {
+		return key.indexOf('.', resource.length + 1) !== -1;
 	}
 
-	private _supportsNamespaceIndex(resource: string) {
-		return namespaceIndexedResources.has(resource);
+	private _setIndexedStorage(key: string, namespace: string, storageEntry: LimitedCollection<string, T>) {
+		if (needsCacheStorageIndex(key, namespace)) this.keyToStorage.set(key, storageEntry);
 	}
 
-	private _setIndexedStorage(resource: string, key: string, storageEntry: LimitedCollection<string, T>) {
-		if (!this._supportsNamespaceIndex(resource)) {
-			return;
-		}
-		this.keyToStorage.set(key, storageEntry);
-	}
-
-	private _deleteIndexedStorage(resource: string, key: string) {
-		if (!this._supportsNamespaceIndex(resource)) {
-			return;
-		}
+	private _deleteIndexedStorage(key: string) {
 		this.keyToStorage.delete(key);
 	}
 
-	private _getIndexedStorage(resource: string, key: string) {
-		if (!this._supportsNamespaceIndex(resource)) {
-			return;
+	private _getStorageNamespaceFromKey(resource: string, layout: CacheResourceLayout, key: string) {
+		if (layout !== 'guild-keyed' && !(layout === 'custom' && this._hasScopedStorageKey(resource, key))) {
+			return resource;
 		}
-		return this.keyToStorage.get(key);
-	}
 
-	private _getDerivedNamespace(resource: string, scope: string) {
-		return scope && scopeDerivedResources.has(resource) ? `${resource}.${scope}` : resource;
+		const scopeEnd = key.indexOf('.', resource.length + 1);
+		return scopeEnd === -1 ? resource : key.slice(0, scopeEnd);
 	}
 
 	private _isResourceNamespace(resource: string, namespace: string) {
@@ -152,311 +124,263 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	private _findNamespaceByStorage(resource: string, storageEntry: LimitedCollection<string, T>) {
-		for (const [namespace, candidate] of this.storage.entries()) {
-			if (candidate === storageEntry && this._isResourceNamespace(resource, namespace)) {
-				return namespace;
-			}
+		for (const [namespace, candidate] of this.storage) {
+			if (candidate === storageEntry && this._isResourceNamespace(resource, namespace)) return namespace;
 		}
-
 		return undefined;
 	}
 
-	private _getStorageNamespace(resource: string, data: any) {
-		const isArray = Array.isArray(data);
-		if (isArray && data.length === 0) {
-			return;
-		}
-
-		const scope = isArray ? data[0].guild_id : data.guild_id;
-		return `${resource}${scope ? `.${scope}` : ''}`;
+	private _getMessageNamespace(data: any) {
+		const scope = Array.isArray(data) ? data[0]?.guild_id : data?.guild_id;
+		return scope ? `message.${scope}` : 'message';
 	}
 
 	private _getStorageEntry(key: string) {
 		const resource = this._getKeyResource(key);
-		const supportsNamespaceIndex = this._supportsNamespaceIndex(resource);
-		const indexedStorage = this._getIndexedStorage(resource, key);
-		if (indexedStorage?.has(key)) {
-			return {
-				resource,
-				storageEntry: indexedStorage,
-			};
-		}
+		const layout = getCacheResourceLayout(resource);
+		const indexedStorage = this.keyToStorage.get(key);
+		if (indexedStorage?.has(key)) return { resource, layout, storageEntry: indexedStorage };
+		if (indexedStorage) this.keyToStorage.delete(key);
 
-		if (indexedStorage) {
-			this._deleteIndexedStorage(resource, key);
-		}
-
-		if (!supportsNamespaceIndex) {
-			const namespace = this._getDerivedNamespace(resource, this._getKeyScope(key));
+		if (layout !== 'guild-indexed' && layout !== 'message') {
+			const namespace = this._getStorageNamespaceFromKey(resource, layout, key);
 			const storageEntry = this.storage.get(namespace);
-			if (storageEntry?.has(key)) {
-				return {
-					resource,
-					namespace,
-					storageEntry,
-				};
-			}
+			if (storageEntry?.has(key)) return { resource, layout, namespace, storageEntry };
 		}
 
-		for (const [namespace, storageEntry] of this.storage.entries()) {
-			if (this._isResourceNamespace(resource, namespace) && storageEntry.has(key)) {
-				this._setIndexedStorage(resource, key, storageEntry);
-				return {
-					resource,
-					namespace,
-					storageEntry,
-				};
-			}
+		for (const [namespace, storageEntry] of this.storage) {
+			if (!this._isResourceNamespace(resource, namespace) || !storageEntry.has(key)) continue;
+			this._setIndexedStorage(key, namespace, storageEntry);
+			return { resource, layout, namespace, storageEntry };
 		}
-
-		return;
+		return undefined;
 	}
 
 	get(key: string) {
 		const entry = this._getStorageEntry(key);
-		if (!entry) {
-			return null;
-		}
-
-		return this.options.decode(entry.storageEntry.get(key)!);
+		return entry ? this.options.decode(entry.storageEntry.get(key)!) : null;
 	}
 
-	private __set(key: string, data: any) {
-		const resource = this._getKeyResource(key);
-		const namespace = this._getStorageNamespace(resource, data);
-		if (!namespace) {
+	private _getWithoutRefresh(key: string) {
+		const entry = this._getStorageEntry(key);
+		const data = entry?.storageEntry.raw(key);
+		return data ? this.options.decode(data.value) : null;
+	}
+
+	private _getRelationshipData(to: string) {
+		const separator = to.indexOf('.');
+		return separator === -1 ? [to, '*'] : [to.slice(0, separator), to.slice(separator + 1)];
+	}
+
+	private _getExplicitRelationshipSet(to: string) {
+		const [resource, scope] = this._getRelationshipData(to);
+		return this.relationships.get(resource)?.get(scope);
+	}
+
+	private _ensureExplicitRelationshipSet(to: string) {
+		const [resource, scope] = this._getRelationshipData(to);
+		let relationships = this.relationships.get(resource);
+		if (!relationships) {
+			relationships = new Map();
+			this.relationships.set(resource, relationships);
+		}
+		let ids = relationships.get(scope);
+		if (!ids) {
+			ids = new Set();
+			relationships.set(scope, ids);
+		}
+		return ids;
+	}
+
+	private _removeExplicitRelationship(key: string) {
+		const relationship = this.keyToRelationship.get(key);
+		if (!relationship) return;
+		const [to, id] = relationship;
+		const [resource, scope] = this._getRelationshipData(to);
+		const relationships = this.relationships.get(resource);
+		const ids = relationships?.get(scope);
+		ids?.delete(id);
+		if (ids?.size === 0) relationships?.delete(scope);
+		if (relationships?.size === 0) this.relationships.delete(resource);
+		this.keyToRelationship.delete(key);
+	}
+
+	private _setExplicitRelationship(key: string, relationship: AdapterRelationship) {
+		const previous = this.keyToRelationship.get(key);
+		if (previous && (previous[0] !== relationship[0] || previous[1] !== relationship[1])) {
+			this._removeExplicitRelationship(key);
+		}
+		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
+		this.keyToRelationship.set(key, relationship);
+	}
+
+	private _syncRelationship(
+		key: string,
+		layout: CacheResourceLayout,
+		namespace: string,
+		relationship: AdapterRelationship,
+	) {
+		if (layout !== 'message' && namespace === relationship[0]) {
+			this._removeExplicitRelationship(key);
 			return;
 		}
+		this._setExplicitRelationship(key, relationship);
+	}
 
-		let storageEntry = this.storage.get(namespace);
-		if (!storageEntry) {
-			const self = this;
-			storageEntry = new LimitedCollection({
-				expire:
-					this.options[resource as Exclude<keyof LimitedMemoryAdapterOptions<T>, 'decode' | 'encode'>]?.expire ??
-					this.options.default.expire,
-				limit:
-					this.options[resource as Exclude<keyof LimitedMemoryAdapterOptions<T>, 'decode' | 'encode'>]?.limit ??
-					this.options.default.limit,
-				resetOnDemand: true,
-				onDelete(k, value) {
-					self._deleteIndexedStorage(resource, k);
-					const relationshipNamespace = resource;
-					const existsRelation = self.relationships.has(relationshipNamespace);
-					if (existsRelation) {
-						switch (relationshipNamespace) {
-							case 'message':
-								{
-									const decodedValue = self.options.decode(value) as { channel_id?: string };
-									if (decodedValue.channel_id)
-										self.removeToRelationship(`${relationshipNamespace}.${decodedValue.channel_id}`, k.split('.')[1]);
-								}
-								break;
-							case 'ban':
-							case 'member':
-							case 'voice_state':
-								{
-									const split = k.split('.');
-									self.removeToRelationship(`${namespace}.${split[1]}`, split[2]);
-								}
-								break;
-							case 'channel':
-							case 'emoji':
-							case 'presence':
-							case 'role':
-							case 'stage_instance':
-							case 'sticker':
-							case 'overwrite':
-								self.removeToRelationship(namespace, k.split('.')[1]);
-								break;
-							// case 'guild':
-							// case 'user':
-							default:
-								self.removeToRelationship(namespace, k.split('.')[1]);
-								break;
-						}
-					}
-				},
-			});
-			this.storage.set(namespace, storageEntry);
-		}
+	private _deleteEmptyStorage(namespace: string, storageEntry: LimitedCollection<string, T>) {
+		if (storageEntry.size === 0 && this.storage.get(namespace) === storageEntry) this.storage.delete(namespace);
+	}
 
-		const previousBucket = this._getIndexedStorage(resource, key);
-		if (previousBucket && previousBucket !== storageEntry) {
-			previousBucket?.delete(key);
-			if (previousBucket?.size === 0) {
-				const previousNamespace = this._findNamespaceByStorage(resource, previousBucket);
-				if (previousNamespace) {
-					this.storage.delete(previousNamespace);
+	private _createStorageEntry(resource: string, namespace: string) {
+		const resourceOptions =
+			this.options[resource as Exclude<keyof LimitedMemoryAdapterOptions<T>, 'decode' | 'encode'>];
+		const expire = resourceOptions?.expire ?? this.options.default.expire;
+		const bucket = new LimitedCollection<string, T>({
+			expire,
+			limit: resourceOptions?.limit ?? this.options.default.limit,
+			resetOnDemand: (expire ?? 0) > 0,
+			onDelete: key => {
+				this._deleteIndexedStorage(key);
+				this._removeExplicitRelationship(key);
+				if (bucket.size === 1 && bucket.has(key) && this.storage.get(namespace) === bucket) {
+					this.storage.delete(namespace);
 				}
-			}
+			},
+		});
+		this.storage.set(namespace, bucket);
+		return bucket;
+	}
+
+	private _moveStoredEntry(
+		resource: string,
+		key: string,
+		storageEntry: LimitedCollection<string, T>,
+		previousStorageEntry: LimitedCollection<string, T> | undefined,
+	) {
+		if (!previousStorageEntry || previousStorageEntry === storageEntry) return;
+		previousStorageEntry.delete(key);
+		if (previousStorageEntry.size !== 0) return;
+		const previousNamespace = this._findNamespaceByStorage(resource, previousStorageEntry);
+		if (previousNamespace) this.storage.delete(previousNamespace);
+	}
+
+	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
+		const data = patch && !Array.isArray(value) ? { ...(this._getWithoutRefresh(key) ?? {}), ...value } : value;
+		const encoded = this.options.encode(data);
+		const resource = this._getKeyResource(key);
+		const layout = getCacheResourceLayout(resource);
+		const namespace = layout === 'message' ? this._getMessageNamespace(data) : relationship[0];
+		if (!namespace) return;
+
+		const storageEntry = this.storage.get(namespace) ?? this._createStorageEntry(resource, namespace);
+		const usesIndex = layout === 'message' || needsCacheStorageIndex(key, namespace);
+		this._moveStoredEntry(resource, key, storageEntry, this.keyToStorage.get(key));
+		storageEntry.set(key, encoded);
+
+		if (storageEntry.has(key)) {
+			if (usesIndex) this.keyToStorage.set(key, storageEntry);
+			this._syncRelationship(key, layout, namespace, relationship);
 		}
-
-		this._setIndexedStorage(resource, key, storageEntry);
-		storageEntry.set(key, this.options.encode(data));
+		this._deleteEmptyStorage(namespace, storageEntry);
 	}
 
-	bulkSet(keys: [string, any][]) {
-		for (const [key, value] of keys) {
-			this.__set(key, value);
-		}
+	set(key: string, value: any, relationship: AdapterRelationship) {
+		this._set(key, value, relationship, false);
 	}
 
-	set(keys: string, data: any) {
-		this.__set(keys, data);
+	bulkSet(entries: AdapterEntry[]) {
+		for (const [key, value, relationship] of entries) this.set(key, value, relationship);
 	}
 
-	bulkPatch(keys: [string, any][]) {
-		for (const [key, value] of keys) {
-			const oldData = this.get(key);
-			this.__set(key, Array.isArray(value) ? value : { ...(oldData ?? {}), ...value });
-		}
+	patch(key: string, value: any, relationship: AdapterRelationship) {
+		this._set(key, value, relationship, true);
 	}
 
-	patch(keys: string, data: any) {
-		const oldData = this.get(keys);
-		this.__set(keys, Array.isArray(data) ? data : { ...(oldData ?? {}), ...data });
+	bulkPatch(entries: AdapterEntry[]) {
+		for (const [key, value, relationship] of entries) this.patch(key, value, relationship);
 	}
 
 	values(to: string) {
-		const array: any[] = [];
-		const data = this.keys(to);
-
-		for (const key of data) {
-			const content = this.get(key);
-
-			if (content !== undefined && content !== null) {
-				array.push(content);
-			}
+		const values: any[] = [];
+		for (const key of this.keys(to)) {
+			const value = this.get(key);
+			if (value !== undefined && value !== null) values.push(value);
 		}
+		return values;
+	}
 
-		return array;
+	private _getRelationshipBucket(to: string) {
+		return getCacheResourceLayout(this._getKeyResource(to)) === 'message' ? undefined : this.storage.get(to);
 	}
 
 	keys(to: string) {
-		const relationship = this._getRelationshipSet(to);
-		if (!relationship) {
-			return [];
+		const bucket = this._getRelationshipBucket(to);
+		if (bucket) return [...bucket.keys()];
+		const keys: string[] = [];
+		for (const [key, relationship] of this.keyToRelationship) {
+			if (relationship[0] === to) keys.push(key);
 		}
-
-		const result: string[] = [];
-		for (const id of relationship) {
-			result.push(`${to}.${id}`);
-		}
-		return result;
+		return keys;
 	}
 
 	count(to: string) {
-		return this._getRelationshipSet(to)?.size ?? 0;
+		return this._getRelationshipBucket(to)?.size ?? this._getExplicitRelationshipSet(to)?.size ?? 0;
+	}
+
+	private _getBucketKey(to: string, id: string, bucket: LimitedCollection<string, T>) {
+		const resource = this._getKeyResource(to);
+		const layout = getCacheResourceLayout(resource);
+		if (layout === 'guild-keyed') return `${to}.${id}`;
+		if (layout !== 'custom') return `${resource}.${id}`;
+		const scopedKey = `${to}.${id}`;
+		return bucket.has(scopedKey) ? scopedKey : `${resource}.${id}`;
+	}
+
+	contains(to: string, id: string): boolean {
+		const bucket = this._getRelationshipBucket(to);
+		return bucket
+			? bucket.has(this._getBucketKey(to, id, bucket))
+			: (this._getExplicitRelationshipSet(to)?.has(id) ?? false);
+	}
+
+	getToRelationship(to: string): string[] {
+		const bucket = this._getRelationshipBucket(to);
+		if (!bucket) return [...(this._getExplicitRelationshipSet(to) ?? [])];
+		const ids: string[] = [];
+		for (const key of bucket.keys()) ids.push(key.slice(key.lastIndexOf('.') + 1));
+		return ids;
 	}
 
 	bulkRemove(keys: string[]) {
-		for (const i of keys) {
-			this.remove(i);
-		}
+		for (const key of keys) this.remove(key);
 	}
 
 	remove(key: string) {
 		const entry = this._getStorageEntry(key);
-		if (!entry) {
-			return;
-		}
-
+		if (!entry) return;
 		entry.storageEntry.delete(key);
-		this._deleteIndexedStorage(entry.resource, key);
-		if (entry.storageEntry.size === 0) {
-			const namespace = entry.namespace ?? this._findNamespaceByStorage(entry.resource, entry.storageEntry);
-			if (namespace) {
-				this.storage.delete(namespace);
-			}
-		}
-	}
-
-	flush(): void {
-		this.storage.clear();
-		this.relationships.clear();
-		this.keyToStorage.clear();
-	}
-
-	contains(to: string, keys: string): boolean {
-		return this._getRelationshipSet(to)?.has(keys) ?? false;
-	}
-
-	private _getRelationshipData(to: string) {
-		const [key, subrelationKey = '*'] = to.split('.');
-		return { key, subrelationKey };
-	}
-
-	private _getRelationshipSet(to: string) {
-		const { key, subrelationKey } = this._getRelationshipData(to);
-		return this.relationships.get(key)?.get(subrelationKey);
-	}
-
-	private _ensureRelationshipSet(to: string) {
-		const { key, subrelationKey } = this._getRelationshipData(to);
-		let relation = this.relationships.get(key);
-		if (!relation) {
-			relation = new Map<string, Set<string>>();
-			this.relationships.set(key, relation);
-		}
-
-		let values = relation.get(subrelationKey);
-		if (!values) {
-			values = new Set<string>();
-			relation.set(subrelationKey, values);
-		}
-
-		return values;
-	}
-
-	getToRelationship(to: string): string[] {
-		return [...(this._getRelationshipSet(to) ?? [])];
-	}
-
-	bulkAddToRelationShip(data: Record<string, string[]>) {
-		for (const i in data) {
-			this.addToRelationship(i, data[i]);
-		}
-	}
-
-	addToRelationship(to: string, keys: string | string[]) {
-		const data = this._ensureRelationshipSet(to);
-
-		for (const key of Array.isArray(keys) ? keys : [keys]) {
-			data.add(key);
-		}
+		this._deleteIndexedStorage(key);
+		if (entry.storageEntry.size !== 0) return;
+		const namespace = entry.namespace ?? this._findNamespaceByStorage(entry.resource, entry.storageEntry);
+		if (namespace) this.storage.delete(namespace);
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
-		const data = this._getRelationshipSet(to);
-		if (!data) {
-			return;
-		}
-
-		for (const key of Array.isArray(keys) ? keys : [keys]) {
-			data.delete(key);
-		}
-
-		if (!data.size) {
-			const { key, subrelationKey } = this._getRelationshipData(to);
-			const relation = this.relationships.get(key);
-			relation?.delete(subrelationKey);
-			if (relation && !relation.size) this.relationships.delete(key);
+		const ids = new Set(Array.isArray(keys) ? keys : [keys]);
+		for (const key of this.keys(to)) {
+			if (ids.has(key.slice(key.lastIndexOf('.') + 1))) this.remove(key);
 		}
 	}
 
 	removeRelationship(to: string | string[]) {
-		for (const i of Array.isArray(to) ? to : [to]) {
-			const { key, subrelationKey } = this._getRelationshipData(i);
-			if (subrelationKey === '*') {
-				this.relationships.delete(key);
-				continue;
-			}
+		for (const relationship of Array.isArray(to) ? to : [to]) this.bulkRemove(this.keys(relationship));
+	}
 
-			const relation = this.relationships.get(key);
-			if (!relation) continue;
-			relation.delete(subrelationKey);
-			if (!relation.size) this.relationships.delete(key);
-		}
+	flush(): void {
+		for (const storageEntry of this.storage.values()) storageEntry.clear();
+		this.storage.clear();
+		this.relationships.clear();
+		this.keyToStorage.clear();
+		this.keyToRelationship.clear();
 	}
 }

--- a/src/cache/adapters/shared.ts
+++ b/src/cache/adapters/shared.ts
@@ -1,0 +1,25 @@
+export type CacheResourceLayout = 'root' | 'guild-indexed' | 'guild-keyed' | 'message' | 'custom';
+
+const resourceLayouts = new Map<string, Exclude<CacheResourceLayout, 'custom'>>([
+	['guild', 'root'],
+	['user', 'root'],
+	['channel', 'guild-indexed'],
+	['emoji', 'guild-indexed'],
+	['presence', 'guild-indexed'],
+	['role', 'guild-indexed'],
+	['stage_instance', 'guild-indexed'],
+	['sticker', 'guild-indexed'],
+	['overwrite', 'guild-indexed'],
+	['ban', 'guild-keyed'],
+	['member', 'guild-keyed'],
+	['voice_state', 'guild-keyed'],
+	['message', 'message'],
+]);
+
+export function getCacheResourceLayout(resource: string): CacheResourceLayout {
+	return resourceLayouts.get(resource) ?? 'custom';
+}
+
+export function needsCacheStorageIndex(key: string, namespace: string) {
+	return !key.startsWith(namespace) || key.charCodeAt(namespace.length) !== 46;
+}

--- a/src/cache/adapters/shared.ts
+++ b/src/cache/adapters/shared.ts
@@ -5,7 +5,7 @@ const resourceLayouts = new Map<string, Exclude<CacheResourceLayout, 'custom'>>(
 	['user', 'root'],
 	['channel', 'guild-indexed'],
 	['emoji', 'guild-indexed'],
-	['presence', 'guild-indexed'],
+	['presence', 'guild-keyed'],
 	['role', 'guild-indexed'],
 	['stage_instance', 'guild-indexed'],
 	['sticker', 'guild-indexed'],

--- a/src/cache/adapters/types.ts
+++ b/src/cache/adapters/types.ts
@@ -2,9 +2,10 @@ import type { Awaitable } from '../../common';
 
 export type AdapterRelationship = readonly [to: string, id: string];
 /**
- * A cache value and the relationship that owns it.
+ * A cache value and the relationship derived by its resource model.
  * Keys must use `resource.id` or `resource.scope.id`; IDs and namespace segments cannot contain dots.
  * Each resource namespace must consistently use one of those layouts.
+ * A physical key must keep the same relationship; adapters do not reconcile conflicting ownership.
  * Adapters assume these preconditions and do not validate them at runtime.
  */
 export type AdapterEntry = readonly [key: string, value: any, relationship: AdapterRelationship];

--- a/src/cache/adapters/types.ts
+++ b/src/cache/adapters/types.ts
@@ -21,12 +21,20 @@ export interface Adapter {
 	bulkGet(keys: string[]): Awaitable<any[]>;
 	get(keys: string): Awaitable<any | null>;
 
-	/** Stores each value and relationship as one atomic operation. Earlier entries may remain if a later entry fails. */
+	/**
+	 * Stores every entry atomically. The batch itself is not atomic and implementations may execute entries concurrently
+	 * or out of order. If the operation rejects, any subset may already be committed, but no writes remain pending after
+	 * the returned promise settles.
+	 */
 	bulkSet(entries: AdapterEntry[]): Awaitable<void>;
 	/** Stores the value and relationship as one atomic operation. */
 	set(key: string, value: any, relationship: AdapterRelationship): Awaitable<void>;
 
-	/** Patches each value and stores its relationship atomically. Earlier entries may remain if a later entry fails. */
+	/**
+	 * Patches every entry atomically. The batch itself is not atomic and implementations may execute entries concurrently
+	 * or out of order. If the operation rejects, any subset may already be committed, but no writes remain pending after
+	 * the returned promise settles.
+	 */
 	bulkPatch(entries: AdapterEntry[]): Awaitable<void>;
 	/** Patches the value and stores its relationship as one atomic operation. */
 	patch(key: string, value: any, relationship: AdapterRelationship): Awaitable<void>;
@@ -37,7 +45,11 @@ export interface Adapter {
 
 	count(to: string): Awaitable<number>;
 
-	/** Removes each value and its owning relationship. Earlier entries may remain if a later removal fails. */
+	/**
+	 * Removes every entry atomically. The batch itself is not atomic and implementations may execute entries concurrently
+	 * or out of order. If the operation rejects, any subset may already be committed, but no removals remain pending after
+	 * the returned promise settles.
+	 */
 	bulkRemove(keys: string[]): Awaitable<void>;
 	/** Removes the value and its owning relationship as one logical operation. */
 	remove(key: string): Awaitable<void>;

--- a/src/cache/adapters/types.ts
+++ b/src/cache/adapters/types.ts
@@ -1,5 +1,14 @@
 import type { Awaitable } from '../../common';
 
+export type AdapterRelationship = readonly [to: string, id: string];
+/**
+ * A cache value and the relationship that owns it.
+ * Keys must use `resource.id` or `resource.scope.id`; IDs and namespace segments cannot contain dots.
+ * Each resource namespace must consistently use one of those layouts.
+ * Adapters assume these preconditions and do not validate them at runtime.
+ */
+export type AdapterEntry = readonly [key: string, value: any, relationship: AdapterRelationship];
+
 export interface Adapter {
 	isAsync: boolean;
 
@@ -12,11 +21,15 @@ export interface Adapter {
 	bulkGet(keys: string[]): Awaitable<any[]>;
 	get(keys: string): Awaitable<any | null>;
 
-	bulkSet(keyValue: [string, any][]): Awaitable<void>;
-	set(id: string, data: any): Awaitable<void>;
+	/** Stores each value and relationship as one atomic operation. Earlier entries may remain if a later entry fails. */
+	bulkSet(entries: AdapterEntry[]): Awaitable<void>;
+	/** Stores the value and relationship as one atomic operation. */
+	set(key: string, value: any, relationship: AdapterRelationship): Awaitable<void>;
 
-	bulkPatch(keyValue: [string, any][]): Awaitable<void>;
-	patch(id: string, data: any): Awaitable<void>;
+	/** Patches each value and stores its relationship atomically. Earlier entries may remain if a later entry fails. */
+	bulkPatch(entries: AdapterEntry[]): Awaitable<void>;
+	/** Patches the value and stores its relationship as one atomic operation. */
+	patch(key: string, value: any, relationship: AdapterRelationship): Awaitable<void>;
 
 	values(to: string): Awaitable<any[]>;
 
@@ -24,8 +37,10 @@ export interface Adapter {
 
 	count(to: string): Awaitable<number>;
 
+	/** Removes each value and its owning relationship. Earlier entries may remain if a later removal fails. */
 	bulkRemove(keys: string[]): Awaitable<void>;
-	remove(keys: string): Awaitable<void>;
+	/** Removes the value and its owning relationship as one logical operation. */
+	remove(key: string): Awaitable<void>;
 
 	flush(): Awaitable<void>;
 
@@ -33,11 +48,9 @@ export interface Adapter {
 
 	getToRelationship(to: string): Awaitable<string[]>;
 
-	bulkAddToRelationShip(data: Record<string, string[]>): Awaitable<void>;
-
-	addToRelationship(to: string, keys: string | string[]): Awaitable<void>;
-
+	/** Removes the selected values and relationships owned by `to`. */
 	removeToRelationship(to: string, keys: string | string[]): Awaitable<void>;
 
+	/** Removes every value and relationship owned by the supplied relationships. */
 	removeRelationship(to: string | string[]): Awaitable<void>;
 }

--- a/src/cache/adapters/workeradapter.ts
+++ b/src/cache/adapters/workeradapter.ts
@@ -2,13 +2,16 @@ import { randomUUID } from 'node:crypto';
 import { lazyLoadPackage, SeyfertError } from '../../common';
 import type { WorkerData } from '../../websocket';
 import type { WorkerSendCacheRequest } from '../../websocket/discord/worker';
-import type { Adapter } from './types';
+import type { Adapter, AdapterEntry, AdapterRelationship } from './types';
 
 let parentPort: import('node:worker_threads').MessagePort;
 
 export class WorkerAdapter implements Adapter {
 	isAsync = true;
-	promises = new Map<string, { resolve: (value: unknown) => void; timeout: NodeJS.Timeout }>();
+	promises = new Map<
+		string,
+		{ resolve: (value: unknown) => void; reject: (error: unknown) => void; timeout: NodeJS.Timeout }
+	>();
 
 	constructor(public workerData: WorkerData) {
 		const worker_threads = lazyLoadPackage<typeof import('node:worker_threads')>('node:worker_threads');
@@ -28,20 +31,33 @@ export class WorkerAdapter implements Adapter {
 		const nonce = randomUUID();
 		if (this.promises.has(nonce)) return this.send(method, ...args);
 
-		this.postMessage({
-			type: 'CACHE_REQUEST',
-			args,
-			nonce,
-			method,
-			workerId: this.workerData.workerId,
-		} satisfies WorkerSendCacheRequest);
-
 		return new Promise<any>((res, rej) => {
 			const timeout = setTimeout(() => {
 				this.promises.delete(nonce);
 				rej(new SeyfertError('CACHE_TIMEOUT', { metadata: { ...{ nonce, method }, detail: 'Timeout cache request' } }));
 			}, 60e3);
-			this.promises.set(nonce, { resolve: res, timeout });
+			const pending = { resolve: res, reject: rej, timeout };
+			const rejectPending = (error: unknown) => {
+				if (this.promises.get(nonce) !== pending) return;
+				clearTimeout(timeout);
+				this.promises.delete(nonce);
+				rej(error);
+			};
+			this.promises.set(nonce, pending);
+			try {
+				const dispatched = this.postMessage({
+					type: 'CACHE_REQUEST',
+					args,
+					nonce,
+					method,
+					workerId: this.workerData.workerId,
+				} satisfies WorkerSendCacheRequest);
+				if (dispatched && (typeof dispatched === 'object' || typeof dispatched === 'function')) {
+					void Promise.resolve(dispatched).catch(rejectPending);
+				}
+			} catch (error) {
+				rejectPending(error);
+			}
 		});
 	}
 
@@ -57,20 +73,20 @@ export class WorkerAdapter implements Adapter {
 		return this.send('get', ...rest);
 	}
 
-	bulkSet(...rest: any[]) {
-		return this.send('bulkSet', ...rest);
+	bulkSet(entries: AdapterEntry[]) {
+		return this.send('bulkSet', entries);
 	}
 
-	set(...rest: any[]) {
-		return this.send('set', ...rest);
+	set(key: string, value: any, relationship: AdapterRelationship) {
+		return this.send('set', key, value, relationship);
 	}
 
-	bulkPatch(...rest: any[]) {
-		return this.send('bulkPatch', ...rest);
+	bulkPatch(entries: AdapterEntry[]) {
+		return this.send('bulkPatch', entries);
 	}
 
-	patch(...rest: any[]) {
-		return this.send('patch', ...rest);
+	patch(key: string, value: any, relationship: AdapterRelationship) {
+		return this.send('patch', key, value, relationship);
 	}
 
 	values(...rest: any[]) {
@@ -103,14 +119,6 @@ export class WorkerAdapter implements Adapter {
 
 	getToRelationship(...rest: any[]) {
 		return this.send('getToRelationship', ...rest);
-	}
-
-	bulkAddToRelationShip(...rest: any[]) {
-		return this.send('bulkAddToRelationShip', ...rest);
-	}
-
-	addToRelationship(...rest: any[]) {
-		return this.send('addToRelationship', ...rest);
 	}
 
 	removeToRelationship(...rest: any[]) {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,7 +1,7 @@
 import type { InternalOptions, UsingClient } from '../commands';
 import { type Awaitable, type If, type Logger, SeyfertError } from '../common';
 import { type APIEmoji, type APISticker, ChannelType, type GatewayDispatchPayload, GatewayIntentBits } from '../types';
-import type { Adapter } from './adapters';
+import type { Adapter, AdapterEntry } from './adapters';
 import { testCacheAdapter } from './conformance';
 import { Bans } from './resources/bans';
 import { Channels } from './resources/channels';
@@ -64,13 +64,13 @@ export type BulkGetKey =
 			string,
 	  ];
 
+export type BulkWriteKey =
+	| readonly [CacheFrom, NonGuildBased, data: any, id: string]
+	| readonly [CacheFrom, GuildBased | GuildRelated, data: any, id: string, guildId: string];
+
 type BulkGetResult<K extends BulkGetKey[0] = BulkGetKey[0]> = Partial<{
 	[P in K]: ReturnManagers[P][];
 }>;
-
-type BulkMutationEntry =
-	| readonly [CacheFrom, NonGuildBased, data: any, sourceId: string]
-	| readonly [CacheFrom, GuildBased | GuildRelated, data: any, sourceId: string, guildId: string];
 
 type PluginCacheResourceContributionLike = {
 	name: string;
@@ -308,9 +308,8 @@ export class Cache {
 		return obj as BulkGetResult<Keys[number][0]>;
 	}
 
-	private prepareBulkMutation(keys: BulkMutationEntry[]) {
-		const allData: [string, any][] = [];
-		const relationshipsData: Record<string, string[]> = {};
+	private _buildBulkWrites(keys: BulkWriteKey[]) {
+		const writes: AdapterEntry[] = [];
 		for (const [from, type, data, id, guildId] of keys) {
 			switch (type) {
 				case 'roles':
@@ -320,80 +319,47 @@ export class Cache {
 				case 'stageInstances':
 				case 'emojis':
 				case 'overwrites':
-				case 'messages':
-					{
-						if (!this[type]?.filter(data, id, guildId, from)) continue;
-						const hashId = this[type]?.hashId(guildId!);
-						if (!hashId) {
-							continue;
-						}
-						if (!(hashId in relationshipsData)) {
-							relationshipsData[hashId] = [];
-						}
-						relationshipsData[hashId].push(id);
-						if (type !== 'overwrites' && type !== 'messages') {
-							data.guild_id = guildId;
-						}
-						if (type === 'messages' && data?.author?.id && this.users?.filter(data.author, data.author.id, from)) {
-							const userHashId = this.users.namespace;
-							if (!(userHashId in relationshipsData)) {
-								relationshipsData[userHashId] = [];
-							}
-							relationshipsData[userHashId].push(data.author.id);
-							allData.push([this.users.hashId(data.author.id), data.author]);
-						}
-						allData.push([this[type]!.hashId(id), this[type]!.parse(data, id, guildId!)]);
+				case 'messages': {
+					const resource = this[type];
+					if (!resource?.filter(data, id, guildId, from)) continue;
+					const relationship = resource.hashId(guildId!);
+					if (type !== 'overwrites' && type !== 'messages') data.guild_id = guildId;
+					if (type === 'messages' && data?.author?.id && this.users?.filter(data.author, data.author.id, from)) {
+						writes.push([this.users.hashId(data.author.id), data.author, [this.users.namespace, data.author.id]]);
 					}
+					writes.push([resource.hashId(id), resource.parse(data, id, guildId!), [relationship, id]]);
 					break;
+				}
 				case 'bans':
 				case 'voiceStates':
-				case 'members':
-					{
-						if (!this[type]?.filter(data, id, guildId, from)) continue;
-						const hashId = this[type]?.hashId(guildId!);
-						if (!hashId) {
-							continue;
-						}
-						if (!(hashId in relationshipsData)) {
-							relationshipsData[hashId] = [];
-						}
-						relationshipsData[hashId].push(id);
-						data.guild_id = guildId;
-						allData.push([this[type]!.hashGuildId(guildId, id), this[type]!.parse(data, id, guildId!)]);
-					}
+				case 'members': {
+					const resource = this[type];
+					if (!resource?.filter(data, id, guildId, from)) continue;
+					const relationship = resource.hashId(guildId!);
+					data.guild_id = guildId;
+					writes.push([resource.hashGuildId(guildId!, id), resource.parse(data, id, guildId!), [relationship, id]]);
 					break;
+				}
 				case 'users':
-				case 'guilds':
-					{
-						if (!this[type]?.filter(data, id, from)) continue;
-						const hashId = this[type]?.namespace;
-						if (!hashId) {
-							continue;
-						}
-						if (!(hashId in relationshipsData)) {
-							relationshipsData[hashId] = [];
-						}
-						relationshipsData[hashId].push(id);
-						allData.push([this[type]!.hashId(id), data]);
-					}
+				case 'guilds': {
+					const resource = this[type];
+					if (!resource?.filter(data, id, from)) continue;
+					writes.push([resource.hashId(id), data, [resource.namespace, id]]);
 					break;
+				}
 				default:
 					throw new SeyfertError('INTERNAL_ERROR', { metadata: { detail: `Invalid type ${type}` } });
 			}
 		}
-		return { data: allData, relationships: relationshipsData };
+		return writes;
 	}
 
-	async bulkPatch(keys: BulkMutationEntry[]) {
-		const mutation = this.prepareBulkMutation(keys);
-		await this.adapter.bulkAddToRelationShip(mutation.relationships);
-		await this.adapter.bulkPatch(mutation.data);
+	async bulkPatch(keys: BulkWriteKey[]) {
+		await this.adapter.bulkPatch(this._buildBulkWrites(keys));
 	}
 
-	async bulkSet(keys: BulkMutationEntry[]) {
-		const mutation = this.prepareBulkMutation(keys);
-		await this.adapter.bulkAddToRelationShip(mutation.relationships);
-		await this.adapter.bulkSet(mutation.data);
+	async bulkSet(keys: BulkWriteKey[]) {
+		await this.adapter.bulkSet(this._buildBulkWrites(keys));
 	}
 
 	onPacket(event: GatewayDispatchPayload) {

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -25,18 +25,10 @@ export type InferAsyncCache = InternalOptions extends { asyncCache: infer P } ? 
 export type ReturnCache<T> = If<InferAsyncCache, Promise<T>, T>;
 
 // GuildBased
-export type GuildBased = 'members' | 'voiceStates' | 'bans';
+export type GuildBased = 'members' | 'voiceStates' | 'presences' | 'bans';
 
 // ClientGuildBased
-export type GuildRelated =
-	| 'emojis'
-	| 'roles'
-	| 'channels'
-	| 'stickers'
-	| 'presences'
-	| 'stageInstances'
-	| 'overwrites'
-	| 'messages';
+export type GuildRelated = 'emojis' | 'roles' | 'channels' | 'stickers' | 'stageInstances' | 'overwrites' | 'messages';
 
 // ClientBased
 export type NonGuildBased = 'users' | 'guilds';
@@ -125,6 +117,8 @@ export class Cache {
 	// guild based
 	members?: Members;
 	voiceStates?: VoiceStates;
+	presences?: Presences;
+	bans?: Bans;
 
 	// guild related
 	overwrites?: Overwrites;
@@ -132,10 +126,8 @@ export class Cache {
 	emojis?: Emojis;
 	channels?: Channels;
 	stickers?: Stickers;
-	presences?: Presences;
 	stageInstances?: StageInstances;
 	messages?: Messages;
-	bans?: Bans;
 
 	__logger__?: Logger;
 	private pluginResourceNames = new Set<string>();
@@ -172,20 +164,20 @@ export class Cache {
 		this.users = disabledCache.users ? undefined : new Users(this, client);
 		this.guilds = disabledCache.guilds ? undefined : new Guilds(this, client);
 
-		// guild related
+		// guild based
 		this.members = disabledCache.members ? undefined : new Members(this, client);
 		this.voiceStates = disabledCache.voiceStates ? undefined : new VoiceStates(this, client);
+		this.presences = disabledCache.presences ? undefined : new Presences(this, client);
+		this.bans = disabledCache.bans ? undefined : new Bans(this, client);
 
-		// guild based
+		// guild related
 		this.roles = disabledCache.roles ? undefined : new Roles(this, client);
 		this.overwrites = disabledCache.overwrites ? undefined : new Overwrites(this, client);
 		this.channels = disabledCache.channels ? undefined : new Channels(this, client);
 		this.emojis = disabledCache.emojis ? undefined : new Emojis(this, client);
 		this.stickers = disabledCache.stickers ? undefined : new Stickers(this, client);
-		this.presences = disabledCache.presences ? undefined : new Presences(this, client);
 		this.stageInstances = disabledCache.stageInstances ? undefined : new StageInstances(this, client);
 		this.messages = disabledCache.messages ? undefined : new Messages(this, client);
-		this.bans = disabledCache.bans ? undefined : new Bans(this, client);
 
 		this.onPacket = disabledCache.onPacket
 			? ((() => {
@@ -262,6 +254,7 @@ export class Cache {
 				case 'bans':
 				case 'voiceStates':
 				case 'members':
+				case 'presences':
 					{
 						if (!allData[type]) {
 							allData[type] = [];
@@ -272,7 +265,6 @@ export class Cache {
 				case 'roles':
 				case 'stickers':
 				case 'channels':
-				case 'presences':
 				case 'stageInstances':
 				case 'emojis':
 				case 'users':
@@ -315,7 +307,6 @@ export class Cache {
 				case 'roles':
 				case 'stickers':
 				case 'channels':
-				case 'presences':
 				case 'stageInstances':
 				case 'emojis':
 				case 'overwrites':
@@ -332,7 +323,8 @@ export class Cache {
 				}
 				case 'bans':
 				case 'voiceStates':
-				case 'members': {
+				case 'members':
+				case 'presences': {
 					const resource = this[type];
 					if (!resource?.filter(data, id, guildId, from)) continue;
 					const relationship = resource.hashId(guildId!);
@@ -477,6 +469,7 @@ export class Cache {
 				break;
 			case 'GUILD_MEMBER_REMOVE':
 				await this.members?.remove(event.d.user.id, event.d.guild_id);
+				await this.presences?.remove(event.d.user.id, event.d.guild_id);
 				break;
 
 			case 'PRESENCE_UPDATE':

--- a/src/cache/resources/default/base.ts
+++ b/src/cache/resources/default/base.ts
@@ -43,16 +43,16 @@ export class BaseResource<T = any, S = any> {
 
 	set(from: CacheFrom, id: string, data: S) {
 		if (!this.filter(data, id, from)) return;
-		return fakePromise(this.addToRelationship(id)).then(() => this.adapter.set(this.hashId(id), data));
+		return this.adapter.set(this.hashId(id), data, [this.namespace, id]);
 	}
 
 	patch(from: CacheFrom, id: string, data: S) {
 		if (!this.filter(data, id, from)) return;
-		return fakePromise(this.addToRelationship(id)).then(() => this.adapter.patch(this.hashId(id), data));
+		return this.adapter.patch(this.hashId(id), data, [this.namespace, id]);
 	}
 
 	remove(id: string) {
-		return fakePromise(this.removeToRelationship(id)).then(() => this.adapter.remove(this.hashId(id)));
+		return this.adapter.remove(this.hashId(id));
 	}
 
 	keys(): ReturnCache<string[]> {
@@ -75,23 +75,11 @@ export class BaseResource<T = any, S = any> {
 		return this.adapter.getToRelationship(this.namespace);
 	}
 
-	addToRelationship(id: string | string[]) {
-		return this.adapter.addToRelationship(this.namespace, id);
-	}
-
-	removeToRelationship(id: string | string[]) {
-		return this.adapter.removeToRelationship(this.namespace, id);
-	}
-
 	flush() {
-		return fakePromise(this.adapter.keys(this.namespace)).then(keys => {
-			return fakePromise(this.adapter.bulkRemove(keys)).then(() => {
-				return this.adapter.removeRelationship(this.namespace);
-			});
-		});
+		return fakePromise(this.adapter.keys(this.namespace)).then(keys => this.adapter.bulkRemove(keys));
 	}
 
 	hashId(id: string) {
-		return id.startsWith(this.namespace) ? id : `${this.namespace}.${id}`;
+		return id.startsWith(`${this.namespace}.`) ? id : `${this.namespace}.${id}`;
 	}
 }

--- a/src/cache/resources/default/guild-based.ts
+++ b/src/cache/resources/default/guild-based.ts
@@ -56,17 +56,9 @@ export class GuildBasedResource<T = any, S = any> {
 
 		if (!keys.length) return fakePromise(undefined).then(() => {}) as void;
 
-		return fakePromise(
-			this.addToRelationship(
-				keys.map(x => x[0]),
-				guild,
-			),
-		).then(() =>
-			this.adapter.bulkSet(
-				keys.map(([key, value]) => {
-					return [this.hashGuildId(guild, key), this.parse(value, key, guild)] as const;
-				}),
-			),
+		const relationship = this.hashId(guild);
+		return this.adapter.bulkSet(
+			keys.map(([key, value]) => [this.hashGuildId(guild, key), this.parse(value, key, guild), [relationship, key]]),
 		) as void;
 	}
 
@@ -79,32 +71,15 @@ export class GuildBasedResource<T = any, S = any> {
 
 		if (!keys.length) return fakePromise(undefined).then(() => {}) as void;
 
-		return fakePromise(this.adapter.bulkGet(keys.map(([key]) => this.hashGuildId(guild, key)))).then(oldDatas => {
-			const oldDataMap = new Map<string, any>();
-			for (const item of oldDatas as any[]) {
-				if (item?.id) oldDataMap.set(item.id, item);
-			}
-			return fakePromise(
-				this.addToRelationship(
-					keys.map(x => x[0]),
-					guild,
-				),
-			).then(() =>
-				this.adapter.bulkSet(
-					keys.map(([key, value]) => {
-						const oldData = oldDataMap.get(key) ?? {};
-						return [this.hashGuildId(guild, key), this.parse({ ...oldData, ...value }, key, guild)];
-					}),
-				),
-			);
-		}) as void;
+		const relationship = this.hashId(guild);
+		return this.adapter.bulkPatch(
+			keys.map(([key, value]) => [this.hashGuildId(guild, key), this.parse(value, key, guild), [relationship, key]]),
+		) as void;
 	}
 
 	remove(id: string | string[], guild: string) {
 		const ids = Array.isArray(id) ? id : [id];
-		return fakePromise(this.removeToRelationship(ids, guild)).then(() =>
-			this.adapter.bulkRemove(ids.map(x => this.hashGuildId(guild, x))),
-		);
+		return this.adapter.bulkRemove(ids.map(x => this.hashGuildId(guild, x)));
 	}
 
 	keys(guild: '*' | (string & {})): ReturnCache<string[]> {
@@ -135,36 +110,15 @@ export class GuildBasedResource<T = any, S = any> {
 		return this.adapter.getToRelationship(this.hashId(guild));
 	}
 
-	addToRelationship(id: string | string[], guild: string) {
-		return this.adapter.addToRelationship(this.hashId(guild), id);
-	}
-
-	removeToRelationship(id: string | string[], guild: string) {
-		return this.adapter.removeToRelationship(this.hashId(guild), id);
-	}
-
-	removeRelationship(id: string | string[]) {
-		return this.adapter.removeRelationship((Array.isArray(id) ? id : [id]).map(x => this.hashId(x)));
-	}
-
 	hashId(id: string) {
-		return id.startsWith(this.namespace) ? id : `${this.namespace}.${id}`;
+		return id.startsWith(`${this.namespace}.`) ? id : `${this.namespace}.${id}`;
 	}
 
 	hashGuildId(guild: string, id: string) {
-		return id.startsWith(this.namespace) ? id : `${this.namespace}.${guild}.${id}`;
+		return id.startsWith(`${this.namespace}.`) ? id : `${this.namespace}.${guild}.${id}`;
 	}
 
 	flush(guild: '*' | (string & {})) {
-		return fakePromise(this.keys(guild)).then(keys => {
-			return fakePromise(this.adapter.bulkRemove(keys)).then(() => {
-				const maybePromises: (unknown | Promise<unknown>)[] = [];
-				for (const i of keys) {
-					const guildId = i.split('.').at(-2)!;
-					maybePromises.push(this.removeRelationship(guildId));
-				}
-				return this.adapter.isAsync ? Promise.all(maybePromises) : maybePromises;
-			});
-		});
+		return fakePromise(this.keys(guild)).then(keys => this.adapter.bulkRemove(keys));
 	}
 }

--- a/src/cache/resources/default/guild-related.ts
+++ b/src/cache/resources/default/guild-related.ts
@@ -56,19 +56,10 @@ export class GuildRelatedResource<T = any, S = any> {
 
 		if (!keys.length) return fakePromise(undefined).then(() => {}) as void;
 
-		return fakePromise(
-			this.addToRelationship(
-				keys.map(x => x[0]),
-				guild,
-			),
-		).then(
-			() =>
-				this.adapter.bulkSet(
-					keys.map(([key, value]) => {
-						return [this.hashId(key), this.parse(value, key, guild)] as const;
-					}),
-				) as void,
-		);
+		const relationship = this.hashId(guild);
+		return this.adapter.bulkSet(
+			keys.map(([key, value]) => [this.hashId(key), this.parse(value, key, guild), [relationship, key]]),
+		) as void;
 	}
 
 	patch(from: CacheFrom, __keys: string, guild: string, data?: any): ReturnCache<void>;
@@ -80,26 +71,15 @@ export class GuildRelatedResource<T = any, S = any> {
 
 		if (!keys.length) return fakePromise(undefined).then(() => {}) as void;
 
-		return fakePromise(
-			this.addToRelationship(
-				keys.map(x => x[0]),
-				guild,
-			),
-		).then(
-			() =>
-				this.adapter.bulkPatch(
-					keys.map(([key, value]) => {
-						return [this.hashId(key), this.parse(value, key, guild)] as const;
-					}),
-				) as void,
-		);
+		const relationship = this.hashId(guild);
+		return this.adapter.bulkPatch(
+			keys.map(([key, value]) => [this.hashId(key), this.parse(value, key, guild), [relationship, key]]),
+		) as void;
 	}
 
-	remove(id: string | string[], guild: string) {
+	remove(id: string | string[], _guild: string) {
 		const ids = Array.isArray(id) ? id : [id];
-		return fakePromise(this.removeToRelationship(ids, guild)).then(() =>
-			this.adapter.bulkRemove(ids.map(x => this.hashId(x))),
-		);
+		return this.adapter.bulkRemove(ids.map(x => this.hashId(x)));
 	}
 
 	keys(guild: '*' | (string & {})): ReturnCache<string[]> {
@@ -132,27 +112,11 @@ export class GuildRelatedResource<T = any, S = any> {
 		return this.adapter.getToRelationship(this.hashId(guild));
 	}
 
-	addToRelationship(id: string | string[], guild: string) {
-		return this.adapter.addToRelationship(this.hashId(guild), id);
-	}
-
-	removeToRelationship(id: string | string[], guild: string) {
-		return this.adapter.removeToRelationship(this.hashId(guild), id);
-	}
-
-	removeRelationship(id: string | string[]) {
-		return this.adapter.removeRelationship((Array.isArray(id) ? id : [id]).map(x => this.hashId(x)));
-	}
-
 	hashId(id: string) {
-		return id.startsWith(this.namespace) ? id : `${this.namespace}.${id}`;
+		return id.startsWith(`${this.namespace}.`) ? id : `${this.namespace}.${id}`;
 	}
 
 	flush(guild: '*' | (string & {}) = '*') {
-		return fakePromise(this.keys(guild)).then(keys => {
-			return fakePromise(this.adapter.bulkRemove(keys)).then(() => {
-				return this.removeRelationship(guild);
-			});
-		});
+		return fakePromise(this.keys(guild)).then(keys => this.adapter.bulkRemove(keys));
 	}
 }

--- a/src/cache/resources/guilds.ts
+++ b/src/cache/resources/guilds.ts
@@ -50,20 +50,13 @@ export class Guilds extends BaseResource<any, APIGuild | GatewayGuildCreateDispa
 
 		const overwriteKeys = this.cache.overwrites ? ((await this.cache.overwrites.keys(id)) ?? []) : [];
 		const messageKeys: string[] = [];
-		const messageRelationships: string[] = [];
-		const overwriteRelationships = this.cache.overwrites ? [this.cache.overwrites.hashId(id)] : [];
 
 		if (this.cache.messages) {
 			const messageEntries = await Promise.allSettled(
-				channelIds.map(async channelId => ({
-					keys: await this.cache.messages!.keys(channelId),
-					relationship: this.cache.messages!.hashId(channelId),
-				})),
+				channelIds.map(channelId => this.cache.messages!.keys(channelId)),
 			);
 			for (const { value } of messageEntries.filter(result => result.status === 'fulfilled')) {
-				const { keys, relationship } = value;
-				messageKeys.push(...keys);
-				messageRelationships.push(relationship);
+				messageKeys.push(...value);
 			}
 		}
 
@@ -83,22 +76,6 @@ export class Guilds extends BaseResource<any, APIGuild | GatewayGuildCreateDispa
 			)
 				.flat()
 				.concat(overwriteKeys, messageKeys),
-		);
-
-		await this.cache.adapter.removeRelationship(
-			[
-				this.cache.members?.hashId(id),
-				this.cache.roles?.hashId(id),
-				this.cache.channels?.hashId(id),
-				this.cache.emojis?.hashId(id),
-				this.cache.stickers?.hashId(id),
-				this.cache.voiceStates?.hashId(id),
-				this.cache.presences?.hashId(id),
-				this.cache.stageInstances?.hashId(id),
-				this.cache.bans?.hashId(id),
-				...overwriteRelationships,
-				...messageRelationships,
-			].filter(x => x !== undefined),
 		);
 
 		await super.remove(id);

--- a/src/cache/resources/presence.ts
+++ b/src/cache/resources/presence.ts
@@ -1,8 +1,8 @@
 import type { CacheFrom } from '../..';
 import type { GatewayPresenceUpdate } from '../../types';
-import { GuildRelatedResource } from './default/guild-related';
+import { GuildBasedResource } from './default/guild-based';
 
-export class Presences extends GuildRelatedResource<PresenceResource, GatewayPresenceUpdate> {
+export class Presences extends GuildBasedResource<PresenceResource, GatewayPresenceUpdate> {
 	namespace = 'presence';
 
 	//@ts-expect-error

--- a/src/client/workerclient.ts
+++ b/src/client/workerclient.ts
@@ -45,6 +45,7 @@ import type {
 	WorkerStart,
 	WorkerStartResharding,
 } from '../websocket/discord/worker';
+import { deserializeWorkerError } from '../websocket/discord/worker-errors';
 import type { ManagerMessages, ManagerSpawnShards } from '../websocket/discord/workermanager';
 import type { BaseClientOptions, InternalRuntimeConfig, ServicesOptions, StartOptions } from './base';
 import { BaseClient } from './base';
@@ -219,8 +220,9 @@ export class WorkerClient<Ready extends boolean = boolean> extends BaseClient {
 				if (this.cache.adapter instanceof WorkerAdapter && this.cache.adapter.promises.has(data.nonce)) {
 					const cacheData = this.cache.adapter.promises.get(data.nonce)!;
 					clearTimeout(cacheData.timeout);
-					cacheData.resolve(data.result);
 					this.cache.adapter.promises.delete(data.nonce);
+					if (data.error) cacheData.reject(deserializeWorkerError(data.error));
+					else cacheData.resolve(data.result);
 				}
 				break;
 			case 'SEND_PAYLOAD':

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -209,15 +209,116 @@ export class Collection<K, V> extends Map<K, V> {
 export type LimitedCollectionData<V> = { expire: number; expireOn: number; value: V };
 type LimitedCollectionExpiration = { expire: number; expireOn: number };
 type LimitedCollectionCloser<K> = LimitedCollectionExpiration & { key: K };
+type LimitedCollectionExpirationNode<K> = LimitedCollectionCloser<K> & { index: number };
+type LimitedCollectionExpirationSchedule =
+	| { type: 'immediate'; handle: NodeJS.Immediate }
+	| { type: 'timeout'; handle: NodeJS.Timeout };
+
+const expirationBatchSize = 1_024;
+const maxTimerDelay = 2_147_483_647;
+
+class LimitedCollectionExpirationQueue<K> {
+	private readonly byKey = new Map<K, LimitedCollectionExpirationNode<K>>();
+	private readonly heap: LimitedCollectionExpirationNode<K>[] = [];
+
+	get size() {
+		return this.byKey.size;
+	}
+
+	get first(): LimitedCollectionCloser<K> | undefined {
+		return this.heap[0];
+	}
+
+	get(key: K): LimitedCollectionExpiration | undefined {
+		return this.byKey.get(key);
+	}
+
+	set(key: K, expire: number, expireOn: number) {
+		const expiration = this.byKey.get(key);
+		if (expiration) {
+			const previousExpireOn = expiration.expireOn;
+			expiration.expire = expire;
+			expiration.expireOn = expireOn;
+			this._rebalance(expiration, previousExpireOn);
+			return;
+		}
+
+		const node = { key, expire, expireOn, index: this.heap.length };
+		this.byKey.set(key, node);
+		this.heap.push(node);
+		this._siftUp(node.index);
+	}
+
+	refresh(key: K, expireOn: number) {
+		const expiration = this.byKey.get(key);
+		if (!expiration) return false;
+		const wasFirst = expiration.index === 0;
+		const previousExpireOn = expiration.expireOn;
+		expiration.expireOn = expireOn;
+		this._rebalance(expiration, previousExpireOn);
+		return wasFirst && previousExpireOn !== expireOn;
+	}
+
+	delete(key: K) {
+		const expiration = this.byKey.get(key);
+		if (!expiration) return false;
+		const index = expiration.index;
+		const last = this.heap.pop()!;
+		this.byKey.delete(key);
+		if (index < this.heap.length) {
+			this.heap[index] = last;
+			last.index = index;
+			const parent = Math.floor((index - 1) / 2);
+			if (index > 0 && this._compare(last, this.heap[parent]!) < 0) this._siftUp(index);
+			else this._siftDown(index);
+		}
+		return true;
+	}
+
+	private _compare(left: LimitedCollectionExpirationNode<K>, right: LimitedCollectionExpirationNode<K>) {
+		return left.expireOn - right.expireOn;
+	}
+
+	private _swap(left: number, right: number) {
+		const value = this.heap[left]!;
+		this.heap[left] = this.heap[right]!;
+		this.heap[right] = value;
+		this.heap[left]!.index = left;
+		value.index = right;
+	}
+
+	private _siftUp(index: number) {
+		while (index > 0) {
+			const parent = Math.floor((index - 1) / 2);
+			if (this._compare(this.heap[index]!, this.heap[parent]!) >= 0) break;
+			this._swap(index, parent);
+			index = parent;
+		}
+	}
+
+	private _siftDown(index: number) {
+		while (true) {
+			const left = index * 2 + 1;
+			const right = left + 1;
+			let smallest = index;
+			if (left < this.heap.length && this._compare(this.heap[left]!, this.heap[smallest]!) < 0) smallest = left;
+			if (right < this.heap.length && this._compare(this.heap[right]!, this.heap[smallest]!) < 0) smallest = right;
+			if (smallest === index) break;
+			this._swap(index, smallest);
+			index = smallest;
+		}
+	}
+
+	private _rebalance(expiration: LimitedCollectionExpirationNode<K>, previousExpireOn: number) {
+		if (expiration.expireOn < previousExpireOn) this._siftUp(expiration.index);
+		else if (expiration.expireOn > previousExpireOn) this._siftDown(expiration.index);
+	}
+}
 
 function validateLimitedCollectionExpiration(expire: number) {
 	if (Number.isNaN(expire)) throw new TypeError('LimitedCollection expiration cannot be NaN');
-	if (Number.isFinite(expire) && expire > 2_147_483_647)
+	if (Number.isFinite(expire) && expire > maxTimerDelay)
 		throw new RangeError('LimitedCollection expiration cannot exceed the maximum timer delay');
-}
-
-function isSameMapKey<K>(left: K, right: K) {
-	return left === right || Object.is(left, right);
 }
 
 export interface LimitedCollectionOptions<K, V> {
@@ -248,12 +349,10 @@ export class LimitedCollection<K, V> {
 	};
 
 	private readonly data = new Map<K, V>();
-	private readonly expirations = new Map<K, LimitedCollectionExpiration>();
+	private expirations: LimitedCollectionExpirationQueue<K> | undefined;
 
 	private readonly options: LimitedCollectionOptions<K, V>;
-	private timeout: NodeJS.Timeout | undefined = undefined;
-	private _closer: LimitedCollectionCloser<K> | undefined = undefined;
-	private _closerDirty = true;
+	private expirationSchedule: LimitedCollectionExpirationSchedule | undefined;
 
 	constructor(options: Partial<LimitedCollectionOptions<K, V>> = {}) {
 		this.options = MergeOptions(LimitedCollection.default, options);
@@ -282,38 +381,42 @@ export class LimitedCollection<K, V> {
 		}
 		validateLimitedCollectionExpiration(customExpire);
 
-		const previousExpiration = this.expirations.get(key);
-		const replacedCloser =
-			previousExpiration !== undefined && this._closer !== undefined && isSameMapKey(this._closer.key, key);
-		if (replacedCloser) {
-			this._closerDirty = true;
+		const expireOn = Number.isFinite(customExpire) && customExpire > 0 ? Date.now() + customExpire : -1;
+		if (expireOn === -1 && !this.expirations) {
+			this.data.set(key, value);
+			if (this.size > this.options.limit) {
+				const iter = this.data.keys();
+				while (this.size > this.options.limit) {
+					const keyValue = iter.next().value!;
+					this.delete(keyValue);
+				}
+			}
+			return;
 		}
 
-		const expires = Number.isFinite(customExpire) && customExpire > 0;
-		const expireOn = expires ? Date.now() + customExpire : -1;
+		const previousCloser = this.expirations?.first;
+		const previousExpireOn = previousCloser?.expireOn;
 		this.data.set(key, value);
 
-		if (expires) {
-			this.expirations.set(key, { expire: customExpire, expireOn });
+		if (expireOn !== -1) {
+			(this.expirations ??= new LimitedCollectionExpirationQueue()).set(key, customExpire, expireOn);
 		} else {
-			this.expirations.delete(key);
+			this._removeExpiration(key);
 		}
 
-		if (expires && !replacedCloser && (!this._closer || this._closerDirty || expireOn <= this._closer.expireOn)) {
-			this._closer = { key, expire: customExpire, expireOn };
-			this._closerDirty = false;
-		}
-
-		if (this.size > this.options.limit) {
-			const iter = this.data.keys();
-			while (this.size > this.options.limit) {
-				const keyValue = iter.next().value!;
-				this.delete(keyValue);
+		try {
+			if (this.size > this.options.limit) {
+				const iter = this.data.keys();
+				while (this.size > this.options.limit) {
+					const keyValue = iter.next().value!;
+					this.delete(keyValue);
+				}
 			}
-		}
-
-		if (replacedCloser || this.closer?.expireOn === expireOn) {
-			this.resetTimeout();
+		} finally {
+			const closer = this.expirations?.first;
+			if (previousCloser !== closer || previousExpireOn !== closer?.expireOn) {
+				this.rescheduleExpiration();
+			}
 		}
 	}
 
@@ -334,7 +437,7 @@ export class LimitedCollection<K, V> {
 		}
 		const resolvedValue = value as V;
 
-		if (this.expirations.size === 0) {
+		if (!this.expirations) {
 			return {
 				value: resolvedValue,
 				expire: -1,
@@ -366,19 +469,13 @@ export class LimitedCollection<K, V> {
 			return;
 		}
 
-		if (!this.options.resetOnDemand || this.expirations.size === 0) {
+		const expirations = this.expirations;
+		if (!this.options.resetOnDemand || !expirations) {
 			return value;
 		}
 
-		const expiration = this.expirations.get(key);
-		if (this.options.resetOnDemand && expiration) {
-			const wasCloser = this._closer !== undefined && isSameMapKey(this._closer.key, key);
-			expiration.expireOn = Date.now() + expiration.expire;
-			if (wasCloser) {
-				this._closerDirty = true;
-				this.resetTimeout();
-			}
-		}
+		const expiration = expirations.get(key);
+		if (expiration && expirations.refresh(key, Date.now() + expiration.expire)) this.rescheduleExpiration();
 		return value;
 	}
 
@@ -396,7 +493,6 @@ export class LimitedCollection<K, V> {
 		return this.data.has(key);
 	}
 
-	private _pendingReset = false;
 	/**
 	 * Removes an element from the limited collection.
 	 * @param key The key of the element to remove.
@@ -408,23 +504,29 @@ export class LimitedCollection<K, V> {
 	 * console.log(collection.delete(2)); // Output: false
 	 */
 	delete(key: K) {
+		return this._delete(key);
+	}
+
+	private _delete(key: K, reschedule = true) {
 		const value = this.data.get(key);
 		if (value === undefined && !this.data.has(key)) {
 			return false;
 		}
 		const resolvedValue = value as V;
+		if (!this.expirations) {
+			this.options.onDelete?.(key, resolvedValue);
+			return this.data.delete(key);
+		}
 
-		const wasCloser = this._closer !== undefined && isSameMapKey(this._closer.key, key);
-		if (wasCloser) this._closerDirty = true;
+		const previousCloser = this.expirations.first;
+		const previousExpireOn = previousCloser?.expireOn;
+
 		this.options.onDelete?.(key, resolvedValue);
 		const result = this.data.delete(key);
-		this.expirations.delete(key);
-		if (wasCloser && !this._pendingReset) {
-			this._pendingReset = true;
-			setImmediate(() => {
-				this._pendingReset = false;
-				this.resetTimeout();
-			});
+		this._removeExpiration(key);
+		const closer = this.expirations?.first;
+		if (reschedule && (previousCloser !== closer || previousExpireOn !== closer?.expireOn)) {
+			this.rescheduleExpiration();
 		}
 		return result;
 	}
@@ -441,27 +543,19 @@ export class LimitedCollection<K, V> {
 	 * console.log(closestElement); // Output: { value: 'three', expire: 500, expireOn: [current timestamp + 500] }
 	 */
 	get closer() {
-		if (this._closerDirty) {
-			this._closer = undefined;
-			for (const [key, expiration] of this.expirations.entries()) {
-				if (!this._closer || expiration.expireOn < this._closer.expireOn) {
-					this._closer = { key, ...expiration };
-				}
-			}
-			this._closerDirty = false;
-		}
-		if (!this._closer) {
+		const closer = this.expirations?.first;
+		if (!closer) {
 			return;
 		}
 
-		const value = this.data.get(this._closer.key);
-		if (value === undefined && !this.data.has(this._closer.key)) {
+		const value = this.data.get(closer.key);
+		if (value === undefined && !this.data.has(closer.key)) {
 			return;
 		}
 		return {
 			value: value as V,
-			expire: this._closer.expire,
-			expireOn: this._closer.expireOn,
+			expire: closer.expire,
+			expireOn: closer.expireOn,
 		};
 	}
 
@@ -478,28 +572,37 @@ export class LimitedCollection<K, V> {
 		return this.data.size;
 	}
 
-	private resetTimeout() {
-		this.stopTimeout();
-		this.startTimeout();
+	private rescheduleExpiration() {
+		this.cancelExpiration();
+		this.scheduleExpiration();
 	}
 
-	private stopTimeout() {
-		clearTimeout(this.timeout);
-		this.timeout = undefined;
+	private cancelExpiration() {
+		const schedule = this.expirationSchedule;
+		if (!schedule) return;
+		if (schedule.type === 'immediate') clearImmediate(schedule.handle);
+		else clearTimeout(schedule.handle);
+		this.expirationSchedule = undefined;
 	}
 
-	private startTimeout() {
-		const { expireOn, expire } = this.closer || { expire: -1, expireOn: -1 };
-		if (expire === -1) {
+	private scheduleExpiration() {
+		const closer = this.expirations?.first;
+		if (!closer) {
 			return;
 		}
-		if (this.timeout) {
-			this.stopTimeout();
-		}
-		this.timeout = setTimeout(() => {
-			this.clearExpired();
-			this.resetTimeout();
-		}, expireOn - Date.now());
+		const delay = Math.max(0, Math.min(maxTimerDelay, closer.expireOn - Date.now()));
+		const drain = () => {
+			this.expirationSchedule = undefined;
+			try {
+				this.drainExpired(expirationBatchSize);
+			} finally {
+				this.rescheduleExpiration();
+			}
+		};
+		this.expirationSchedule =
+			delay === 0 && typeof setImmediate === 'function'
+				? { type: 'immediate', handle: setImmediate(drain) }
+				: { type: 'timeout', handle: setTimeout(drain, delay) };
 	}
 
 	keys() {
@@ -535,25 +638,32 @@ export class LimitedCollection<K, V> {
 	}
 
 	clear() {
+		this.cancelExpiration();
 		this.data.clear();
-		this.expirations.clear();
-		this._closer = undefined;
-		this._closerDirty = false;
-		this.resetTimeout();
+		this.expirations = undefined;
 	}
 
-	private clearExpired() {
-		for (const [key, expiration] of this.expirations) {
-			if (Date.now() >= expiration.expireOn) {
-				if (this._closer !== undefined && isSameMapKey(this._closer.key, key)) {
-					this._closerDirty = true;
-				}
-				if (this.data.has(key)) {
-					this.options.onDelete?.(key, this.data.get(key)!);
-				}
-				this.data.delete(key);
-				this.expirations.delete(key);
+	private drainExpired(limit: number) {
+		let deleted = 0;
+		const now = Date.now();
+		while (deleted < limit) {
+			const expiration = this.expirations?.first;
+			if (!expiration || now < expiration.expireOn) break;
+			const expireOn = expiration.expireOn;
+			try {
+				this._delete(expiration.key, false);
+			} catch (error) {
+				if (this.expirations?.get(expiration.key)?.expireOn === expireOn) this._removeExpiration(expiration.key);
+				throw error;
 			}
+			deleted++;
 		}
+	}
+
+	private _removeExpiration(key: K) {
+		const expirations = this.expirations;
+		if (!expirations) return;
+		expirations.delete(key);
+		if (expirations.size === 0) this.expirations = undefined;
 	}
 }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -365,6 +365,7 @@ export class LimitedCollection<K, V> {
 	 * @param key The key of the element.
 	 * @param value The value of the element.
 	 * @param customExpire The custom expiration time for the element.
+	 * @returns Whether the configured limit accepted the entry. Reentrant mutations from `onDelete` do not change this result.
 	 * @example
 	 * const collection = new LimitedCollection<number, string>({ limit: 3 });
 	 * collection.set(1, 'one');
@@ -377,8 +378,9 @@ export class LimitedCollection<K, V> {
 	 */
 	set(key: K, value: V, customExpire = this.options.expire) {
 		if (this.options.limit <= 0) {
-			return;
+			return false;
 		}
+		const retained = this.options.limit >= 1;
 		validateLimitedCollectionExpiration(customExpire);
 
 		const expireOn = Number.isFinite(customExpire) && customExpire > 0 ? Date.now() + customExpire : -1;
@@ -391,7 +393,7 @@ export class LimitedCollection<K, V> {
 					this.delete(keyValue);
 				}
 			}
-			return;
+			return retained;
 		}
 
 		const previousCloser = this.expirations?.first;
@@ -418,6 +420,7 @@ export class LimitedCollection<K, V> {
 				this.rescheduleExpiration();
 			}
 		}
+		return retained;
 	}
 
 	/**
@@ -513,15 +516,14 @@ export class LimitedCollection<K, V> {
 			return false;
 		}
 		const resolvedValue = value as V;
+		this.options.onDelete?.(key, resolvedValue);
 		if (!this.expirations) {
-			this.options.onDelete?.(key, resolvedValue);
 			return this.data.delete(key);
 		}
 
 		const previousCloser = this.expirations.first;
 		const previousExpireOn = previousCloser?.expireOn;
 
-		this.options.onDelete?.(key, resolvedValue);
 		const result = this.data.delete(key);
 		this._removeExpiration(key);
 		const closer = this.expirations?.first;

--- a/src/common/shorters/channels.ts
+++ b/src/common/shorters/channels.ts
@@ -75,23 +75,17 @@ export class ChannelShorter extends BaseShorter {
 	async edit(
 		id: string,
 		body: RESTPatchAPIChannelJSONBody,
-		optional: ChannelShorterOptionalParams = { guildId: '@me' },
+		optional: ChannelShorterOptionalParams = {},
 	): Promise<AllChannels> {
-		const options = MergeOptions<MakeRequired<ChannelShorterOptionalParams, 'guildId'>>({ guildId: '@me' }, optional);
-		const res = await this.client.proxy.channels(id).patch({ body, reason: options.reason });
-		await this.client.cache.channels?.setIfNI(
-			CacheFrom.Rest,
-			BaseChannel.__intent__(options.guildId),
-			res.id,
-			options.guildId,
-			res,
-		);
+		const res = await this.client.proxy.channels(id).patch({ body, reason: optional.reason });
+		const guildId = 'guild_id' in res && res.guild_id ? res.guild_id : '@me';
+		await this.client.cache.channels?.setIfNI(CacheFrom.Rest, BaseChannel.__intent__(guildId), res.id, guildId, res);
 		if (body.permission_overwrites && 'permission_overwrites' in res && res.permission_overwrites)
 			await this.client.cache.overwrites?.setIfNI(
 				CacheFrom.Rest,
-				BaseChannel.__intent__(options.guildId),
+				BaseChannel.__intent__(guildId),
 				res.id,
-				options.guildId,
+				guildId,
 				res.permission_overwrites,
 			);
 		return channelFrom(res, this.client);

--- a/src/common/shorters/members.ts
+++ b/src/common/shorters/members.ts
@@ -240,8 +240,13 @@ export class MemberShorter extends BaseShorter {
 		return new PermissionsBitField(roles.map(x => BigInt(x.permissions.bits)));
 	}
 
-	presence(memberId: string) {
-		return this.client.cache.presences?.get(memberId);
+	/**
+	 * Gets a member's cached presence in a guild.
+	 * @param guildId The ID of the guild.
+	 * @param memberId The ID of the member.
+	 */
+	presence(guildId: string, memberId: string) {
+		return this.client.cache.presences?.get(memberId, guildId);
 	}
 
 	async voice(guildId: string, memberId: (string & {}) | '@me', force = false): Promise<VoiceStateStructure> {

--- a/src/events/hooks/presence.ts
+++ b/src/events/hooks/presence.ts
@@ -3,5 +3,5 @@ import { toCamelCase } from '../../common';
 import type { GatewayPresenceUpdateDispatchData } from '../../types';
 
 export const PRESENCE_UPDATE = async (self: UsingClient, data: GatewayPresenceUpdateDispatchData) => {
-	return [toCamelCase(data), await self.cache.presences?.get(data.user.id)] as const;
+	return [toCamelCase(data), await self.cache.presences?.get(data.user.id, data.guild_id)] as const;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,12 @@ export * from './types';
 export { ShardManager, WorkerManager } from './websocket/discord';
 export type { ShardData, ShardManagerOptions, WorkerData, WorkerManagerOptions } from './websocket/discord/shared';
 export type { WorkerInfo, WorkerShardInfo } from './websocket/discord/worker';
+export type {
+	ManagerMessages,
+	ManagerSendCacheResult,
+	SerializedWorkerError,
+	SerializedWorkerValue,
+} from './websocket/discord/workermanager';
 
 /**
  * Creates an event with the specified data and run function.

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -90,7 +90,7 @@ export class BaseGuildMember extends DiscordBase {
 	}
 
 	presence() {
-		return this.client.members.presence(this.id);
+		return this.client.members.presence(this.guildId, this.id);
 	}
 
 	voice(mode?: 'rest' | 'flow'): Promise<VoiceStateStructure>;

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -56,8 +56,12 @@ export class User extends DiscordBase<APIUser> {
 		return this.rest.cdn.banners(this.id).get(this.banner, options);
 	}
 
-	presence() {
-		return this.client.members.presence(this.id);
+	/**
+	 * Gets the user's cached presence in a guild.
+	 * @param guildId The ID of the guild.
+	 */
+	presence(guildId: string) {
+		return this.client.members.presence(guildId, this.id);
 	}
 
 	toString() {

--- a/src/websocket/discord/events/presenceUpdate.ts
+++ b/src/websocket/discord/events/presenceUpdate.ts
@@ -4,12 +4,13 @@ export class PresenceUpdateHandler {
 	presenceUpdate = new Map<string, { timeout: NodeJS.Timeout; presence: GatewayPresenceUpdateDispatchData }>();
 
 	check(presence: GatewayPresenceUpdateDispatchData) {
-		if (!this.presenceUpdate.has(presence.user.id)) {
+		const key = `${presence.guild_id}.${presence.user.id}`;
+		if (!this.presenceUpdate.has(key)) {
 			this.setPresence(presence);
 			return true;
 		}
 
-		const data = this.presenceUpdate.get(presence.user.id)!;
+		const data = this.presenceUpdate.get(key)!;
 
 		if (this.presenceEquals(data.presence, presence)) {
 			return false;
@@ -23,10 +24,11 @@ export class PresenceUpdateHandler {
 	}
 
 	setPresence(presence: GatewayPresenceUpdateDispatchData) {
-		this.presenceUpdate.set(presence.user.id, {
+		const key = `${presence.guild_id}.${presence.user.id}`;
+		this.presenceUpdate.set(key, {
 			presence,
 			timeout: setTimeout(() => {
-				this.presenceUpdate.delete(presence.user.id);
+				this.presenceUpdate.delete(key);
 			}, 1.5e3),
 		});
 	}

--- a/src/websocket/discord/worker-errors.ts
+++ b/src/websocket/discord/worker-errors.ts
@@ -1,0 +1,109 @@
+import { SeyfertError } from '../../common';
+import type { SerializedWorkerError, SerializedWorkerValue } from './workermanager';
+
+function safeString(value: unknown) {
+	try {
+		return String(value);
+	} catch {
+		return '<unprintable>';
+	}
+}
+
+function isError(value: unknown): value is Error {
+	try {
+		return value instanceof Error;
+	} catch {
+		return false;
+	}
+}
+
+function isArray(value: unknown): value is unknown[] {
+	try {
+		return Array.isArray(value);
+	} catch {
+		return false;
+	}
+}
+
+function serializeWorkerValue(value: unknown, ancestors: WeakSet<object>): SerializedWorkerValue {
+	if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+	if (typeof value === 'number') return Number.isFinite(value) ? value : safeString(value);
+	if (typeof value !== 'object') return value === undefined ? '[undefined]' : safeString(value);
+	if (ancestors.has(value)) return '[Circular]';
+	ancestors.add(value);
+	try {
+		if (isError(value)) return serializeError(value, ancestors);
+		if (isArray(value)) return value.map(item => serializeWorkerValue(item, ancestors));
+		const result = Object.create(null) as Record<string, SerializedWorkerValue>;
+		for (const [key, item] of Object.entries(value)) result[key] = serializeWorkerValue(item, ancestors);
+		return { type: 'record', value: result };
+	} catch (error) {
+		return `[Unserializable value: ${isError(error) ? error.message : safeString(error)}]`;
+	} finally {
+		ancestors.delete(value);
+	}
+}
+
+function serializeMetadata(metadata: Record<string, unknown>, ancestors: WeakSet<object>) {
+	if (ancestors.has(metadata)) return { value: '[Circular]' };
+	ancestors.add(metadata);
+	try {
+		const result = Object.create(null) as Record<string, SerializedWorkerValue>;
+		for (const [key, value] of Object.entries(metadata)) result[key] = serializeWorkerValue(value, ancestors);
+		return result;
+	} catch (error) {
+		return { value: `[Unserializable value: ${isError(error) ? error.message : safeString(error)}]` };
+	} finally {
+		ancestors.delete(metadata);
+	}
+}
+
+function serializeError(error: Error, ancestors: WeakSet<object>): SerializedWorkerError {
+	const result: SerializedWorkerError = {
+		type: 'error',
+		name: error.name,
+		message: error.message,
+		stack: error.stack,
+	};
+	if (error instanceof SeyfertError) {
+		result.code = error.code;
+		if (error.metadata) result.metadata = serializeMetadata(error.metadata, ancestors);
+	}
+	if (error.cause !== undefined) result.cause = serializeWorkerValue(error.cause, ancestors);
+	return result;
+}
+
+export function serializeWorkerError(error: unknown): SerializedWorkerError {
+	const ancestors = new WeakSet<object>();
+	if (typeof error === 'object' && error !== null && isError(error)) {
+		ancestors.add(error);
+		try {
+			return serializeError(error, ancestors);
+		} catch (serializationError) {
+			return { type: 'error', name: 'Error', message: `Unserializable error: ${safeString(serializationError)}` };
+		}
+	}
+	return { type: 'error', name: 'Error', message: safeString(error), cause: serializeWorkerValue(error, ancestors) };
+}
+
+function deserializeWorkerValue(value: SerializedWorkerValue): unknown {
+	if (typeof value !== 'object' || value === null) return value;
+	if (Array.isArray(value)) return value.map(deserializeWorkerValue);
+	if (value.type === 'error') return deserializeWorkerError(value);
+	return Object.fromEntries(Object.entries(value.value).map(([key, item]) => [key, deserializeWorkerValue(item)]));
+}
+
+function deserializeMetadata(metadata: Record<string, SerializedWorkerValue>) {
+	return Object.fromEntries(Object.entries(metadata).map(([key, value]) => [key, deserializeWorkerValue(value)]));
+}
+
+export function deserializeWorkerError(error: SerializedWorkerError) {
+	const cause = error.cause === undefined ? undefined : deserializeWorkerValue(error.cause);
+	const metadata = error.metadata ? deserializeMetadata(error.metadata) : undefined;
+	const result =
+		error.code !== undefined ? new SeyfertError(error.code, { metadata, cause }) : new Error(error.message, { cause });
+	result.name = error.name;
+	result.message = error.message;
+	if (error.stack !== undefined) result.stack = error.stack;
+	return result;
+}

--- a/src/websocket/discord/worker.ts
+++ b/src/websocket/discord/worker.ts
@@ -46,8 +46,6 @@ export type WorkerSendCacheRequest = CreateWorkerMessage<
 			| 'flush'
 			| 'contains'
 			| 'getToRelationship'
-			| 'bulkAddToRelationShip'
-			| 'addToRelationship'
 			| 'removeRelationship'
 			| 'removeToRelationship';
 		args: unknown[];

--- a/src/websocket/discord/workermanager.ts
+++ b/src/websocket/discord/workermanager.ts
@@ -12,6 +12,7 @@ import { ConnectQueue } from '../structures/timeout';
 import { Heartbeater, type WorkerHeartbeaterMessages } from './heartbeater';
 import type { ShardOptions, WorkerData, WorkerManagerOptions } from './shared';
 import { WORKER_TIMEOUT_MS, type WorkerInfo, type WorkerMessages, type WorkerShardInfo } from './worker';
+import { serializeWorkerError } from './worker-errors';
 
 type WorkerManagerConstructorOptionalKeys = 'token' | 'intents' | 'info' | 'handlePayload' | 'handleWorkerMessage';
 type WorkerManagerConstructorOptions = WorkerManagerOptions extends infer Options
@@ -405,13 +406,15 @@ export class WorkerManager extends Map<
 							metadata: { detail: 'Invalid request from unavailable worker' },
 						});
 					}
-					// @ts-expect-error
-					const result = await this.cacheAdapter[message.method](...message.args);
-					this.postMessage(message.workerId, {
-						type: 'CACHE_RESULT',
-						nonce: message.nonce,
-						result,
-					} as ManagerSendCacheResult);
+					let response: ManagerSendCacheResult;
+					try {
+						// @ts-expect-error
+						const result = await this.cacheAdapter[message.method](...message.args);
+						response = { type: 'CACHE_RESULT', nonce: message.nonce, result };
+					} catch (error) {
+						response = { type: 'CACHE_RESULT', nonce: message.nonce, error: serializeWorkerError(error) };
+					}
+					this.postMessage(message.workerId, response);
 				}
 				break;
 			case 'RECEIVE_PAYLOAD':
@@ -750,7 +753,27 @@ export type ManagerSendPayload = CreateManagerMessage<
 >;
 export type ManagerRequestShardInfo = CreateManagerMessage<'SHARD_INFO', { nonce: string; shardId: number }>;
 export type ManagerRequestWorkerInfo = CreateManagerMessage<'WORKER_INFO', { nonce: string }>;
-export type ManagerSendCacheResult = CreateManagerMessage<'CACHE_RESULT', { nonce: string; result: any }>;
+export type SerializedWorkerValue =
+	| null
+	| boolean
+	| number
+	| string
+	| SerializedWorkerError
+	| SerializedWorkerValue[]
+	| { type: 'record'; value: { [key: string]: SerializedWorkerValue } };
+export interface SerializedWorkerError {
+	type: 'error';
+	name: string;
+	message: string;
+	stack?: string;
+	code?: string;
+	metadata?: Record<string, SerializedWorkerValue>;
+	cause?: SerializedWorkerValue;
+}
+export type ManagerSendCacheResult = CreateManagerMessage<
+	'CACHE_RESULT',
+	{ nonce: string } & ({ result: any; error?: never } | { error: SerializedWorkerError; result?: never })
+>;
 export type ManagerSendBotReady = CreateManagerMessage<'BOT_READY'>;
 export type ManagerSendApiResponse = CreateManagerMessage<
 	'API_RESPONSE',

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -1,9 +1,18 @@
 // biome-ignore assist/source/organizeImports: The root entrypoint must initialize before BaseClient to avoid the client barrel cycle.
 import { assert, describe, expect, test, vi } from 'vitest';
 import { BaseResource } from '../src/cache/resources/default/base';
-import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter } from '../src/index';
-import type { APIUser } from '../src/index';
+import {
+	Cache,
+	CacheFrom,
+	Client,
+	GatewayDispatchEvents,
+	LimitedMemoryAdapter,
+	MemoryAdapter,
+	PresenceUpdateStatus,
+} from '../src/index';
+import type { APIUser, PresenceUpdateReceiveStatus } from '../src/index';
 import { BaseClient } from '../src/client/base';
+import { PRESENCE_UPDATE } from '../src/events/hooks/presence';
 
 const intents = 53608447;
 const adapterKinds = ['MemoryAdapter', 'LimitedMemoryAdapter'] as const;
@@ -27,6 +36,16 @@ function channelWrite(guildId: string, name = guildId) {
 		{ id: 'channel-1', guild_id: guildId, name },
 		[`channel.${guildId}`, 'channel-1'],
 	] as const;
+}
+
+function presenceData(guildId: string, status: PresenceUpdateReceiveStatus) {
+	return {
+		activities: [],
+		client_status: {},
+		guild_id: guildId,
+		status,
+		user: { id: 'user-1' },
+	};
 }
 
 describe('test memory cache adapter', () => {
@@ -135,17 +154,17 @@ describe('memory cache adapter bucket ownership', () => {
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
 
-	test('indexes only globally keyed relationships and cleans up owner moves', () => {
+	test('indexes globally keyed relationships for lookup and cleanup', () => {
 		const adapter = new MemoryAdapter();
 		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-1' }, ['channel.guild-1', 'channel-1']);
-		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-1']);
 
 		assert.equal(adapter.keyToStorage.size, 1);
 		assert.equal(adapter.storage.size, 1);
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 
-		adapter.removeToRelationship('channel.guild-2', 'channel-1');
+		adapter.remove('channel.channel-1');
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
@@ -174,6 +193,114 @@ describe('base cache resource', () => {
 	});
 });
 
+describe.each(adapterKinds)('%s guild-scoped presences', kind => {
+	test('keeps one independently mutable entry per guild', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+
+		await cache.bulkSet([
+			[CacheFrom.Test, 'presences', presenceData('guild-1', PresenceUpdateStatus.Online), 'user-1', 'guild-1'],
+			[CacheFrom.Test, 'presences', presenceData('guild-2', PresenceUpdateStatus.Idle), 'user-1', 'guild-2'],
+		]);
+
+		expect(
+			await cache.bulkGet([
+				['presences', 'user-1', 'guild-1'],
+				['presences', 'user-1', 'guild-2'],
+			]),
+		).toEqual({
+			presences: [
+				expect.objectContaining({ guild_id: 'guild-1', status: 'online' }),
+				expect.objectContaining({ guild_id: 'guild-2', status: 'idle' }),
+			],
+		});
+		expect(await cache.presences?.keys('guild-1')).toEqual(['presence.guild-1.user-1']);
+		expect(await cache.presences?.values('guild-2')).toEqual([
+			expect.objectContaining({ guild_id: 'guild-2', status: 'idle' }),
+		]);
+		expect(await cache.presences?.count('guild-1')).toBe(1);
+		expect(await cache.presences?.contains('user-1', 'guild-2')).toBe(true);
+
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.DoNotDisturb),
+		);
+		expect(await cache.presences?.get('user-1', 'guild-1')).toMatchObject({ status: 'dnd' });
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+
+		await cache.presences?.remove('user-1', 'guild-1');
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('guild cleanup removes only that guild presence', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
+		);
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
+		await cache.guilds?.remove('guild-1');
+
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('member removal removes only that guild presence', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
+		);
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
+
+		await cache.onPacket({
+			d: {
+				guild_id: 'guild-1',
+				user: { avatar: null, discriminator: '0', global_name: null, id: 'user-1', username: 'user' },
+			},
+			op: 0,
+			s: 1,
+			t: GatewayDispatchEvents.GuildMemberRemove,
+		});
+
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('presence hook reads the previous value from the event guild', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
+		);
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
+
+		const [, previous] = await PRESENCE_UPDATE(
+			client,
+			presenceData('guild-1', PresenceUpdateStatus.DoNotDisturb) as Parameters<typeof PRESENCE_UPDATE>[1],
+		);
+
+		expect(previous).toMatchObject({ guild_id: 'guild-1', status: 'online' });
+	});
+});
+
 describe.each(adapterKinds)('%s custom cache routing', kind => {
 	test.each([
 		['root', 'custom.entry', ['custom', 'entry'], false],
@@ -191,6 +318,31 @@ describe.each(adapterKinds)('%s custom cache routing', kind => {
 		adapter.remove(key);
 		assert.equal(adapter.get(key), null);
 		assert.equal(adapter.contains(relationship[0], relationship[1]), false);
+	});
+});
+
+describe.each(adapterKinds)('%s relationship removal', kind => {
+	test.each([
+		['user.', 'user'],
+		['channel.', 'channel.guild-1'],
+		['presence.guild-1.', 'presence.guild-1'],
+		['custom.guild-1.', 'custom.guild-1'],
+	] as const)('removes only selected entries from %s', (prefix, relationship) => {
+		const adapter = createTestAdapter(kind);
+		adapter.set(`${prefix}first`, { id: 'first' }, [relationship, 'first']);
+		adapter.set(`${prefix}second`, { id: 'second' }, [relationship, 'second']);
+
+		adapter.removeToRelationship(relationship, 'first');
+		assert.equal(adapter.get(`${prefix}first`), null);
+		assert.equal(adapter.contains(relationship, 'first'), false);
+		assert.deepEqual(adapter.keys(relationship), [`${prefix}second`]);
+		assert.deepEqual(adapter.get(`${prefix}second`), { id: 'second' });
+
+		adapter.removeToRelationship(relationship, ['missing', 'second']);
+		assert.equal(adapter.count(relationship), 0);
+		assert.equal(adapter.get(`${prefix}second`), null);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
 	});
 });
 
@@ -324,7 +476,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		assert.deepEqual(adapter.keys('custom.guild-1'), ['custom.entry']);
 	});
 
-	test('preserves the old value and relationship when a replacement cannot encode', () => {
+	test('preserves the old value when a replacement cannot encode', () => {
 		let reject = false;
 		const adapter = createTestAdapter(kind, {
 			encode(data) {
@@ -335,10 +487,9 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		reject = true;
-		expect(() => adapter.set(...channelWrite('guild-2', 'new'))).toThrow('encode failed');
+		expect(() => adapter.set(...channelWrite('guild-1', 'new'))).toThrow('encode failed');
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 
 	test('propagates bulk failures without leaving an orphaned entry', () => {
@@ -363,7 +514,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		}
 	});
 
-	test('patch decode failures leave both value and relationship untouched', () => {
+	test('patch decode failures leave the value untouched', () => {
 		let rejectDecode = false;
 		const adapter = createTestAdapter(kind, {
 			decode(data) {
@@ -374,11 +525,10 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		rejectDecode = true;
-		expect(() => adapter.patch(...channelWrite('guild-2', 'new'))).toThrow('decode failed');
+		expect(() => adapter.patch(...channelWrite('guild-1', 'new'))).toThrow('decode failed');
 		rejectDecode = false;
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 });
 
@@ -399,15 +549,50 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.contains('member.guild-2', 'user-2'), false);
 	});
 
-	test('moves a globally keyed resource between bucket-owned relationships', () => {
+	test('uses the global-key index for lookup and cleanup', () => {
 		const adapter = new LimitedMemoryAdapter();
 		adapter.set(...channelWrite('guild-1'));
-		adapter.set(...channelWrite('guild-2'));
 
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), true);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1', name: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 		assert.equal(adapter.storage.size, 1);
+		assert.equal(adapter.relationships.size, 0);
+
+		adapter.remove('channel.channel-1');
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('does not scan guild buckets for a globally keyed miss', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(...channelWrite('guild-1'));
+		adapter.set('channel.channel-2', { id: 'channel-2', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-2']);
+		const iterateStorage = vi.spyOn(adapter.storage, Symbol.iterator);
+
+		assert.equal(adapter.get('channel.missing'), null);
+		expect(iterateStorage).not.toHaveBeenCalled();
+	});
+
+	test('relocates message storage without changing its relationship owner', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' }, ['message.channel-1', 'message-1']);
+		adapter.patch('message.message-1', { guild_id: 'guild-1' }, ['message.channel-1', 'message-1']);
+
+		assert.equal(adapter.storage.has('message'), false);
+		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
+		assert.deepEqual(adapter.get('message.message-1'), {
+			id: 'message-1',
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+		});
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+
+		adapter.remove('message.message-1');
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
 		assert.equal(adapter.relationships.size, 0);
 	});
 
@@ -417,34 +602,79 @@ describe('limited memory cache adapter ownership', () => {
 			'message.channel-1',
 			'message-1',
 		]);
-		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-2' }, [
-			'message.channel-2',
-			'message-1',
-		]);
 
-		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
-		assert.equal(adapter.contains('message.channel-2', 'message-1'), true);
-		assert.deepEqual(adapter.keys('message.channel-2'), ['message.message-1']);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+		assert.deepEqual(adapter.keys('message.channel-1'), ['message.message-1']);
 		assert.equal(adapter.relationships.size, 1);
+
+		adapter.remove('message.message-1');
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.relationships.size, 0);
 	});
 
-	test('removes an unscoped message after moving it into guild storage', () => {
+	test('preserves distinct physical and relationship message IDs', () => {
 		const adapter = new LimitedMemoryAdapter();
-		adapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' }, ['message.channel-1', 'message-1']);
+		adapter.set('message.physical-id', { id: 'physical-id', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'relationship-id',
+		]);
+
+		assert.deepEqual(adapter.keys('message.channel-1'), ['message.physical-id']);
+		assert.deepEqual(adapter.getToRelationship('message.channel-1'), ['relationship-id']);
+
+		adapter.removeToRelationship('message.channel-1', 'relationship-id');
+		assert.equal(adapter.get('message.physical-id'), null);
+		assert.equal(adapter.count('message.channel-1'), 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+
+		adapter.set('message.physical-id', { id: 'physical-id', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'relationship-id',
+		]);
+		adapter.removeRelationship('message.channel-1');
+		assert.equal(adapter.get('message.physical-id'), null);
+		assert.equal(adapter.relationships.size, 0);
+	});
+
+	test('cleans message indexes and relationships when their bucket evicts them', () => {
+		const adapter = new LimitedMemoryAdapter({ message: { limit: 1 } });
 		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
 			'message.channel-1',
 			'message-1',
 		]);
-
-		assert.equal(adapter.storage.has('message'), false);
-		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
-
-		adapter.remove('message.message-1');
+		adapter.set('message.message-2', { id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-2',
+		]);
 
 		assert.equal(adapter.get('message.message-1'), null);
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
-		assert.equal(adapter.storage.size, 0);
-		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.get('message.message-2') !== null, true);
+		assert.equal(adapter.contains('message.channel-1', 'message-2'), true);
+		assert.equal(adapter.keyToStorage.size, 1);
+	});
+
+	test('cleans message indexes and relationships when they expire', () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = new LimitedMemoryAdapter({ message: { expire: 100 } });
+			adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+				'message.channel-1',
+				'message-1',
+			]);
+
+			vi.advanceTimersByTime(100);
+
+			assert.equal(adapter.get('message.message-1'), null);
+			assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+			assert.equal(adapter.storage.size, 0);
+			assert.equal(adapter.keyToStorage.size, 0);
+			assert.equal(adapter.relationships.size, 0);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('does not allocate relationship sets for bucket-owned resources', () => {
@@ -532,16 +762,6 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.get('custom.entry-1'), null);
 		assert.equal(adapter.contains(to, 'entry-1'), false);
 		assert.equal(adapter.contains(to, 'entry-2'), true);
-	});
-
-	test('moves a custom relationship between owners', () => {
-		const adapter = new LimitedMemoryAdapter();
-		adapter.set('custom.entry', { id: 'entry' }, ['custom.guild-1', 'entry']);
-		adapter.set('custom.entry', { id: 'entry', owner: 'guild-2' }, ['custom.guild-2', 'entry']);
-
-		assert.equal(adapter.contains('custom.guild-1', 'entry'), false);
-		assert.deepEqual(adapter.getToRelationship('custom.guild-2'), ['entry']);
-		assert.deepEqual(adapter.get('custom.entry'), { id: 'entry', owner: 'guild-2' });
 	});
 
 	test('stores empty array resources in the relationship-owned bucket', () => {

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -1,11 +1,33 @@
-import { assert, describe, expect, test } from 'vitest';
+// biome-ignore assist/source/organizeImports: The root entrypoint must initialize before BaseClient to avoid the client barrel cycle.
+import { assert, describe, expect, test, vi } from 'vitest';
 import { BaseResource } from '../src/cache/resources/default/base';
-import { BaseClient } from '../src/client/base';
-import type { APIUser } from '../src/index';
 import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter } from '../src/index';
+import type { APIUser } from '../src/index';
+import { BaseClient } from '../src/client/base';
 
-// all intents
 const intents = 53608447;
+const adapterKinds = ['MemoryAdapter', 'LimitedMemoryAdapter'] as const;
+
+interface TestAdapterOptions {
+	encode?(data: any): any;
+	decode?(data: any): unknown;
+}
+
+function createTestAdapter(kind: (typeof adapterKinds)[number], options: TestAdapterOptions = {}) {
+	if (kind === 'LimitedMemoryAdapter') return new LimitedMemoryAdapter(options);
+	return new MemoryAdapter({
+		encode: options.encode ?? (data => data),
+		decode: options.decode ?? (data => data),
+	});
+}
+
+function channelWrite(guildId: string, name = guildId) {
+	return [
+		'channel.channel-1',
+		{ id: 'channel-1', guild_id: guildId, name },
+		[`channel.${guildId}`, 'channel-1'],
+	] as const;
+}
 
 describe('test memory cache adapter', () => {
 	const adapter = new MemoryAdapter();
@@ -13,40 +35,31 @@ describe('test memory cache adapter', () => {
 	test('discord cache', () => {
 		const client = new Client({
 			getRC: () => ({
-				locations: {
-					base: '',
-					output: '',
-				},
+				locations: { base: '', output: '' },
 				intents,
 				token: '',
 			}),
 		});
-		client.setServices({
-			cache: {
-				adapter,
-			},
-		});
+		client.setServices({ cache: { adapter } });
 		return client.cache.testAdapter();
 	});
 
 	test('get and values preserve falsy decoded values', () => {
 		const primitiveAdapter = new MemoryAdapter({
-			encode(data) {
-				return data;
-			},
-			decode(data) {
-				return data;
-			},
+			encode: data => data,
+			decode: data => data,
 		});
 
-		primitiveAdapter.set('user.0', 0);
-		primitiveAdapter.set('user.false', false);
-		primitiveAdapter.set('user.empty', '');
-		primitiveAdapter.addToRelationship('user', ['0', 'false', 'empty']);
+		primitiveAdapter.bulkSet([
+			['user.0', 0, ['user', '0']],
+			['user.false', false, ['user', 'false']],
+			['user.empty', '', ['user', 'empty']],
+		]);
 
 		expect(primitiveAdapter.get('user.0')).toBe(0);
 		expect(primitiveAdapter.get('user.false')).toBe(false);
 		expect(primitiveAdapter.get('user.empty')).toBe('');
+		expect(primitiveAdapter.bulkGet(['user.0', 'user.false', 'user.empty'])).toEqual([0, false, '']);
 		expect(primitiveAdapter.values('user')).toEqual([0, false, '']);
 	});
 
@@ -102,6 +115,52 @@ describe('test memory cache adapter', () => {
 	});
 });
 
+describe('memory cache adapter bucket ownership', () => {
+	test('derives root and guild-keyed relationships from their cache keys', () => {
+		const adapter = new MemoryAdapter();
+		adapter.bulkSet([
+			['user.user-1', { id: 'user-1' }, ['user', 'user-1']],
+			['member.guild-1.user-1', { id: 'user-1', guild_id: 'guild-1' }, ['member.guild-1', 'user-1']],
+		]);
+
+		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.storage.size, 2);
+		assert.equal(adapter.storage.get('user')?.size, 1);
+		assert.equal(adapter.storage.get('member.guild-1')?.size, 1);
+		assert.deepEqual(adapter.keys('user'), ['user.user-1']);
+		assert.deepEqual(adapter.keys('member.guild-1'), ['member.guild-1.user-1']);
+
+		adapter.removeRelationship(['user', 'member.guild-1']);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('indexes only globally keyed relationships and cleans up owner moves', () => {
+		const adapter = new MemoryAdapter();
+		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-1' }, ['channel.guild-1', 'channel-1']);
+		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-1']);
+
+		assert.equal(adapter.keyToStorage.size, 1);
+		assert.equal(adapter.storage.size, 1);
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
+		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+
+		adapter.removeToRelationship('channel.guild-2', 'channel-1');
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('scans entries across relationship buckets', () => {
+		const adapter = new MemoryAdapter();
+		adapter.bulkSet([
+			['member.guild-1.user-1', { id: 'user-1' }, ['member.guild-1', 'user-1']],
+			['member.guild-2.user-2', { id: 'user-2' }, ['member.guild-2', 'user-2']],
+		]);
+
+		expect(adapter.scan('member.*.*', true)).toEqual(['member.guild-1.user-1', 'member.guild-2.user-2']);
+	});
+});
+
 describe('base cache resource', () => {
 	test('normalizes adapter cache misses to undefined', () => {
 		const adapter = new MemoryAdapter();
@@ -110,8 +169,28 @@ describe('base cache resource', () => {
 		assert.strictEqual(adapter.get('base.missing'), null);
 		assert.strictEqual(resource.get('missing'), undefined);
 
-		adapter.set('base.present', { id: 'present' });
+		adapter.set('base.present', { id: 'present' }, ['base', 'present']);
 		assert.deepEqual(resource.get('present'), { id: 'present' });
+	});
+});
+
+describe.each(adapterKinds)('%s custom cache routing', kind => {
+	test.each([
+		['root', 'custom.entry', ['custom', 'entry'], false],
+		['guild indexed', 'custom.entry', ['custom.guild-1', 'entry'], true],
+		['guild keyed', 'custom.guild-1.entry', ['custom.guild-1', 'entry'], false],
+	] as const)('routes a %s entry', (_layout, key, relationship, indexed) => {
+		const adapter = createTestAdapter(kind);
+		adapter.set(key, { id: 'entry' }, relationship);
+
+		assert.deepEqual(adapter.get(key), { id: 'entry' });
+		assert.deepEqual(adapter.keys(relationship[0]), [key]);
+		assert.equal(adapter.contains(relationship[0], relationship[1]), true);
+		assert.equal(adapter.keyToStorage.size, indexed ? 1 : 0);
+
+		adapter.remove(key);
+		assert.equal(adapter.get(key), null);
+		assert.equal(adapter.contains(relationship[0], relationship[1]), false);
 	});
 });
 
@@ -121,51 +200,36 @@ describe('test limited memory cache adapter', () => {
 	test('discord cache', () => {
 		const client = new Client({
 			getRC: () => ({
-				locations: {
-					base: '',
-					output: '',
-				},
+				locations: { base: '', output: '' },
 				intents,
 				token: '',
 			}),
 		});
-		client.setServices({
-			cache: {
-				adapter,
-			},
-		});
+		client.setServices({ cache: { adapter } });
 		return client.cache.testAdapter();
 	});
 
 	test('bulkGet preserves falsy decoded values', () => {
 		const primitiveAdapter = new LimitedMemoryAdapter({
-			encode(data) {
-				return data;
-			},
-			decode(data) {
-				return data;
-			},
+			encode: data => data,
+			decode: data => data,
 		});
 
-		primitiveAdapter.set('user.0', 0);
-		primitiveAdapter.set('user.false', false);
-		primitiveAdapter.set('user.empty', '');
+		primitiveAdapter.bulkSet([
+			['user.0', 0, ['user', '0']],
+			['user.false', false, ['user', 'false']],
+			['user.empty', '', ['user', 'empty']],
+		]);
 
 		expect(primitiveAdapter.bulkGet(['user.0', 'user.false', 'user.empty'])).toEqual([0, false, '']);
 	});
 
-	test('bulkRemove clears message relationship buckets', () => {
-		const primitiveAdapter = new LimitedMemoryAdapter({
-			encode(data) {
-				return data;
-			},
-			decode(data) {
-				return data;
-			},
-		});
-
-		primitiveAdapter.addToRelationship('message.channel-1', 'message-1');
-		primitiveAdapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' });
+	test('bulkRemove clears message relationships', () => {
+		const primitiveAdapter = new LimitedMemoryAdapter();
+		primitiveAdapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
 
 		primitiveAdapter.bulkRemove(['message.message-1']);
 
@@ -175,24 +239,15 @@ describe('test limited memory cache adapter', () => {
 	test('guild removal clears message and overwrite cache indexes', async () => {
 		const client = new Client({
 			getRC: () => ({
-				locations: {
-					base: '',
-					output: '',
-				},
+				locations: { base: '', output: '' },
 				intents,
 				token: '',
 			}),
 		});
-
-		client.setServices({
-			cache: {
-				adapter: new LimitedMemoryAdapter(),
-			},
-		});
+		client.setServices({ cache: { adapter: new LimitedMemoryAdapter() } });
 
 		const guildId = 'guild-1';
 		const channelId = 'channel-1';
-
 		await client.cache.channels?.set(CacheFrom.Test, channelId, guildId, {
 			id: channelId,
 			guild_id: guildId,
@@ -203,12 +258,7 @@ describe('test limited memory cache adapter', () => {
 			id: 'message-1',
 			channel_id: channelId,
 			content: 'hello',
-			author: {
-				id: 'user-1',
-				username: 'user',
-				discriminator: '0',
-				avatar: null,
-			},
+			author: { id: 'user-1', username: 'user', discriminator: '0', avatar: null },
 		} as any);
 		await client.cache.overwrites?.set(CacheFrom.Test, channelId, guildId, [
 			{ id: 'role-1', allow: '0', deny: '0', type: 0 },
@@ -216,23 +266,16 @@ describe('test limited memory cache adapter', () => {
 
 		expect(await client.cache.messages?.count(channelId)).toBe(1);
 		expect(await client.cache.overwrites?.count(guildId)).toBe(1);
-
 		await client.cache.guilds?.remove(guildId);
-
 		expect(await client.cache.messages?.count(channelId)).toBe(0);
-		expect(await client.cache.messages?.keys(channelId)).toEqual([]);
 		expect(await client.cache.overwrites?.count(guildId)).toBe(0);
-		expect(await client.cache.overwrites?.keys(guildId)).toEqual([]);
 		expect(await client.cache.overwrites?.raw(channelId)).toBeNull();
 	});
 
 	test('rebuilds resources when disabledCache is explicitly false', () => {
 		const client = new Client({
 			getRC: () => ({
-				locations: {
-					base: '',
-					output: '',
-				},
+				locations: { base: '', output: '' },
 				intents,
 				token: '',
 			}),
@@ -240,105 +283,289 @@ describe('test limited memory cache adapter', () => {
 
 		client.setServices({ cache: { disabledCache: true } });
 		assert.equal(client.cache.users, undefined);
-
 		client.setServices({ cache: { disabledCache: false } });
 		assert.notEqual(client.cache.users, undefined);
 	});
 });
 
-describe('test limited memory cache adapter indexing', () => {
-	test('resolves get patch and remove across multiple buckets', () => {
-		const adapter = new LimitedMemoryAdapter({
-			default: {
-				limit: Number.POSITIVE_INFINITY,
-			},
-			member: {
-				limit: Number.POSITIVE_INFINITY,
+describe.each(adapterKinds)('%s atomic write failures', kind => {
+	test.each([
+		['root', 'user.user-1', { id: 'user-1' }, 'user', 'user-1'],
+		['guild related', 'channel.channel-1', { id: 'channel-1', guild_id: 'guild-1' }, 'channel.guild-1', 'channel-1'],
+		['message', 'message.message-1', { id: 'message-1', guild_id: 'guild-1' }, 'message.channel-1', 'message-1'],
+		['custom', 'custom.entry-1', { id: 'entry-1', guild_id: 'guild-1' }, 'custom.guild-1', 'entry-1'],
+	] as const)('does not create a %s relationship when encoding fails', (_label, key, value, to, id) => {
+		const adapter = createTestAdapter(kind, {
+			encode() {
+				throw new Error('encode failed');
 			},
 		});
 
-		adapter.bulkAddToRelationShip({
-			'member.guild-1': ['user-1'],
-			'member.guild-2': ['user-2'],
+		expect(() => adapter.set(key, value, [to, id])).toThrow('encode failed');
+		assert.equal(adapter.contains(to, id), false);
+		assert.equal(adapter.storage.size, 0);
+	});
+
+	test('does not create custom routing state when encoding fails', () => {
+		let reject = true;
+		const adapter = createTestAdapter(kind, {
+			encode(data) {
+				if (reject) throw new Error('encode failed');
+				return data;
+			},
 		});
 
+		expect(() => adapter.set('custom.entry', { id: 'entry' }, ['custom', 'entry'])).toThrow('encode failed');
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+		reject = false;
+		adapter.set('custom.entry', { id: 'entry' }, ['custom.guild-1', 'entry']);
+
+		assert.deepEqual(adapter.keys('custom.guild-1'), ['custom.entry']);
+	});
+
+	test('preserves the old value and relationship when a replacement cannot encode', () => {
+		let reject = false;
+		const adapter = createTestAdapter(kind, {
+			encode(data) {
+				if (reject) throw new Error('encode failed');
+				return data;
+			},
+		});
+		adapter.set(...channelWrite('guild-1', 'old'));
+
+		reject = true;
+		expect(() => adapter.set(...channelWrite('guild-2', 'new'))).toThrow('encode failed');
+		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
+	});
+
+	test('keeps successful bulk entries and rejects the failing entry without an orphan', () => {
+		const adapter = createTestAdapter(kind, {
+			encode(data) {
+				if (data.id === 'user-2') throw new Error('encode failed');
+				return data;
+			},
+		});
+
+		expect(() =>
+			adapter.bulkSet([
+				['user.user-1', { id: 'user-1' }, ['user', 'user-1']],
+				['user.user-2', { id: 'user-2' }, ['user', 'user-2']],
+				['user.user-3', { id: 'user-3' }, ['user', 'user-3']],
+			]),
+		).toThrow('encode failed');
+		assert.equal(adapter.contains('user', 'user-1'), true);
+		assert.equal(adapter.contains('user', 'user-2'), false);
+		assert.equal(adapter.contains('user', 'user-3'), false);
+	});
+
+	test('patch decode failures leave both value and relationship untouched', () => {
+		let rejectDecode = false;
+		const adapter = createTestAdapter(kind, {
+			decode(data) {
+				if (rejectDecode) throw new Error('decode failed');
+				return data;
+			},
+		});
+		adapter.set(...channelWrite('guild-1', 'old'));
+
+		rejectDecode = true;
+		expect(() => adapter.patch(...channelWrite('guild-2', 'new'))).toThrow('decode failed');
+		rejectDecode = false;
+		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
+	});
+});
+
+describe('limited memory cache adapter ownership', () => {
+	test('resolves patch and removal across guild-keyed buckets', () => {
+		const adapter = new LimitedMemoryAdapter();
 		adapter.bulkSet([
-			['member.guild-1.user-1', { id: 'user-1', guild_id: 'guild-1', nick: 'uno' }],
-			['member.guild-2.user-2', { id: 'user-2', guild_id: 'guild-2', nick: 'dos' }],
+			['member.guild-1.user-1', { id: 'user-1', guild_id: 'guild-1', nick: 'uno' }, ['member.guild-1', 'user-1']],
+			['member.guild-2.user-2', { id: 'user-2', guild_id: 'guild-2', nick: 'dos' }, ['member.guild-2', 'user-2']],
 		]);
 
-		assert.deepEqual(adapter.get('member.guild-2.user-2'), {
-			id: 'user-2',
-			guild_id: 'guild-2',
-			nick: 'dos',
-		});
-		assert.equal(
-			(adapter as LimitedMemoryAdapter<unknown> & { keyToStorage: Map<string, unknown> }).keyToStorage.has(
-				'member.guild-2.user-2',
-			),
-			false,
-		);
-
-		adapter.patch('member.guild-2.user-2', { nick: 'dos-updated' });
-
-		assert.deepEqual(adapter.get('member.guild-2.user-2'), {
-			id: 'user-2',
-			guild_id: 'guild-2',
-			nick: 'dos-updated',
-		});
+		adapter.patch('member.guild-2.user-2', { nick: 'updated' }, ['member.guild-2', 'user-2']);
+		assert.equal((adapter.get('member.guild-2.user-2') as { nick: string }).nick, 'updated');
+		assert.equal(adapter.keyToStorage.size, 0);
 
 		adapter.remove('member.guild-2.user-2');
-
 		assert.equal(adapter.get('member.guild-2.user-2'), null);
+		assert.equal(adapter.contains('member.guild-2', 'user-2'), false);
 	});
 
-	test('removes message relationships using the deleted message channel', () => {
-		const adapter = new LimitedMemoryAdapter({
-			default: {
-				limit: Number.POSITIVE_INFINITY,
-			},
-			message: {
-				limit: Number.POSITIVE_INFINITY,
-			},
-		});
+	test('moves a globally keyed resource between bucket-owned relationships', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(...channelWrite('guild-1'));
+		adapter.set(...channelWrite('guild-2'));
 
-		adapter.bulkAddToRelationShip({
-			'message.channel-1': ['message-1'],
-			'message.channel-2': ['message-2'],
-		});
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
+		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.equal(adapter.storage.size, 1);
+		assert.equal(adapter.relationships.size, 0);
+	});
 
-		adapter.bulkSet([
-			['message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1', content: 'one' }],
-			['message.message-2', { id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-2', content: 'two' }],
+	test('keeps an explicit secondary index when message ownership differs from storage', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-2' }, [
+			'message.channel-2',
+			'message-1',
 		]);
 
-		adapter.remove('message.message-2');
-
-		assert.deepEqual(adapter.getToRelationship('message.channel-1'), ['message-1']);
-		assert.deepEqual(adapter.getToRelationship('message.channel-2'), []);
-		assert.equal(
-			(adapter as LimitedMemoryAdapter<unknown> & { keyToStorage: Map<string, unknown> }).keyToStorage.has(
-				'message.message-2',
-			),
-			false,
-		);
-	});
-	test('relationship reads do not allocate empty buckets', () => {
-		const adapter = new LimitedMemoryAdapter();
-		const relationships = (adapter as LimitedMemoryAdapter<unknown> & { relationships: Map<string, unknown> })
-			.relationships;
-
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
-		assert.deepEqual(adapter.getToRelationship('message.channel-1'), []);
-		assert.deepEqual(adapter.keys('message.channel-1'), []);
-		assert.equal(adapter.count('message.channel-1'), 0);
-		assert.equal(relationships.size, 0);
+		assert.equal(adapter.contains('message.channel-2', 'message-1'), true);
+		assert.deepEqual(adapter.keys('message.channel-2'), ['message.message-1']);
+		assert.equal(adapter.relationships.size, 1);
+	});
 
-		adapter.addToRelationship('message.channel-1', 'message-1');
-		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+	test('removes an unscoped message after moving it into guild storage', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' }, ['message.channel-1', 'message-1']);
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
 
-		adapter.removeToRelationship('message.channel-1', 'message-1');
-		assert.equal(relationships.size, 0);
+		assert.equal(adapter.storage.has('message'), false);
+		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
+
+		adapter.remove('message.message-1');
+
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('does not allocate relationship sets for bucket-owned resources', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(...channelWrite('guild-1'));
+
+		assert.equal(adapter.count('channel.guild-1'), 1);
+		assert.deepEqual(adapter.getToRelationship('channel.guild-1'), ['channel-1']);
+		assert.equal(adapter.relationships.size, 0);
+	});
+
+	test('removes expired buckets and their global indexes', () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = new LimitedMemoryAdapter({ default: { expire: 100 } });
+			adapter.set(...channelWrite('guild-1'));
+			vi.advanceTimersByTime(100);
+			assert.equal(adapter.get('channel.channel-1'), null);
+			assert.equal(adapter.storage.size, 0);
+			assert.equal(adapter.keyToStorage.size, 0);
+			assert.equal(adapter.count('channel.guild-1'), 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test('flush disposes all limited collection timers', () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = new LimitedMemoryAdapter({ default: { expire: 100 } });
+			adapter.set(...channelWrite('guild-1'));
+			assert.equal(vi.getTimerCount(), 1);
+			adapter.flush();
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test.each(['decode', 'encode'] as const)('a failed patch does not refresh expiration when %s throws', failure => {
+		vi.useFakeTimers();
+		try {
+			let reject = false;
+			const adapter = new LimitedMemoryAdapter({
+				default: { expire: 100 },
+				encode(data) {
+					if (reject && failure === 'encode') throw new Error('encode failed');
+					return data;
+				},
+				decode(data) {
+					if (reject && failure === 'decode') throw new Error('decode failed');
+					return data;
+				},
+			});
+			adapter.set(...channelWrite('guild-1', 'old'));
+			vi.advanceTimersByTime(80);
+
+			reject = true;
+			expect(() => adapter.patch(...channelWrite('guild-1', 'new'))).toThrow(`${failure} failed`);
+			vi.advanceTimersByTime(21);
+
+			assert.equal(adapter.storage.size, 0);
+			assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test('does not retain a value or relationship when its limit rejects it', () => {
+		const adapter = new LimitedMemoryAdapter({ default: { limit: 0 } });
+		adapter.set(...channelWrite('guild-1'));
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
+	});
+
+	test.each([
+		['root', 'custom', { id: 'entry-1', guild_id: 'ignored' }],
+		['guild related', 'custom.guild-1', { id: 'entry-1', guild_id: 'guild-1' }],
+	] as const)('evicts custom %s relationships from their owning bucket', (_label, to, first) => {
+		const adapter = new LimitedMemoryAdapter({ default: { limit: 1 } });
+		adapter.set('custom.entry-1', first, [to, 'entry-1']);
+		adapter.set('custom.entry-2', { ...first, id: 'entry-2' }, [to, 'entry-2']);
+
+		assert.equal(adapter.get('custom.entry-1'), null);
+		assert.equal(adapter.contains(to, 'entry-1'), false);
+		assert.equal(adapter.contains(to, 'entry-2'), true);
+	});
+
+	test('moves a custom relationship between owners', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('custom.entry', { id: 'entry' }, ['custom.guild-1', 'entry']);
+		adapter.set('custom.entry', { id: 'entry', owner: 'guild-2' }, ['custom.guild-2', 'entry']);
+
+		assert.equal(adapter.contains('custom.guild-1', 'entry'), false);
+		assert.deepEqual(adapter.getToRelationship('custom.guild-2'), ['entry']);
+		assert.deepEqual(adapter.get('custom.entry'), { id: 'entry', owner: 'guild-2' });
+	});
+
+	test('stores empty array resources in the relationship-owned bucket', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('overwrite.channel-1', [], ['overwrite.guild-1', 'channel-1']);
+		assert.deepEqual(adapter.get('overwrite.channel-1'), []);
+		assert.equal(adapter.contains('overwrite.guild-1', 'channel-1'), true);
+	});
+
+	test('message removal does not decode its stored value', () => {
+		let rejectDecode = false;
+		const adapter = new LimitedMemoryAdapter({
+			encode: data => data,
+			decode(data) {
+				if (rejectDecode) throw new Error('decode failed');
+				return data;
+			},
+		});
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
+
+		rejectDecode = true;
+		adapter.remove('message.message-1');
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
 	});
 
 	test('message cache stores authors so transformed messages can be read back', async () => {
@@ -365,10 +592,8 @@ describe('test limited memory cache adapter indexing', () => {
 		};
 
 		await cache.messages?.set(CacheFrom.Rest, message.id, message.channel_id, message);
-
 		const cachedMessage = await cache.messages?.get(message.id);
 		const rawMessage = await cache.messages?.raw(message.id);
-
 		assert.equal(cachedMessage?.author.id, message.author.id);
 		assert.equal(rawMessage?.user_id, message.author.id);
 		assert.equal(await cache.users?.raw(message.author.id), message.author as APIUser);
@@ -378,26 +603,13 @@ describe('test limited memory cache adapter indexing', () => {
 describe('base client runtime config cache', () => {
 	test('keeps runtime config scoped per client instance', async () => {
 		const clientA = new BaseClient({
-			getRC: () => ({
-				locations: {
-					base: 'src-a',
-				},
-				intents,
-				token: 'token-a',
-			}),
+			getRC: () => ({ locations: { base: 'src-a' }, intents, token: 'token-a' }),
 		});
 		const clientB = new BaseClient({
-			getRC: () => ({
-				locations: {
-					base: 'src-b',
-				},
-				intents: 0,
-				token: 'token-b',
-			}),
+			getRC: () => ({ locations: { base: 'src-b' }, intents: 0, token: 'token-b' }),
 		});
 
 		const [configA, configB] = await Promise.all([clientA.getRC(), clientB.getRC()]);
-
 		expect(configA.token).toBe('token-a');
 		expect(configB.token).toBe('token-b');
 		expect(configA.locations.base).toBe('src-a');

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -341,7 +341,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 
-	test('keeps successful bulk entries and rejects the failing entry without an orphan', () => {
+	test('propagates bulk failures without leaving an orphaned entry', () => {
 		const adapter = createTestAdapter(kind, {
 			encode(data) {
 				if (data.id === 'user-2') throw new Error('encode failed');
@@ -356,9 +356,11 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 				['user.user-3', { id: 'user-3' }, ['user', 'user-3']],
 			]),
 		).toThrow('encode failed');
-		assert.equal(adapter.contains('user', 'user-1'), true);
+		assert.equal(adapter.get('user.user-2'), null);
 		assert.equal(adapter.contains('user', 'user-2'), false);
-		assert.equal(adapter.contains('user', 'user-3'), false);
+		for (const id of ['user-1', 'user-3']) {
+			assert.equal(adapter.contains('user', id), adapter.get(`user.${id}`) !== null);
+		}
 	});
 
 	test('patch decode failures leave both value and relationship untouched', () => {

--- a/tests/channel-overwrites.test.mts
+++ b/tests/channel-overwrites.test.mts
@@ -1,8 +1,45 @@
 import { createMockBot, mockWorld, Routes } from '@slipher/testing';
 import { describe, expect, test } from 'vitest';
-import { OverwriteType } from '../lib';
+import { Client, GatewayIntentBits, LimitedMemoryAdapter, MemoryAdapter, OverwriteType } from '../lib';
 
 describe('channel overwrites endpoint', () => {
+	test.each([
+		['MemoryAdapter', MemoryAdapter],
+		['LimitedMemoryAdapter', LimitedMemoryAdapter],
+	] as const)('channel edits preserve guild ownership with %s', async (_name, Adapter) => {
+		const world = mockWorld();
+		const guild = world.registerGuild();
+		const role = world.registerRole(guild.id);
+		const channel = world.registerChannel(guild.id, {
+			overwrites: [{ id: role.id, type: 'role', allow: ['KickMembers'], deny: [] }],
+		});
+		const client = new Client();
+		const adapter = new Adapter();
+		client.setServices({ cache: { adapter } });
+		await using bot = await createMockBot({ world, client });
+		client.cache.intents = 0;
+		const raw = await client.channels.raw(channel.id, true);
+		bot.rest.intercept(Routes.editChannel, () => ({ ...raw, name: 'edited', permission_overwrites: [] }));
+
+		await client.channels.edit(channel.id, { name: 'edited', permission_overwrites: [] });
+
+		expect(await client.cache.channels?.raw(channel.id)).toMatchObject({ guild_id: guild.id, name: 'edited' });
+		expect(await client.cache.overwrites?.raw(channel.id)).toEqual([]);
+		expect(await client.cache.channels?.keys('@me')).toEqual([]);
+		expect(await client.cache.overwrites?.keys('@me')).toEqual([]);
+
+		client.cache.intents = GatewayIntentBits.Guilds;
+		const overwrites = [{ id: role.id, type: OverwriteType.Role, allow: '2', deny: '0' }];
+		bot.rest.intercept(Routes.editChannel, () => ({ ...raw, name: 'pending', permission_overwrites: overwrites }));
+		await client.channels.edit(channel.id, { name: 'pending', permission_overwrites: overwrites });
+		expect(await client.cache.channels?.raw(channel.id)).toMatchObject({ name: 'edited' });
+		expect(await client.cache.overwrites?.raw(channel.id)).toEqual([]);
+
+		await client.cache.guilds?.remove(guild.id);
+		expect(adapter.scan('channel.*')).toEqual([]);
+		expect(adapter.scan('overwrite.*')).toEqual([]);
+	});
+
 	test('edit and delete overwrite keeps the real cache and world in sync', async () => {
 		const world = mockWorld();
 		const guild = world.registerGuild({ everyonePermissions: ['ManageRoles'] });

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -1,6 +1,15 @@
 import { assert, describe, expect, test, vi } from 'vitest';
 import { Collection, LimitedCollection } from '../src/collection';
 
+function withFakeTimers(run: () => void) {
+	vi.useFakeTimers();
+	try {
+		run();
+	} finally {
+		vi.useRealTimers();
+	}
+}
+
 describe('Collection', () => {
 	test('sweep removes matching elements', () => {
 		const c = new Collection<number, string>();
@@ -364,6 +373,21 @@ describe('LimitedCollection', () => {
 		assert.deepEqual(deleted, [[1, 'one']]);
 	});
 
+	test('onDelete observes the entry before it is removed', () => {
+		let observed: { hasKey: boolean; size: number } | undefined;
+		let c: LimitedCollection<number, string>;
+		c = new LimitedCollection({
+			limit: 1,
+			onDelete: key => {
+				observed = { hasKey: c.has(key), size: c.size };
+			},
+		});
+		c.set(1, 'one');
+		c.set(2, 'two');
+
+		assert.deepEqual(observed, { hasKey: true, size: 2 });
+	});
+
 	test('clear empties collection', () => {
 		const c = new LimitedCollection<number, string>();
 		c.set(1, 'one');
@@ -373,13 +397,13 @@ describe('LimitedCollection', () => {
 	});
 
 	test('expire removes element after timeout', () => {
-		vi.useFakeTimers();
-		const c = new LimitedCollection<number, string>();
-		c.set(1, 'one', 100);
-		assert.equal(c.has(1), true);
-		vi.advanceTimersByTime(101);
-		assert.equal(c.has(1), false);
-		vi.useRealTimers();
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>();
+			c.set(1, 'one', 100);
+			assert.equal(c.has(1), true);
+			vi.advanceTimersByTime(101);
+			assert.equal(c.has(1), false);
+		});
 	});
 
 	test('closer returns element with soonest expiry', () => {
@@ -397,31 +421,169 @@ describe('LimitedCollection', () => {
 	});
 
 	test('resetOnDemand extends expiry on get', () => {
-		vi.useFakeTimers();
-		const c = new LimitedCollection<number, string>({ resetOnDemand: true });
-		c.set(1, 'one', 100);
-		vi.advanceTimersByTime(80);
-		c.get(1); // should reset the expiry
-		vi.advanceTimersByTime(80);
-		assert.equal(c.has(1), true);
-		vi.advanceTimersByTime(21);
-		assert.equal(c.has(1), false);
-		vi.useRealTimers();
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({ resetOnDemand: true });
+			c.set(1, 'one', 100);
+			vi.advanceTimersByTime(80);
+			c.get(1); // should reset the expiry
+			vi.advanceTimersByTime(80);
+			assert.equal(c.has(1), true);
+			vi.advanceTimersByTime(21);
+			assert.equal(c.has(1), false);
+		});
+	});
+
+	test('reschedules a hot key without expiring it from the old deadline', () => {
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({ resetOnDemand: true });
+			c.set(1, 'one', 100);
+			vi.advanceTimersByTime(80);
+			assert.equal(c.get(1), 'one');
+			vi.advanceTimersByTime(30);
+			assert.equal(c.has(1), true);
+			vi.advanceTimersByTime(70);
+			assert.equal(c.has(1), false);
+		});
+	});
+
+	test('clears expiration timers when the collection is cleared', () => {
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({ expire: 100 });
+			c.set(1, 'one');
+			assert.equal(vi.getTimerCount(), 1);
+			c.clear();
+			assert.equal(vi.getTimerCount(), 0);
+			vi.advanceTimersByTime(200);
+			assert.equal(c.size, 0);
+		});
+	});
+
+	test('keeps one tracked timer when an expiration callback replaces the collection', () => {
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({
+				expire: 100,
+				onDelete: key => {
+					if (key !== 1) return;
+					c.clear();
+					c.set(2, 'two');
+				},
+			});
+			c.set(1, 'one');
+
+			vi.advanceTimersByTime(100);
+			assert.equal(c.has(2), true);
+			assert.equal(vi.getTimerCount(), 1);
+
+			c.clear();
+			assert.equal(vi.getTimerCount(), 0);
+		});
+	});
+
+	test('expires a large batch with one callback per element', () => {
+		withFakeTimers(() => {
+			const deleted: number[] = [];
+			const c = new LimitedCollection<number, string>({ onDelete: key => deleted.push(key) });
+			for (let key = 0; key < 1_500; key++) c.set(key, String(key), 100);
+			vi.advanceTimersByTime(100);
+			assert.equal(c.size, 476);
+			assert.equal(deleted.length, 1_024);
+			vi.runAllTimers();
+			assert.equal(c.size, 0);
+			assert.equal(deleted.length, 1_500);
+			assert.equal(new Set(deleted).size, 1_500);
+		});
+	});
+
+	test('cancels a pending expiration continuation when cleared', () => {
+		withFakeTimers(() => {
+			const deleted: number[] = [];
+			const c = new LimitedCollection<number, string>({ onDelete: key => deleted.push(key) });
+			for (let key = 0; key < 1_500; key++) c.set(key, String(key), 100);
+
+			vi.advanceTimersByTime(100);
+			assert.equal(c.size, 476);
+			assert.equal(vi.getTimerCount(), 1);
+			c.clear();
+			assert.equal(vi.getTimerCount(), 0);
+
+			vi.runAllTimers();
+			assert.equal(deleted.length, 1_024);
+		});
+	});
+
+	test('preserves an entry when its eviction callback throws', () => {
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({
+				limit: 1,
+				onDelete: key => {
+					if (key === 1) throw new Error('rejected deletion');
+				},
+			});
+			c.set(1, 'one', 60_000);
+			expect(() => c.set(2, 'two', 100)).toThrow('rejected deletion');
+			assert.equal(c.has(1), true);
+			assert.equal(c.has(2), true);
+
+			vi.advanceTimersByTime(100);
+			assert.equal(c.has(2), false);
+			assert.equal(c.has(1), true);
+			assert.equal(vi.getTimerCount(), 1);
+		});
+	});
+
+	test('preserves expiration when a delete callback throws', () => {
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>({
+				onDelete: () => {
+					throw new Error('rejected deletion');
+				},
+			});
+			c.set(1, 'one', 100);
+			expect(() => c.delete(1)).toThrow('rejected deletion');
+			assert.equal(c.has(1), true);
+			assert.equal(vi.getTimerCount(), 1);
+		});
+	});
+
+	test('does not retry a failed expiration and continues with later entries', () => {
+		withFakeTimers(() => {
+			const calls: number[] = [];
+			const c = new LimitedCollection<number, string>({
+				onDelete: key => {
+					calls.push(key);
+					if (key === 1) throw new Error('rejected deletion');
+				},
+			});
+			c.set(1, 'one', 100);
+			c.set(2, 'two', 200);
+
+			expect(() => vi.advanceTimersByTime(100)).toThrow('rejected deletion');
+			assert.deepEqual(calls, [1]);
+			assert.equal(c.has(1), true);
+			assert.equal(c.has(2), true);
+			assert.equal(vi.getTimerCount(), 1);
+
+			vi.advanceTimersByTime(100);
+			assert.deepEqual(calls, [1, 2]);
+			assert.equal(c.has(1), true);
+			assert.equal(c.has(2), false);
+			assert.equal(vi.getTimerCount(), 0);
+		});
 	});
 
 	test('overwriting the closer with a later expiry does not expire early', () => {
-		vi.useFakeTimers();
-		const c = new LimitedCollection<number, string>();
-		c.set(1, 'one', 100);
-		vi.advanceTimersByTime(50);
-		c.set(1, 'one-again', 200);
-		vi.advanceTimersByTime(60);
-		assert.equal(c.has(1), true);
-		vi.advanceTimersByTime(139);
-		assert.equal(c.has(1), true);
-		vi.advanceTimersByTime(2);
-		assert.equal(c.has(1), false);
-		vi.useRealTimers();
+		withFakeTimers(() => {
+			const c = new LimitedCollection<number, string>();
+			c.set(1, 'one', 100);
+			vi.advanceTimersByTime(50);
+			c.set(1, 'one-again', 200);
+			vi.advanceTimersByTime(60);
+			assert.equal(c.has(1), true);
+			vi.advanceTimersByTime(139);
+			assert.equal(c.has(1), true);
+			vi.advanceTimersByTime(2);
+			assert.equal(c.has(1), false);
+		});
 	});
 
 	test('replacing the closer with a later expiration schedules the next closer immediately', () => {

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -433,19 +433,6 @@ describe('LimitedCollection', () => {
 		});
 	});
 
-	test('reschedules a hot key without expiring it from the old deadline', () => {
-		withFakeTimers(() => {
-			const c = new LimitedCollection<number, string>({ resetOnDemand: true });
-			c.set(1, 'one', 100);
-			vi.advanceTimersByTime(80);
-			assert.equal(c.get(1), 'one');
-			vi.advanceTimersByTime(30);
-			assert.equal(c.has(1), true);
-			vi.advanceTimersByTime(70);
-			assert.equal(c.has(1), false);
-		});
-	});
-
 	test('clears expiration timers when the collection is cleared', () => {
 		withFakeTimers(() => {
 			const c = new LimitedCollection<number, string>({ expire: 100 });
@@ -481,16 +468,22 @@ describe('LimitedCollection', () => {
 
 	test('expires a large batch with one callback per element', () => {
 		withFakeTimers(() => {
-			const deleted: number[] = [];
-			const c = new LimitedCollection<number, string>({ onDelete: key => deleted.push(key) });
-			for (let key = 0; key < 1_500; key++) c.set(key, String(key), 100);
-			vi.advanceTimersByTime(100);
-			assert.equal(c.size, 476);
-			assert.equal(deleted.length, 1_024);
-			vi.runAllTimers();
-			assert.equal(c.size, 0);
-			assert.equal(deleted.length, 1_500);
-			assert.equal(new Set(deleted).size, 1_500);
+			const drainFirstBatch = (size: number) => {
+				const deleted: number[] = [];
+				const c = new LimitedCollection<number, string>({ onDelete: key => deleted.push(key) });
+				for (let key = 0; key < size; key++) c.set(key, String(key), 100);
+				vi.advanceTimersByTime(100);
+				assert.ok(c.size > 0 && c.size < size);
+				assert.equal(deleted.length, size - c.size);
+				const firstBatchSize = deleted.length;
+				vi.runAllTimers();
+				assert.equal(c.size, 0);
+				assert.equal(deleted.length, size);
+				assert.equal(new Set(deleted).size, size);
+				return firstBatchSize;
+			};
+
+			assert.equal(drainFirstBatch(1_500), drainFirstBatch(3_000));
 		});
 	});
 
@@ -501,13 +494,14 @@ describe('LimitedCollection', () => {
 			for (let key = 0; key < 1_500; key++) c.set(key, String(key), 100);
 
 			vi.advanceTimersByTime(100);
-			assert.equal(c.size, 476);
+			assert.ok(c.size > 0 && c.size < 1_500);
+			const deletedBeforeClear = deleted.length;
 			assert.equal(vi.getTimerCount(), 1);
 			c.clear();
 			assert.equal(vi.getTimerCount(), 0);
 
 			vi.runAllTimers();
-			assert.equal(deleted.length, 1_024);
+			assert.equal(deleted.length, deletedBeforeClear);
 		});
 	});
 

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -249,8 +249,28 @@ describe('LimitedCollection', () => {
 
 	test('limit 0 rejects all inserts', () => {
 		const c = new LimitedCollection<number, string>({ limit: 0 });
-		c.set(1, 'one');
+		assert.equal(c.set(1, 'one'), false);
 		assert.equal(c.size, 0);
+	});
+
+	test('set reports limit acceptance independently of reentrant deletion', () => {
+		const retained = new LimitedCollection<number, string>();
+		assert.equal(retained.set(1, 'one'), true);
+
+		const fractionalLimit = new LimitedCollection<number, string>({ limit: 0.5 });
+		assert.equal(fractionalLimit.set(1, 'one'), false);
+		assert.equal(fractionalLimit.size, 0);
+
+		let reentrant: LimitedCollection<number, string>;
+		reentrant = new LimitedCollection({
+			limit: 1,
+			onDelete(key) {
+				if (key === 1) reentrant.delete(2);
+			},
+		});
+		reentrant.set(1, 'one');
+		assert.equal(reentrant.set(2, 'two'), true);
+		assert.equal(reentrant.has(2), false);
 	});
 
 	test('rejects NaN limits but preserves zero and infinity behavior', () => {
@@ -386,6 +406,23 @@ describe('LimitedCollection', () => {
 		c.set(2, 'two');
 
 		assert.deepEqual(observed, { hasKey: true, size: 2 });
+	});
+
+	test('deleting an entry also cancels the expiration its callback creates', () => {
+		vi.useFakeTimers();
+		try {
+			const c = new LimitedCollection<string, string>({
+				onDelete: (key, value) => c.set(key, value, 5),
+			});
+			c.set('entry', 'value');
+			c.delete('entry');
+
+			assert.equal(c.size, 0);
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
 	});
 
 	test('clear empties collection', () => {

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -268,10 +268,11 @@ const cacheBulkGetKeys = [
 	['users', 'user-id'],
 	['roles', 'role-id'],
 	['members', 'member-id', 'guild-id'],
+	['presences', 'user-id', 'guild-id'],
 ] as const satisfies readonly BulkGetKey[];
 const cacheBulkGetResult = cacheContract.bulkGet(cacheBulkGetKeys);
 type CacheBulkGetResult = Awaited<typeof cacheBulkGetResult>;
-expectType<true>(true as Equal<keyof CacheBulkGetResult, 'users' | 'roles' | 'members'>);
+expectType<true>(true as Equal<keyof CacheBulkGetResult, 'users' | 'roles' | 'members' | 'presences'>);
 // @ts-expect-error tuple-aware bulkGet results only include requested resource keys.
 expectType<CacheBulkGetResult['channels']>([]);
 declare const dynamicBulkGetKeys: BulkGetKey[];
@@ -296,6 +297,23 @@ cacheContract.overwrites?.values(wildcardCacheSelector);
 cacheContract.members?.values(cacheResourceSelector);
 cacheContract.bans?.values(cacheResourceSelector);
 cacheContract.voiceStates?.values(wildcardCacheSelector);
+cacheContract.presences?.get('user-id', 'guild-id');
+cacheContract.presences?.flush('guild-id');
+// @ts-expect-error Presence cache reads require the guild that owns the entry.
+cacheContract.presences?.get('user-id');
+// @ts-expect-error Guild-based presence flushes require an explicit guild selector.
+cacheContract.presences?.flush();
+// @ts-expect-error Bulk presence reads require a guild ID.
+const invalidPresenceBulkGetKey = ['presences', 'user-id'] as const satisfies BulkGetKey;
+
+declare const memberPresenceShorter: MemberShorter;
+memberPresenceShorter.presence('guild-id', 'user-id');
+// @ts-expect-error MemberShorter.presence requires both guild and user IDs.
+memberPresenceShorter.presence('user-id');
+declare const isolatedUser: UserStructure;
+isolatedUser.presence('guild-id');
+// @ts-expect-error A User has no implicit guild for presence lookup.
+isolatedUser.presence();
 
 type ChannelPinResult = Awaited<ReturnType<Client['channels']['pins']>>;
 expectType<true>(true as Equal<ChannelPinResult['items'][number]['pinnedAt'], number>);

--- a/tests/presence.test.mts
+++ b/tests/presence.test.mts
@@ -1,0 +1,50 @@
+import { apiMember, apiUser } from '@slipher/testing';
+import { describe, expect, test, vi } from 'vitest';
+import type { PresenceUpdateReceiveStatus } from '../lib';
+import { CacheFrom, Client, PresenceUpdateStatus } from '../lib';
+import { GuildMember, User } from '../lib/structures';
+import { PresenceUpdateHandler } from '../lib/websocket/discord/events/presenceUpdate';
+
+const guildId = '100000000000000001';
+const userId = '200000000000000002';
+
+const presenceData = (currentGuildId: string, status: PresenceUpdateReceiveStatus = PresenceUpdateStatus.Online) => ({
+	activities: [],
+	client_status: {},
+	guild_id: currentGuildId,
+	status,
+	user: { id: userId },
+});
+
+describe('guild-scoped presence consumers', () => {
+	test('shorter and structures resolve the presence from their requested guild', async () => {
+		const client = new Client();
+		const userData = apiUser({ id: userId, username: 'user' });
+		const member = new GuildMember(client, apiMember({ roles: [] }), userData, guildId);
+		const user = new User(client, userData);
+		await client.cache.presences?.set(CacheFrom.Test, userId, guildId, presenceData(guildId));
+		await client.cache.presences?.set(
+			CacheFrom.Test,
+			userId,
+			'guild-2',
+			presenceData('guild-2', PresenceUpdateStatus.Idle),
+		);
+
+		expect(await client.members.presence(guildId, userId)).toMatchObject({ guild_id: guildId, status: 'online' });
+		expect(await member.presence()).toMatchObject({ guild_id: guildId, status: 'online' });
+		expect(await user.presence('guild-2')).toMatchObject({ guild_id: 'guild-2', status: 'idle' });
+	});
+
+	test('deduplicates presence updates independently per guild', () => {
+		vi.useFakeTimers();
+		try {
+			const handler = new PresenceUpdateHandler();
+			expect(handler.check(presenceData('guild-1'))).toBe(true);
+			expect(handler.check(presenceData('guild-2'))).toBe(true);
+			expect(handler.check(presenceData('guild-1'))).toBe(false);
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+});

--- a/tests/root-export-contract.ts
+++ b/tests/root-export-contract.ts
@@ -22,6 +22,8 @@ import {
 	HeadingLevel,
 	type HttpConfig,
 	LabelComponent,
+	type ManagerMessages,
+	type ManagerSendCacheResult,
 	type MaybeResolvedChannel,
 	MessageActivityType,
 	type MessageLink,
@@ -34,6 +36,8 @@ import {
 	type RESTOAuth2BotAuthorizationQuery,
 	type RESTPatchCurrentApplicationJSONBody,
 	type ResolvedChannel,
+	type SerializedWorkerError,
+	type SerializedWorkerValue,
 	SeyfertError,
 	type SeyfertErrorCode,
 	SeyfertErrorMessages,
@@ -110,6 +114,20 @@ expectType<ShardData>({ resume_seq: null });
 expectType<WorkerData['mode']>('threads');
 expectType<WorkerInfo>({ shards: [] });
 expectType<WorkerShardInfo>({ shardId: 0, workerId: 0, open: false, latency: 0, resumable: false });
+declare const managerMessage: ManagerMessages;
+expectType<string>(managerMessage.type);
+expectType<SerializedWorkerValue>({ type: 'record', value: { cause: ['nested', 1, null] } });
+expectType<SerializedWorkerError>({
+	type: 'error',
+	name: 'Error',
+	message: 'failed',
+	cause: { type: 'record', value: { code: 'nested' } },
+});
+expectType<ManagerSendCacheResult>({
+	type: 'CACHE_RESULT',
+	nonce: 'cache-request',
+	error: { type: 'error', name: 'Error', message: 'failed' },
+});
 
 declare const resolvedChannel: APIInteractionDataResolvedChannel;
 expectType<string | undefined>(resolvedChannel.app_permissions);

--- a/tests/workermanager.test.mts
+++ b/tests/workermanager.test.mts
@@ -294,6 +294,24 @@ describe('WorkerManager', () => {
 		}
 	});
 
+	test('rejects cache requests when a custom transport throws synchronously', async () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = Object.create(WorkerAdapter.prototype) as WorkerAdapter;
+			adapter.workerData = { workerId: 0 } as WorkerAdapter['workerData'];
+			adapter.promises = new Map();
+			adapter.postMessage = () => {
+				throw new Error('transport failed');
+			};
+
+			await expect(adapter.get('user.user-1')).rejects.toThrow('transport failed');
+			assert.equal(adapter.promises.size, 0);
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	test('preserves empty custom error fields', () => {
 		const original = new SeyfertError('', { metadata: { detail: 'empty code' } });
 		original.stack = '';

--- a/tests/workermanager.test.mts
+++ b/tests/workermanager.test.mts
@@ -1,7 +1,10 @@
 import { resolve } from 'node:path';
 import type { Worker } from 'node:worker_threads';
-import { describe, expect, test, vi } from 'vitest';
+import { assert, describe, expect, test, vi } from 'vitest';
+import { WorkerAdapter } from '../lib/cache';
 import { WorkerClient } from '../lib/client/workerclient';
+import { SeyfertError } from '../lib/common';
+import { deserializeWorkerError, serializeWorkerError } from '../lib/websocket/discord/worker-errors';
 import { WorkerManager } from '../lib/websocket/discord/workermanager';
 
 describe('WorkerManager', () => {
@@ -176,6 +179,129 @@ describe('WorkerManager', () => {
 		await client.handleManagerMessages(wireMessage as never);
 
 		expect([...new Uint8Array(await response)]).toEqual([...bytes]);
+	});
+
+	test('returns cache adapter failures to the requesting worker', async () => {
+		const sharedMetadata = { value: 42 };
+		const metadata = JSON.parse('{"__proto__":{"scope":"metadata"}}') as Record<string, unknown>;
+		metadata.value = 1n;
+		metadata.first = sharedMetadata;
+		metadata.second = sharedMetadata;
+		metadata.self = metadata;
+		const cause = JSON.parse(
+			'{"name":"payload","message":"detail","extra":42,"__proto__":{"scope":"cause"}}',
+		) as Record<string, unknown>;
+		cause.nested = new Error('root cause', { cause: 2n });
+		const manager = Object.create(WorkerManager.prototype) as WorkerManager;
+		manager.has = () => true;
+		manager.cacheAdapter = {
+			set() {
+				throw new SeyfertError('CUSTOM_CACHE_ERROR', {
+					metadata,
+					cause,
+				});
+			},
+		} as unknown as WorkerManager['cacheAdapter'];
+		let wireMessage: unknown;
+		manager.postMessage = ((_workerId: number, message: unknown) => {
+			wireMessage = JSON.parse(JSON.stringify(message));
+		}) as WorkerManager['postMessage'];
+
+		const adapter = Object.create(WorkerAdapter.prototype) as WorkerAdapter;
+		adapter.workerData = { workerId: 0 } as WorkerAdapter['workerData'];
+		adapter.promises = new Map();
+		let request: unknown;
+		adapter.postMessage = message => {
+			request = message;
+		};
+		const pending = adapter.set('user.user-1', { id: 'user-1' }, ['user', 'user-1']);
+		const rejected = pending.then(
+			() => undefined,
+			error => error,
+		);
+
+		await manager.handleWorkerMessage(request as never);
+
+		const client = Object.create(WorkerClient.prototype) as WorkerClient;
+		Object.defineProperty(client, 'cache', { value: { adapter } });
+		await client.handleManagerMessages(wireMessage as never);
+		const error = await rejected;
+		expect(error).toMatchObject({
+			name: 'SeyfertError',
+			code: 'CUSTOM_CACHE_ERROR',
+			metadata: {
+				value: '1',
+				first: { value: 42 },
+				second: { value: 42 },
+				self: '[Circular]',
+			},
+			cause: {
+				name: 'payload',
+				message: 'detail',
+				extra: 42,
+				nested: { message: 'root cause', cause: '2' },
+			},
+		});
+		assert.equal(Object.hasOwn(error.metadata, '__proto__'), true);
+		assert.deepEqual(error.metadata.__proto__, { scope: 'metadata' });
+		assert.equal(Object.hasOwn(error.cause, '__proto__'), true);
+		assert.deepEqual(error.cause.__proto__, { scope: 'cause' });
+		assert.equal(adapter.promises.size, 0);
+	});
+
+	test('registers cache requests before a synchronous response', async () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = Object.create(WorkerAdapter.prototype) as WorkerAdapter;
+			adapter.workerData = { workerId: 0 } as WorkerAdapter['workerData'];
+			adapter.promises = new Map();
+			const client = Object.create(WorkerClient.prototype) as WorkerClient;
+			Object.defineProperty(client, 'cache', { value: { adapter } });
+			adapter.postMessage = request => {
+				void client.handleManagerMessages({
+					type: 'CACHE_RESULT',
+					nonce: request.nonce,
+					error: { type: 'error', name: 'Error', message: 'synchronous failure' },
+				});
+			};
+
+			const rejection = expect(adapter.set('user.user-1', { id: 'user-1' }, ['user', 'user-1'])).rejects.toThrow(
+				'synchronous failure',
+			);
+			assert.equal(vi.getTimerCount(), 0);
+			await rejection;
+			assert.equal(adapter.promises.size, 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test('rejects cache requests when an async custom transport fails', async () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = Object.create(WorkerAdapter.prototype) as WorkerAdapter;
+			adapter.workerData = { workerId: 0 } as WorkerAdapter['workerData'];
+			adapter.promises = new Map();
+			adapter.postMessage = async () => {
+				throw new Error('transport failed');
+			};
+
+			await expect(adapter.get('user.user-1')).rejects.toThrow('transport failed');
+			assert.equal(adapter.promises.size, 0);
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test('preserves empty custom error fields', () => {
+		const original = new SeyfertError('', { metadata: { detail: 'empty code' } });
+		original.stack = '';
+		const serialized = JSON.parse(JSON.stringify(serializeWorkerError(original)));
+		const error = deserializeWorkerError(serialized);
+
+		expect(error).toBeInstanceOf(SeyfertError);
+		expect(error).toMatchObject({ code: '', metadata: { detail: 'empty code' }, stack: '' });
 	});
 });
 


### PR DESCRIPTION
## Problem

Cache resources register relationship ownership separately from value mutation. If encoding or storage fails between those operations, relationship indexes can describe values that were never stored. Replacing a value can likewise move its relationship before the replacement is known to be usable.

That split also duplicates bookkeeping across the in-memory adapters, while adapter failures crossing the worker boundary currently surface as 60-second request timeouts instead of the original error.

## Contract

Adapter writes now carry the owning relationship together with the value:

```ts
// Before
await adapter.addToRelationship(`channel.${guildId}`, channelId);
await adapter.set(`channel.${channelId}`, channel);

// After
await adapter.set(
  `channel.${channelId}`,
  channel,
  [`channel.${guildId}`, channelId],
);
```

`set`, `patch`, `bulkSet`, and `bulkPatch` make each entry atomic: encoding completes before either the stored value or its relationship changes. A bulk call is not a transaction; implementations may execute entries concurrently or out of order, and a rejection can leave any completed subset committed. Once the returned promise settles, no writes from that call remain pending.

`addToRelationship` and `bulkAddToRelationShip` are removed, making this a breaking change for custom adapters. Relationship removals now remove the owned values together with their relationship state rather than maintaining a separate index lifecycle.

Adapter entries must use `resource.id` or `resource.scope.id`, with IDs and namespace segments that do not contain dots. A custom resource must use one layout consistently. These are low-level adapter preconditions and are not validated at runtime, so unsupported keys or mismatched relationships have no state-integrity guarantee.

## Runtime behavior

`MemoryAdapter` stores entries in relationship-owned buckets and keeps a secondary lookup only when the owner cannot be derived from the key. `LimitedMemoryAdapter` uses the same ownership model where storage and relationship scopes match, while retaining explicit relationships for messages because their storage scope is a guild and their relationship scope is a channel.

`LimitedCollection` tracks expirations with a heap and processes at most 1,024 entries per event-loop turn. Failed patches read existing values without refreshing their TTL, so decode or encode failures leave the previous value, ownership, and expiration unchanged. Clearing the collection also disposes pending scheduling state.

Worker-backed adapter failures are returned to the requesting worker instead of becoming timeouts. Error replies use a JSON-safe representation that preserves standard `Error` fields together with `SeyfertError` codes, metadata, and causes. Synchronous replies and synchronous or asynchronous transport failures also settle and remove the pending request immediately.

## Performance

`pnpm bench:limited-cache` keeps the comparison in the repository and reports isolated balanced samples as medians with MAD, metric direction, retained state, and behavioral probes.

On Node 24.14.1, the integrated branch improved no-TTL throughput by 77.9% for `MemoryAdapter` and 74.7% for `LimitedMemoryAdapter`. The mixed 80/20 workload improved by 15.1% and 23.5%, while the Limited TTL workload improved throughput by 56.2% and reduced its event-loop maximum by 92.7%. The many-bucket Memory result was inconclusive; Limited improved throughput by 38.5% and reduced RSS growth by 81.5 MiB.

The accepted tradeoff is `MemoryAdapter`'s steady-read path: throughput was 12.4% lower because reads may now resolve relationship ownership. Limited steady-read throughput was statistically inconclusive. The benchmark prints signal warnings when a faster arm reaches the sample cap before its cumulative measurement target.

## Review package

Until the contract is available in a tagged release, install the [pkg.pr.new preview](https://pkg.pr.new/seyfert@439) generated for this branch:

```sh
npm i https://pkg.pr.new/seyfert@439
```
