### PR TITLE
fix(cache)!: scope presences by guild

### DIFF
--- a/benchmarks/limited-cache.mjs
+++ b/benchmarks/limited-cache.mjs
@@ -38,6 +38,11 @@ const comparisons = [
 		label: 'Memory working tree compared with Limited working tree',
 	},
 ];
+const messageProbes = [
+	{ key: 'message.0', relationship: 'message.channel-0' },
+	{ key: 'message.100000', relationship: 'message.channel-0' },
+	{ key: 'message.199999', relationship: 'message.channel-19999' },
+];
 
 const scenarios = [
 	{
@@ -134,6 +139,22 @@ const scenarios = [
 		write: writeUser,
 	},
 	{
+		id: 'indexed-misses',
+		label: 'Indexed cache misses',
+		description: '6,680 retained channel buckets followed by 10k missing channel reads',
+		writes: 0,
+		preloadWrites: 6_680,
+		readOperations: 10_000,
+		expectedEntries: 6_680,
+		probes: [
+			{ key: 'channel.0', relationship: 'channel.guild-0' },
+			{ key: 'channel.3339', relationship: 'channel.guild-3339' },
+			{ key: 'channel.6679', relationship: 'channel.guild-6679' },
+		],
+		write: writeChannel,
+		read: readMissingChannel,
+	},
+	{
 		id: 'bulk',
 		label: 'Bulk writes',
 		description: '200k user writes in 1k-entry batches, with one repeated ID per batch',
@@ -149,7 +170,68 @@ const scenarios = [
 		batchSize: 1_000,
 		writeBatch: writeUserBatch,
 	},
+	{
+		id: 'message-writes',
+		label: 'Message writes',
+		description: '200k individual message writes distributed across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+	},
+	{
+		id: 'message-bulk',
+		label: 'Message bulk writes',
+		description: '200k message writes in 1k-entry batches across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		batchSize: 1_000,
+		writeBatch: writeMessageBatch,
+	},
+	{
+		id: 'message-hits',
+		label: 'Message cache hits',
+		description: '200k retained messages followed by 1m deterministic cache hits',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 1_000_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMessage,
+	},
+	{
+		id: 'message-misses',
+		label: 'Message cache misses',
+		description: '200k retained messages followed by 300k deterministic cache misses',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 300_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMissingMessage,
+	},
+	{
+		id: 'message-ttl',
+		label: 'Message TTL expiration wave',
+		description: '200k message writes across 6,680 guild buckets, expiring after 3s',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		expectedLimitedEntries: 0,
+		probes: messageProbes,
+		limitedProbes: messageProbes.map(probe => ({ ...probe, present: false })),
+		write: writeMessage,
+		adapterOptions: { message: { expire: 3_000 } },
+		waitForCleanup: true,
+	},
 ];
+
+const scenarioArgument = process.argv.indexOf('--scenario');
+const selectedScenarios =
+	scenarioArgument === -1 ? scenarios : scenarios.filter(scenario => scenario.id === process.argv[scenarioArgument + 1]);
+if (selectedScenarios.length === 0) throw new Error(`Unknown scenario ${process.argv[scenarioArgument + 1]}`);
 
 function evaluateCommonJs(source, filename, dependencies) {
 	const typescript = requireFromRepository('typescript');
@@ -258,10 +340,9 @@ function countEntries(adapter, arm) {
 }
 
 function countRelationshipIds(adapter, arm) {
+	if (isMemoryArm(arm)) return countEntries(adapter, arm);
 	let count = 0;
-	if (isMemoryArm(arm) && !hasBucketedStorage(adapter)) {
-		for (const values of adapter.relationships.values()) count += values.size;
-	} else if (usesAtomicWrites(adapter)) {
+	if (usesAtomicWrites(adapter)) {
 		for (const [namespace, storage] of adapter.storage) {
 			for (const key of storage.keys()) {
 				if (adapter.keyToRelationship?.has(key) || namespace === 'message' || namespace.startsWith('message.')) continue;
@@ -305,6 +386,25 @@ function countBuckets(adapter, arm) {
 	return isMemoryArm(arm) && !hasBucketedStorage(adapter) ? 1 : adapter.storage.size;
 }
 
+function countSchedules(adapter, arm) {
+	if (isMemoryArm(arm) || !hasBucketedStorage(adapter)) return 0;
+	let schedules = 0;
+	for (const bucket of adapter.storage.values()) {
+		if (bucket.expirationSchedule !== undefined) schedules++;
+	}
+	return schedules;
+}
+
+function retainedState(adapter, arm) {
+	return {
+		entries: countEntries(adapter, arm),
+		buckets: countBuckets(adapter, arm),
+		relationshipIds: countRelationshipIds(adapter, arm),
+		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
+		schedules: countSchedules(adapter, arm),
+	};
+}
+
 function usesAtomicWrites(adapter) {
 	return adapter.set.length >= 3;
 }
@@ -344,6 +444,34 @@ function writeChannel(adapter, id) {
 	);
 }
 
+function messageEntry(id) {
+	const stringId = String(id);
+	const guildId = `guild-${id % 6_680}`;
+	const channelId = `channel-${id % 20_000}`;
+	return [
+		`message.${stringId}`,
+		{ id: stringId, guild_id: guildId, channel_id: channelId, content: `message-${stringId}` },
+		[`message.${channelId}`, stringId],
+	];
+}
+
+function writeMessage(adapter, id) {
+	setWithRelationship(adapter, ...messageEntry(id));
+}
+
+function readMessage(adapter, randomState, scenario) {
+	const id = String(randomState % scenario.preloadWrites);
+	return adapter.get(`message.${id}`)?.id === id;
+}
+
+function readMissingMessage(adapter, randomState) {
+	return adapter.get(`message.missing-${randomState}`) === null;
+}
+
+function readMissingChannel(adapter, randomState) {
+	return adapter.get(`channel.missing-${randomState}`) === null;
+}
+
 function writeUserBatch(adapter, start, end) {
 	const ids = [];
 	const entries = [];
@@ -358,6 +486,21 @@ function writeUserBatch(adapter, start, end) {
 		return;
 	}
 	adapter.bulkAddToRelationShip({ user: ids });
+	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
+	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+}
+
+function writeMessageBatch(adapter, start, end) {
+	const entries = [];
+	for (let index = start; index < end; index++) entries.push(messageEntry(index));
+	if (usesAtomicWrites(adapter)) {
+		adapter.bulkSet(entries);
+		for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+		return;
+	}
+	const relationships = {};
+	for (const [, , [to, id]] of entries) (relationships[to] ??= []).push(id);
+	adapter.bulkAddToRelationShip(relationships);
 	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
 	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
 }
@@ -418,9 +561,13 @@ async function executeWorkload(adapter, scenario, observe) {
 			scenario.readOperations,
 			() => {
 				randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
-				const id = String(randomState % scenario.preloadWrites);
 				expectedReads++;
-				if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				if (scenario.read) {
+					if (scenario.read(adapter, randomState, scenario)) validatedReads++;
+				} else {
+					const id = String(randomState % scenario.preloadWrites);
+					if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				}
 			},
 			observe,
 		);
@@ -476,12 +623,7 @@ async function verifyScenarioRelationships(arm, scenario, adapters) {
 		await prepareWorkload(adapter, scenario, () => {});
 		await executeWorkload(adapter, scenario, () => {});
 		await waitForCleanup(adapter, arm, scenario, () => {});
-		const retained = {
-			entries: countEntries(adapter, arm),
-			buckets: countBuckets(adapter, arm),
-			relationshipIds: countRelationshipIds(adapter, arm),
-			indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-		};
+		const retained = retainedState(adapter, arm);
 		assertRetainedState(adapter, arm, scenario, retained);
 		const verifiedRelationships = countVerifiedRelationships(adapter);
 		if (verifiedRelationships !== retained.relationshipIds) {
@@ -503,8 +645,8 @@ async function runChild(arm, scenarioId) {
 	globalThis.gc?.();
 	await immediate();
 	const adapter = createAdapter(arm, scenario, adapters);
-	const baselineRss = process.memoryUsage().rss;
-	let peakRss = baselineRss;
+	const baselineMemory = process.memoryUsage();
+	let peakRss = baselineMemory.rss;
 	const observe = () => {
 		peakRss = Math.max(peakRss, process.memoryUsage().rss);
 	};
@@ -523,13 +665,11 @@ async function runChild(arm, scenarioId) {
 	observe();
 	eventLoopDelay.disable();
 	const cpu = process.cpuUsage(cpuStart);
-	const retained = {
-		entries: countEntries(adapter, arm),
-		buckets: countBuckets(adapter, arm),
-		relationshipIds: countRelationshipIds(adapter, arm),
-		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-	};
+	const retained = retainedState(adapter, arm);
 	assertRetainedState(adapter, arm, scenario, retained);
+	globalThis.gc?.();
+	await immediate();
+	const retainedMemory = process.memoryUsage();
 	adapter.flush();
 	if (process.env.SEYFERT_CACHE_BENCH_VERIFY_RELATIONSHIPS === '1') {
 		await verifyScenarioRelationships(arm, scenario, adapters);
@@ -541,7 +681,9 @@ async function runChild(arm, scenarioId) {
 		...workload,
 		cleanupMilliseconds,
 		cpuMilliseconds: (cpu.user + cpu.system) / 1_000,
-		peakRssDeltaMiB: (peakRss - baselineRss) / mebibyte,
+		peakRssDeltaMiB: (peakRss - baselineMemory.rss) / mebibyte,
+		rssAfterGcDeltaMiB: (retainedMemory.rss - baselineMemory.rss) / mebibyte,
+		heapAfterGcDeltaMiB: (retainedMemory.heapUsed - baselineMemory.heapUsed) / mebibyte,
 		eventLoopP95Milliseconds: eventLoopDelay.percentile(95) / 1e6,
 		eventLoopMaxMilliseconds: eventLoopDelay.max / 1e6,
 		retained,
@@ -563,6 +705,8 @@ function summarize(runs) {
 		'throughputOpsPerSecond',
 		'cpuMilliseconds',
 		'peakRssDeltaMiB',
+		'rssAfterGcDeltaMiB',
+		'heapAfterGcDeltaMiB',
 		'eventLoopP95Milliseconds',
 		'eventLoopMaxMilliseconds',
 	];
@@ -653,6 +797,8 @@ function printMetricTable(summary) {
 				'Throughput ↑': formatMeasuredMetric(value, 'throughputOpsPerSecond', 'ops/s', 0),
 				'CPU ↓': formatMeasuredMetric(value, 'cpuMilliseconds', 'ms'),
 				'RSS growth ↓': formatMeasuredMetric(value, 'peakRssDeltaMiB', 'MiB'),
+				'RSS after GC ↓': formatMeasuredMetric(value, 'rssAfterGcDeltaMiB', 'MiB'),
+				'Heap after GC ↓': formatMeasuredMetric(value, 'heapAfterGcDeltaMiB', 'MiB'),
 				'Loop p95 ↓': formatMeasuredMetric(value, 'eventLoopP95Milliseconds', 'ms', 2),
 				'Loop max ↓': formatMeasuredMetric(value, 'eventLoopMaxMilliseconds', 'ms', 2),
 				'Cleanup wait ↓':
@@ -693,6 +839,22 @@ function printComparison(summary, comparison) {
 		)}`,
 	);
 	console.log(
+		`  RSS after GC ↓   ${markInconclusive(
+			describeAbsoluteChange(candidate.rssAfterGcDeltaMiB, baseline.rssAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'rssAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
+		`  Heap after GC ↓  ${markInconclusive(
+			describeAbsoluteChange(candidate.heapAfterGcDeltaMiB, baseline.heapAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'heapAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
 		`  Event-loop max ↓ ${markInconclusive(
 			describeRelativeChange(candidate.eventLoopMaxMilliseconds, baseline.eventLoopMaxMilliseconds),
 			candidate,
@@ -721,6 +883,7 @@ function printRetainedState(summary) {
 				Buckets: retained.buckets,
 				'Logical relationships': retained.relationshipIds,
 				Indexes: retained.indexes,
+				Schedules: retained.schedules,
 			};
 		}),
 	);
@@ -797,14 +960,14 @@ async function runCoordinator() {
 	console.log('Direction:  ↑ higher is better; ↓ lower is better; retained-state counts are descriptive');
 	console.log('Metrics:    values are medians; ± is median absolute deviation as a percentage; loop values are event-loop delays\n');
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		for (let repetition = 1; repetition <= maximumRepetitions; repetition++) {
 			for (const arm of balancedArms(repetition)) runs.push(runIsolated(arm, scenario, repetition));
 			if (repetition >= minimumRepetitions && hasEnoughMeasuredTime(runs, scenario.id)) break;
 		}
 	}
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		const summary = Object.fromEntries(
 			arms.map(arm => [
 				arm.id,

--- a/src/cache/adapters/default.ts
+++ b/src/cache/adapters/default.ts
@@ -83,14 +83,6 @@ export class MemoryAdapter<T> implements Adapter {
 		return storageEntry;
 	}
 
-	private _moveIndexedEntry(key: string, namespace: string) {
-		const previousNamespace = this.keyToStorage.get(key);
-		if (previousNamespace === undefined || previousNamespace === namespace) return;
-		const previousStorage = this.storage.get(previousNamespace);
-		previousStorage?.delete(key);
-		if (previousStorage?.size === 0) this.storage.delete(previousNamespace);
-	}
-
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
 		const data = patch && !Array.isArray(value) ? { ...(this.get(key) ?? {}), ...value } : value;
 		const encoded = this.options.encode(data);
@@ -101,7 +93,6 @@ export class MemoryAdapter<T> implements Adapter {
 			this.storage.set(namespace, storageEntry);
 		}
 		const indexed = needsCacheStorageIndex(key, namespace);
-		if (indexed) this._moveIndexedEntry(key, namespace);
 		storageEntry.set(key, encoded);
 		if (indexed) this.keyToStorage.set(key, namespace);
 	}

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -323,6 +323,11 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
+		const bucket = this._getRelationshipBucket(to);
+		if (bucket) {
+			for (const id of Array.isArray(keys) ? keys : [keys]) bucket.delete(this._getBucketKey(to, id, bucket));
+			return;
+		}
 		const ids = new Set(Array.isArray(keys) ? keys : [keys]);
 		for (const [key, index] of this.keyToStorage) {
 			if (Array.isArray(index) && index[1][0] === to && ids.has(index[1][1])) this.remove(key);

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -33,7 +33,7 @@ export interface LimitedMemoryAdapterOptions<T> {
 
 export type LimitedMemoryStorageIndex<T> =
 	| LimitedCollection<string, T>
-	| readonly [storage: LimitedCollection<string, T>, relationship: string];
+	| readonly [storage: LimitedCollection<string, T>, relationship: AdapterRelationship];
 
 export class LimitedMemoryAdapter<T> implements Adapter {
 	isAsync = false;
@@ -112,7 +112,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	private _deleteIndexedStorage(key: string, storageEntry: LimitedCollection<string, T>) {
 		const index = this.keyToStorage.get(key);
 		if (!index || this._getIndexedStorage(index) !== storageEntry) return;
-		this._removeExplicitRelationship(key, index);
+		this._removeExplicitRelationship(index);
 		this.keyToStorage.delete(key);
 	}
 
@@ -185,10 +185,9 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return ids;
 	}
 
-	private _removeExplicitRelationship(key: string, index: LimitedMemoryStorageIndex<T>) {
+	private _removeExplicitRelationship(index: LimitedMemoryStorageIndex<T>) {
 		if (!Array.isArray(index)) return;
-		const to = index[1];
-		const id = key.slice(key.lastIndexOf('.') + 1);
+		const [to, id] = index[1];
 		const [resource, scope] = this._getRelationshipData(to);
 		const relationships = this.relationships.get(resource);
 		const ids = relationships?.get(scope);
@@ -239,7 +238,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		if (storageEntry.set(key, encoded)) {
 			if (previousMessageStorage && previousMessageStorage !== storageEntry) previousMessageStorage.delete(key);
 			if (usesIndex) {
-				this.keyToStorage.set(key, layout === 'message' ? [storageEntry, relationship[0]] : storageEntry);
+				this.keyToStorage.set(key, layout === 'message' ? [storageEntry, relationship] : storageEntry);
 			}
 			if (layout === 'message') this._syncMessageRelationship(relationship);
 		}
@@ -278,10 +277,11 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	keys(to: string) {
 		const bucket = this._getRelationshipBucket(to);
 		if (bucket) return [...bucket.keys()];
-		const ids = this._getExplicitRelationshipSet(to);
-		if (!ids) return [];
-		const resource = this._getKeyResource(to);
-		return [...ids].map(id => `${resource}.${id}`);
+		const keys: string[] = [];
+		for (const [key, index] of this.keyToStorage) {
+			if (Array.isArray(index) && index[1][0] === to) keys.push(key);
+		}
+		return keys;
 	}
 
 	count(to: string) {
@@ -324,8 +324,8 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 	removeToRelationship(to: string, keys: string | string[]) {
 		const ids = new Set(Array.isArray(keys) ? keys : [keys]);
-		for (const key of this.keys(to)) {
-			if (ids.has(key.slice(key.lastIndexOf('.') + 1))) this.remove(key);
+		for (const [key, index] of this.keyToStorage) {
+			if (Array.isArray(index) && index[1][0] === to && ids.has(index[1][1])) this.remove(key);
 		}
 	}
 

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -31,13 +31,16 @@ export interface LimitedMemoryAdapterOptions<T> {
 	decode?(data: T): unknown;
 }
 
+export type LimitedMemoryStorageIndex<T> =
+	| LimitedCollection<string, T>
+	| readonly [storage: LimitedCollection<string, T>, relationship: string];
+
 export class LimitedMemoryAdapter<T> implements Adapter {
 	isAsync = false;
 
 	readonly storage = new Map<string, LimitedCollection<string, T>>();
 	readonly relationships = new Map<string, Map<string, Set<string>>>();
-	readonly keyToStorage = new Map<string, LimitedCollection<string, T>>();
-	private readonly keyToRelationship = new Map<string, AdapterRelationship>();
+	readonly keyToStorage = new Map<string, LimitedMemoryStorageIndex<T>>();
 
 	options: MakeRequired<LimitedMemoryAdapterOptions<T>, 'default' | 'encode' | 'decode'>;
 
@@ -102,11 +105,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return key.indexOf('.', resource.length + 1) !== -1;
 	}
 
-	private _setIndexedStorage(key: string, namespace: string, storageEntry: LimitedCollection<string, T>) {
-		if (needsCacheStorageIndex(key, namespace)) this.keyToStorage.set(key, storageEntry);
+	private _getIndexedStorage(index: LimitedMemoryStorageIndex<T>) {
+		return Array.isArray(index) ? index[0] : index;
 	}
 
-	private _deleteIndexedStorage(key: string) {
+	private _deleteIndexedStorage(key: string, storageEntry: LimitedCollection<string, T>) {
+		const index = this.keyToStorage.get(key);
+		if (!index || this._getIndexedStorage(index) !== storageEntry) return;
+		this._removeExplicitRelationship(key, index);
 		this.keyToStorage.delete(key);
 	}
 
@@ -119,39 +125,26 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return scopeEnd === -1 ? resource : key.slice(0, scopeEnd);
 	}
 
-	private _isResourceNamespace(resource: string, namespace: string) {
-		return namespace === resource || namespace.startsWith(`${resource}.`);
-	}
-
-	private _findNamespaceByStorage(resource: string, storageEntry: LimitedCollection<string, T>) {
-		for (const [namespace, candidate] of this.storage) {
-			if (candidate === storageEntry && this._isResourceNamespace(resource, namespace)) return namespace;
-		}
-		return undefined;
-	}
-
 	private _getMessageNamespace(data: any) {
 		const scope = Array.isArray(data) ? data[0]?.guild_id : data?.guild_id;
 		return scope ? `message.${scope}` : 'message';
 	}
 
 	private _getStorageEntry(key: string) {
+		const index = this.keyToStorage.get(key);
+		if (index) {
+			const indexedStorage = this._getIndexedStorage(index);
+			if (indexedStorage.has(key)) return { storageEntry: indexedStorage };
+			this._deleteIndexedStorage(key, indexedStorage);
+			return undefined;
+		}
+
 		const resource = this._getKeyResource(key);
 		const layout = getCacheResourceLayout(resource);
-		const indexedStorage = this.keyToStorage.get(key);
-		if (indexedStorage?.has(key)) return { resource, layout, storageEntry: indexedStorage };
-		if (indexedStorage) this.keyToStorage.delete(key);
-
 		if (layout !== 'guild-indexed' && layout !== 'message') {
 			const namespace = this._getStorageNamespaceFromKey(resource, layout, key);
 			const storageEntry = this.storage.get(namespace);
-			if (storageEntry?.has(key)) return { resource, layout, namespace, storageEntry };
-		}
-
-		for (const [namespace, storageEntry] of this.storage) {
-			if (!this._isResourceNamespace(resource, namespace) || !storageEntry.has(key)) continue;
-			this._setIndexedStorage(key, namespace, storageEntry);
-			return { resource, layout, namespace, storageEntry };
+			if (storageEntry?.has(key)) return { storageEntry };
 		}
 		return undefined;
 	}
@@ -192,39 +185,20 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return ids;
 	}
 
-	private _removeExplicitRelationship(key: string) {
-		const relationship = this.keyToRelationship.get(key);
-		if (!relationship) return;
-		const [to, id] = relationship;
+	private _removeExplicitRelationship(key: string, index: LimitedMemoryStorageIndex<T>) {
+		if (!Array.isArray(index)) return;
+		const to = index[1];
+		const id = key.slice(key.lastIndexOf('.') + 1);
 		const [resource, scope] = this._getRelationshipData(to);
 		const relationships = this.relationships.get(resource);
 		const ids = relationships?.get(scope);
 		ids?.delete(id);
 		if (ids?.size === 0) relationships?.delete(scope);
 		if (relationships?.size === 0) this.relationships.delete(resource);
-		this.keyToRelationship.delete(key);
 	}
 
-	private _setExplicitRelationship(key: string, relationship: AdapterRelationship) {
-		const previous = this.keyToRelationship.get(key);
-		if (previous && (previous[0] !== relationship[0] || previous[1] !== relationship[1])) {
-			this._removeExplicitRelationship(key);
-		}
+	private _syncMessageRelationship(relationship: AdapterRelationship) {
 		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
-		this.keyToRelationship.set(key, relationship);
-	}
-
-	private _syncRelationship(
-		key: string,
-		layout: CacheResourceLayout,
-		namespace: string,
-		relationship: AdapterRelationship,
-	) {
-		if (layout !== 'message' && namespace === relationship[0]) {
-			this._removeExplicitRelationship(key);
-			return;
-		}
-		this._setExplicitRelationship(key, relationship);
 	}
 
 	private _deleteEmptyStorage(namespace: string, storageEntry: LimitedCollection<string, T>) {
@@ -240,8 +214,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 			limit: resourceOptions?.limit ?? this.options.default.limit,
 			resetOnDemand: (expire ?? 0) > 0,
 			onDelete: key => {
-				this._deleteIndexedStorage(key);
-				this._removeExplicitRelationship(key);
+				this._deleteIndexedStorage(key, bucket);
 				if (bucket.size === 1 && bucket.has(key) && this.storage.get(namespace) === bucket) {
 					this.storage.delete(namespace);
 				}
@@ -249,19 +222,6 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		});
 		this.storage.set(namespace, bucket);
 		return bucket;
-	}
-
-	private _moveStoredEntry(
-		resource: string,
-		key: string,
-		storageEntry: LimitedCollection<string, T>,
-		previousStorageEntry: LimitedCollection<string, T> | undefined,
-	) {
-		if (!previousStorageEntry || previousStorageEntry === storageEntry) return;
-		previousStorageEntry.delete(key);
-		if (previousStorageEntry.size !== 0) return;
-		const previousNamespace = this._findNamespaceByStorage(resource, previousStorageEntry);
-		if (previousNamespace) this.storage.delete(previousNamespace);
 	}
 
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
@@ -274,12 +234,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 		const storageEntry = this.storage.get(namespace) ?? this._createStorageEntry(resource, namespace);
 		const usesIndex = layout === 'message' || needsCacheStorageIndex(key, namespace);
-		this._moveStoredEntry(resource, key, storageEntry, this.keyToStorage.get(key));
-		storageEntry.set(key, encoded);
-
-		if (storageEntry.has(key)) {
-			if (usesIndex) this.keyToStorage.set(key, storageEntry);
-			this._syncRelationship(key, layout, namespace, relationship);
+		const previousMessageIndex = layout === 'message' ? this.keyToStorage.get(key) : undefined;
+		const previousMessageStorage = previousMessageIndex ? this._getIndexedStorage(previousMessageIndex) : undefined;
+		if (storageEntry.set(key, encoded)) {
+			if (previousMessageStorage && previousMessageStorage !== storageEntry) previousMessageStorage.delete(key);
+			if (usesIndex) {
+				this.keyToStorage.set(key, layout === 'message' ? [storageEntry, relationship[0]] : storageEntry);
+			}
+			if (layout === 'message') this._syncMessageRelationship(relationship);
 		}
 		this._deleteEmptyStorage(namespace, storageEntry);
 	}
@@ -316,11 +278,10 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	keys(to: string) {
 		const bucket = this._getRelationshipBucket(to);
 		if (bucket) return [...bucket.keys()];
-		const keys: string[] = [];
-		for (const [key, relationship] of this.keyToRelationship) {
-			if (relationship[0] === to) keys.push(key);
-		}
-		return keys;
+		const ids = this._getExplicitRelationshipSet(to);
+		if (!ids) return [];
+		const resource = this._getKeyResource(to);
+		return [...ids].map(id => `${resource}.${id}`);
 	}
 
 	count(to: string) {
@@ -359,10 +320,6 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		const entry = this._getStorageEntry(key);
 		if (!entry) return;
 		entry.storageEntry.delete(key);
-		this._deleteIndexedStorage(key);
-		if (entry.storageEntry.size !== 0) return;
-		const namespace = entry.namespace ?? this._findNamespaceByStorage(entry.resource, entry.storageEntry);
-		if (namespace) this.storage.delete(namespace);
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
@@ -381,6 +338,5 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		this.storage.clear();
 		this.relationships.clear();
 		this.keyToStorage.clear();
-		this.keyToRelationship.clear();
 	}
 }

--- a/src/cache/adapters/shared.ts
+++ b/src/cache/adapters/shared.ts
@@ -5,7 +5,7 @@ const resourceLayouts = new Map<string, Exclude<CacheResourceLayout, 'custom'>>(
 	['user', 'root'],
 	['channel', 'guild-indexed'],
 	['emoji', 'guild-indexed'],
-	['presence', 'guild-indexed'],
+	['presence', 'guild-keyed'],
 	['role', 'guild-indexed'],
 	['stage_instance', 'guild-indexed'],
 	['sticker', 'guild-indexed'],

--- a/src/cache/adapters/types.ts
+++ b/src/cache/adapters/types.ts
@@ -2,9 +2,10 @@ import type { Awaitable } from '../../common';
 
 export type AdapterRelationship = readonly [to: string, id: string];
 /**
- * A cache value and the relationship that owns it.
+ * A cache value and the relationship derived by its resource model.
  * Keys must use `resource.id` or `resource.scope.id`; IDs and namespace segments cannot contain dots.
  * Each resource namespace must consistently use one of those layouts.
+ * A physical key must keep the same relationship; adapters do not reconcile conflicting ownership.
  * Adapters assume these preconditions and do not validate them at runtime.
  */
 export type AdapterEntry = readonly [key: string, value: any, relationship: AdapterRelationship];

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -25,18 +25,10 @@ export type InferAsyncCache = InternalOptions extends { asyncCache: infer P } ? 
 export type ReturnCache<T> = If<InferAsyncCache, Promise<T>, T>;
 
 // GuildBased
-export type GuildBased = 'members' | 'voiceStates' | 'bans';
+export type GuildBased = 'members' | 'voiceStates' | 'presences' | 'bans';
 
 // ClientGuildBased
-export type GuildRelated =
-	| 'emojis'
-	| 'roles'
-	| 'channels'
-	| 'stickers'
-	| 'presences'
-	| 'stageInstances'
-	| 'overwrites'
-	| 'messages';
+export type GuildRelated = 'emojis' | 'roles' | 'channels' | 'stickers' | 'stageInstances' | 'overwrites' | 'messages';
 
 // ClientBased
 export type NonGuildBased = 'users' | 'guilds';
@@ -125,6 +117,8 @@ export class Cache {
 	// guild based
 	members?: Members;
 	voiceStates?: VoiceStates;
+	presences?: Presences;
+	bans?: Bans;
 
 	// guild related
 	overwrites?: Overwrites;
@@ -132,10 +126,8 @@ export class Cache {
 	emojis?: Emojis;
 	channels?: Channels;
 	stickers?: Stickers;
-	presences?: Presences;
 	stageInstances?: StageInstances;
 	messages?: Messages;
-	bans?: Bans;
 
 	__logger__?: Logger;
 	private pluginResourceNames = new Set<string>();
@@ -172,20 +164,20 @@ export class Cache {
 		this.users = disabledCache.users ? undefined : new Users(this, client);
 		this.guilds = disabledCache.guilds ? undefined : new Guilds(this, client);
 
-		// guild related
+		// guild based
 		this.members = disabledCache.members ? undefined : new Members(this, client);
 		this.voiceStates = disabledCache.voiceStates ? undefined : new VoiceStates(this, client);
+		this.presences = disabledCache.presences ? undefined : new Presences(this, client);
+		this.bans = disabledCache.bans ? undefined : new Bans(this, client);
 
-		// guild based
+		// guild related
 		this.roles = disabledCache.roles ? undefined : new Roles(this, client);
 		this.overwrites = disabledCache.overwrites ? undefined : new Overwrites(this, client);
 		this.channels = disabledCache.channels ? undefined : new Channels(this, client);
 		this.emojis = disabledCache.emojis ? undefined : new Emojis(this, client);
 		this.stickers = disabledCache.stickers ? undefined : new Stickers(this, client);
-		this.presences = disabledCache.presences ? undefined : new Presences(this, client);
 		this.stageInstances = disabledCache.stageInstances ? undefined : new StageInstances(this, client);
 		this.messages = disabledCache.messages ? undefined : new Messages(this, client);
-		this.bans = disabledCache.bans ? undefined : new Bans(this, client);
 
 		this.onPacket = disabledCache.onPacket
 			? ((() => {
@@ -262,6 +254,7 @@ export class Cache {
 				case 'bans':
 				case 'voiceStates':
 				case 'members':
+				case 'presences':
 					{
 						if (!allData[type]) {
 							allData[type] = [];
@@ -272,7 +265,6 @@ export class Cache {
 				case 'roles':
 				case 'stickers':
 				case 'channels':
-				case 'presences':
 				case 'stageInstances':
 				case 'emojis':
 				case 'users':
@@ -315,7 +307,6 @@ export class Cache {
 				case 'roles':
 				case 'stickers':
 				case 'channels':
-				case 'presences':
 				case 'stageInstances':
 				case 'emojis':
 				case 'overwrites':
@@ -332,7 +323,8 @@ export class Cache {
 				}
 				case 'bans':
 				case 'voiceStates':
-				case 'members': {
+				case 'members':
+				case 'presences': {
 					const resource = this[type];
 					if (!resource?.filter(data, id, guildId, from)) continue;
 					const relationship = resource.hashId(guildId!);

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -469,6 +469,7 @@ export class Cache {
 				break;
 			case 'GUILD_MEMBER_REMOVE':
 				await this.members?.remove(event.d.user.id, event.d.guild_id);
+				await this.presences?.remove(event.d.user.id, event.d.guild_id);
 				break;
 
 			case 'PRESENCE_UPDATE':

--- a/src/cache/resources/presence.ts
+++ b/src/cache/resources/presence.ts
@@ -1,8 +1,8 @@
 import type { CacheFrom } from '../..';
 import type { GatewayPresenceUpdate } from '../../types';
-import { GuildRelatedResource } from './default/guild-related';
+import { GuildBasedResource } from './default/guild-based';
 
-export class Presences extends GuildRelatedResource<PresenceResource, GatewayPresenceUpdate> {
+export class Presences extends GuildBasedResource<PresenceResource, GatewayPresenceUpdate> {
 	namespace = 'presence';
 
 	//@ts-expect-error

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -365,6 +365,7 @@ export class LimitedCollection<K, V> {
 	 * @param key The key of the element.
 	 * @param value The value of the element.
 	 * @param customExpire The custom expiration time for the element.
+	 * @returns Whether the configured limit accepted the entry. Reentrant mutations from `onDelete` do not change this result.
 	 * @example
 	 * const collection = new LimitedCollection<number, string>({ limit: 3 });
 	 * collection.set(1, 'one');
@@ -377,8 +378,9 @@ export class LimitedCollection<K, V> {
 	 */
 	set(key: K, value: V, customExpire = this.options.expire) {
 		if (this.options.limit <= 0) {
-			return;
+			return false;
 		}
+		const retained = this.options.limit >= 1;
 		validateLimitedCollectionExpiration(customExpire);
 
 		const expireOn = Number.isFinite(customExpire) && customExpire > 0 ? Date.now() + customExpire : -1;
@@ -391,7 +393,7 @@ export class LimitedCollection<K, V> {
 					this.delete(keyValue);
 				}
 			}
-			return;
+			return retained;
 		}
 
 		const previousCloser = this.expirations?.first;
@@ -418,6 +420,7 @@ export class LimitedCollection<K, V> {
 				this.rescheduleExpiration();
 			}
 		}
+		return retained;
 	}
 
 	/**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -516,15 +516,14 @@ export class LimitedCollection<K, V> {
 			return false;
 		}
 		const resolvedValue = value as V;
+		this.options.onDelete?.(key, resolvedValue);
 		if (!this.expirations) {
-			this.options.onDelete?.(key, resolvedValue);
 			return this.data.delete(key);
 		}
 
 		const previousCloser = this.expirations.first;
 		const previousExpireOn = previousCloser?.expireOn;
 
-		this.options.onDelete?.(key, resolvedValue);
 		const result = this.data.delete(key);
 		this._removeExpiration(key);
 		const closer = this.expirations?.first;

--- a/src/common/shorters/channels.ts
+++ b/src/common/shorters/channels.ts
@@ -75,23 +75,17 @@ export class ChannelShorter extends BaseShorter {
 	async edit(
 		id: string,
 		body: RESTPatchAPIChannelJSONBody,
-		optional: ChannelShorterOptionalParams = { guildId: '@me' },
+		optional: ChannelShorterOptionalParams = {},
 	): Promise<AllChannels> {
-		const options = MergeOptions<MakeRequired<ChannelShorterOptionalParams, 'guildId'>>({ guildId: '@me' }, optional);
-		const res = await this.client.proxy.channels(id).patch({ body, reason: options.reason });
-		await this.client.cache.channels?.setIfNI(
-			CacheFrom.Rest,
-			BaseChannel.__intent__(options.guildId),
-			res.id,
-			options.guildId,
-			res,
-		);
+		const res = await this.client.proxy.channels(id).patch({ body, reason: optional.reason });
+		const guildId = 'guild_id' in res && res.guild_id ? res.guild_id : '@me';
+		await this.client.cache.channels?.setIfNI(CacheFrom.Rest, BaseChannel.__intent__(guildId), res.id, guildId, res);
 		if (body.permission_overwrites && 'permission_overwrites' in res && res.permission_overwrites)
 			await this.client.cache.overwrites?.setIfNI(
 				CacheFrom.Rest,
-				BaseChannel.__intent__(options.guildId),
+				BaseChannel.__intent__(guildId),
 				res.id,
-				options.guildId,
+				guildId,
 				res.permission_overwrites,
 			);
 		return channelFrom(res, this.client);

--- a/src/common/shorters/members.ts
+++ b/src/common/shorters/members.ts
@@ -240,8 +240,13 @@ export class MemberShorter extends BaseShorter {
 		return new PermissionsBitField(roles.map(x => BigInt(x.permissions.bits)));
 	}
 
-	presence(memberId: string) {
-		return this.client.cache.presences?.get(memberId);
+	/**
+	 * Gets a member's cached presence in a guild.
+	 * @param guildId The ID of the guild.
+	 * @param memberId The ID of the member.
+	 */
+	presence(guildId: string, memberId: string) {
+		return this.client.cache.presences?.get(memberId, guildId);
 	}
 
 	async voice(guildId: string, memberId: (string & {}) | '@me', force = false): Promise<VoiceStateStructure> {

--- a/src/events/hooks/presence.ts
+++ b/src/events/hooks/presence.ts
@@ -3,5 +3,5 @@ import { toCamelCase } from '../../common';
 import type { GatewayPresenceUpdateDispatchData } from '../../types';
 
 export const PRESENCE_UPDATE = async (self: UsingClient, data: GatewayPresenceUpdateDispatchData) => {
-	return [toCamelCase(data), await self.cache.presences?.get(data.user.id)] as const;
+	return [toCamelCase(data), await self.cache.presences?.get(data.user.id, data.guild_id)] as const;
 };

--- a/src/structures/GuildMember.ts
+++ b/src/structures/GuildMember.ts
@@ -90,7 +90,7 @@ export class BaseGuildMember extends DiscordBase {
 	}
 
 	presence() {
-		return this.client.members.presence(this.id);
+		return this.client.members.presence(this.guildId, this.id);
 	}
 
 	voice(mode?: 'rest' | 'flow'): Promise<VoiceStateStructure>;

--- a/src/structures/User.ts
+++ b/src/structures/User.ts
@@ -56,8 +56,12 @@ export class User extends DiscordBase<APIUser> {
 		return this.rest.cdn.banners(this.id).get(this.banner, options);
 	}
 
-	presence() {
-		return this.client.members.presence(this.id);
+	/**
+	 * Gets the user's cached presence in a guild.
+	 * @param guildId The ID of the guild.
+	 */
+	presence(guildId: string) {
+		return this.client.members.presence(guildId, this.id);
 	}
 
 	toString() {

--- a/src/websocket/discord/events/presenceUpdate.ts
+++ b/src/websocket/discord/events/presenceUpdate.ts
@@ -4,12 +4,13 @@ export class PresenceUpdateHandler {
 	presenceUpdate = new Map<string, { timeout: NodeJS.Timeout; presence: GatewayPresenceUpdateDispatchData }>();
 
 	check(presence: GatewayPresenceUpdateDispatchData) {
-		if (!this.presenceUpdate.has(presence.user.id)) {
+		const key = `${presence.guild_id}.${presence.user.id}`;
+		if (!this.presenceUpdate.has(key)) {
 			this.setPresence(presence);
 			return true;
 		}
 
-		const data = this.presenceUpdate.get(presence.user.id)!;
+		const data = this.presenceUpdate.get(key)!;
 
 		if (this.presenceEquals(data.presence, presence)) {
 			return false;
@@ -23,10 +24,11 @@ export class PresenceUpdateHandler {
 	}
 
 	setPresence(presence: GatewayPresenceUpdateDispatchData) {
-		this.presenceUpdate.set(presence.user.id, {
+		const key = `${presence.guild_id}.${presence.user.id}`;
+		this.presenceUpdate.set(key, {
 			presence,
 			timeout: setTimeout(() => {
-				this.presenceUpdate.delete(presence.user.id);
+				this.presenceUpdate.delete(key);
 			}, 1.5e3),
 		});
 	}

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -321,6 +321,31 @@ describe.each(adapterKinds)('%s custom cache routing', kind => {
 	});
 });
 
+describe.each(adapterKinds)('%s relationship removal', kind => {
+	test.each([
+		['user.', 'user'],
+		['channel.', 'channel.guild-1'],
+		['presence.guild-1.', 'presence.guild-1'],
+		['custom.guild-1.', 'custom.guild-1'],
+	] as const)('removes only selected entries from %s', (prefix, relationship) => {
+		const adapter = createTestAdapter(kind);
+		adapter.set(`${prefix}first`, { id: 'first' }, [relationship, 'first']);
+		adapter.set(`${prefix}second`, { id: 'second' }, [relationship, 'second']);
+
+		adapter.removeToRelationship(relationship, 'first');
+		assert.equal(adapter.get(`${prefix}first`), null);
+		assert.equal(adapter.contains(relationship, 'first'), false);
+		assert.deepEqual(adapter.keys(relationship), [`${prefix}second`]);
+		assert.deepEqual(adapter.get(`${prefix}second`), { id: 'second' });
+
+		adapter.removeToRelationship(relationship, ['missing', 'second']);
+		assert.equal(adapter.count(relationship), 0);
+		assert.equal(adapter.get(`${prefix}second`), null);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+});
+
 describe('test limited memory cache adapter', () => {
 	const adapter = new LimitedMemoryAdapter();
 

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -1,9 +1,10 @@
 // biome-ignore assist/source/organizeImports: The root entrypoint must initialize before BaseClient to avoid the client barrel cycle.
 import { assert, describe, expect, test, vi } from 'vitest';
 import { BaseResource } from '../src/cache/resources/default/base';
-import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter } from '../src/index';
-import type { APIUser } from '../src/index';
+import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter, PresenceUpdateStatus } from '../src/index';
+import type { APIUser, PresenceUpdateReceiveStatus } from '../src/index';
 import { BaseClient } from '../src/client/base';
+import { PRESENCE_UPDATE } from '../src/events/hooks/presence';
 
 const intents = 53608447;
 const adapterKinds = ['MemoryAdapter', 'LimitedMemoryAdapter'] as const;
@@ -27,6 +28,16 @@ function channelWrite(guildId: string, name = guildId) {
 		{ id: 'channel-1', guild_id: guildId, name },
 		[`channel.${guildId}`, 'channel-1'],
 	] as const;
+}
+
+function presenceData(guildId: string, status: PresenceUpdateReceiveStatus) {
+	return {
+		activities: [],
+		client_status: {},
+		guild_id: guildId,
+		status,
+		user: { id: 'user-1' },
+	};
 }
 
 describe('test memory cache adapter', () => {
@@ -171,6 +182,97 @@ describe('base cache resource', () => {
 
 		adapter.set('base.present', { id: 'present' }, ['base', 'present']);
 		assert.deepEqual(resource.get('present'), { id: 'present' });
+	});
+});
+
+describe.each(adapterKinds)('%s guild-scoped presences', kind => {
+	test('keeps one independently mutable entry per guild', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+
+		await cache.bulkSet([
+			[CacheFrom.Test, 'presences', presenceData('guild-1', PresenceUpdateStatus.Online), 'user-1', 'guild-1'],
+			[CacheFrom.Test, 'presences', presenceData('guild-2', PresenceUpdateStatus.Idle), 'user-1', 'guild-2'],
+		]);
+
+		expect(await cache.bulkGet([
+			['presences', 'user-1', 'guild-1'],
+			['presences', 'user-1', 'guild-2'],
+		])).toEqual({
+			presences: [
+				expect.objectContaining({ guild_id: 'guild-1', status: 'online' }),
+				expect.objectContaining({ guild_id: 'guild-2', status: 'idle' }),
+			],
+		});
+		expect(await cache.presences?.keys('guild-1')).toEqual(['presence.guild-1.user-1']);
+		expect(await cache.presences?.values('guild-2')).toEqual([
+			expect.objectContaining({ guild_id: 'guild-2', status: 'idle' }),
+		]);
+		expect(await cache.presences?.count('guild-1')).toBe(1);
+		expect(await cache.presences?.contains('user-1', 'guild-2')).toBe(true);
+
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.DoNotDisturb),
+		);
+		expect(await cache.presences?.get('user-1', 'guild-1')).toMatchObject({ status: 'dnd' });
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+
+		await cache.presences?.remove('user-1', 'guild-1');
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('guild cleanup removes only that guild presence', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
+		);
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-2',
+			presenceData('guild-2', PresenceUpdateStatus.Idle),
+		);
+		await cache.guilds?.remove('guild-1');
+
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('presence hook reads the previous value from the event guild', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
+		);
+		await cache.presences?.set(
+			CacheFrom.Test,
+			'user-1',
+			'guild-2',
+			presenceData('guild-2', PresenceUpdateStatus.Idle),
+		);
+
+		const [current, previous] = await PRESENCE_UPDATE(
+			client,
+			presenceData('guild-1', PresenceUpdateStatus.DoNotDisturb) as Parameters<typeof PRESENCE_UPDATE>[1],
+		);
+
+		expect(current).toMatchObject({ guildId: 'guild-1', status: 'dnd' });
+		expect(previous).toMatchObject({ guild_id: 'guild-1', status: 'online' });
 	});
 });
 

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -266,12 +266,11 @@ describe.each(adapterKinds)('%s guild-scoped presences', kind => {
 			presenceData('guild-2', PresenceUpdateStatus.Idle),
 		);
 
-		const [current, previous] = await PRESENCE_UPDATE(
+		const [, previous] = await PRESENCE_UPDATE(
 			client,
 			presenceData('guild-1', PresenceUpdateStatus.DoNotDisturb) as Parameters<typeof PRESENCE_UPDATE>[1],
 		);
 
-		expect(current).toMatchObject({ guildId: 'guild-1', status: 'dnd' });
 		expect(previous).toMatchObject({ guild_id: 'guild-1', status: 'online' });
 	});
 });

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -146,17 +146,17 @@ describe('memory cache adapter bucket ownership', () => {
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
 
-	test('indexes only globally keyed relationships and cleans up owner moves', () => {
+	test('indexes globally keyed relationships for lookup and cleanup', () => {
 		const adapter = new MemoryAdapter();
 		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-1' }, ['channel.guild-1', 'channel-1']);
-		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-1']);
 
 		assert.equal(adapter.keyToStorage.size, 1);
 		assert.equal(adapter.storage.size, 1);
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 
-		adapter.removeToRelationship('channel.guild-2', 'channel-1');
+		adapter.remove('channel.channel-1');
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
@@ -425,7 +425,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		assert.deepEqual(adapter.keys('custom.guild-1'), ['custom.entry']);
 	});
 
-	test('preserves the old value and relationship when a replacement cannot encode', () => {
+	test('preserves the old value when a replacement cannot encode', () => {
 		let reject = false;
 		const adapter = createTestAdapter(kind, {
 			encode(data) {
@@ -436,10 +436,9 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		reject = true;
-		expect(() => adapter.set(...channelWrite('guild-2', 'new'))).toThrow('encode failed');
+		expect(() => adapter.set(...channelWrite('guild-1', 'new'))).toThrow('encode failed');
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 
 	test('propagates bulk failures without leaving an orphaned entry', () => {
@@ -464,7 +463,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		}
 	});
 
-	test('patch decode failures leave both value and relationship untouched', () => {
+	test('patch decode failures leave the value untouched', () => {
 		let rejectDecode = false;
 		const adapter = createTestAdapter(kind, {
 			decode(data) {
@@ -475,11 +474,10 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		rejectDecode = true;
-		expect(() => adapter.patch(...channelWrite('guild-2', 'new'))).toThrow('decode failed');
+		expect(() => adapter.patch(...channelWrite('guild-1', 'new'))).toThrow('decode failed');
 		rejectDecode = false;
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 });
 
@@ -500,52 +498,120 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.contains('member.guild-2', 'user-2'), false);
 	});
 
-	test('moves a globally keyed resource between bucket-owned relationships', () => {
+	test('uses the global-key index for lookup and cleanup', () => {
 		const adapter = new LimitedMemoryAdapter();
 		adapter.set(...channelWrite('guild-1'));
-		adapter.set(...channelWrite('guild-2'));
 
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), true);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1', name: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 		assert.equal(adapter.storage.size, 1);
+		assert.equal(adapter.relationships.size, 0);
+
+		adapter.remove('channel.channel-1');
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('does not scan guild buckets for a globally keyed miss', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(...channelWrite('guild-1'));
+		adapter.set('channel.channel-2', { id: 'channel-2', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-2']);
+		const iterateStorage = vi.spyOn(adapter.storage, Symbol.iterator);
+
+		assert.equal(adapter.get('channel.missing'), null);
+		expect(iterateStorage).not.toHaveBeenCalled();
+	});
+
+	test('relocates message storage without changing its relationship owner', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(
+			'message.message-1',
+			{ id: 'message-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-1'],
+		);
+		adapter.patch(
+			'message.message-1',
+			{ guild_id: 'guild-1' },
+			['message.channel-1', 'message-1'],
+		);
+
+		assert.equal(adapter.storage.has('message'), false);
+		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
+		assert.deepEqual(adapter.get('message.message-1'), {
+			id: 'message-1',
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+		});
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+
+		adapter.remove('message.message-1');
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
 		assert.equal(adapter.relationships.size, 0);
 	});
 
 	test('keeps an explicit secondary index when message ownership differs from storage', () => {
 		const adapter = new LimitedMemoryAdapter();
-		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
-			'message.channel-1',
-			'message-1',
-		]);
-		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-2' }, [
-			'message.channel-2',
-			'message-1',
-		]);
+		adapter.set(
+			'message.message-1',
+			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-1'],
+		);
 
-		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
-		assert.equal(adapter.contains('message.channel-2', 'message-1'), true);
-		assert.deepEqual(adapter.keys('message.channel-2'), ['message.message-1']);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+		assert.deepEqual(adapter.keys('message.channel-1'), ['message.message-1']);
 		assert.equal(adapter.relationships.size, 1);
-	});
-
-	test('removes an unscoped message after moving it into guild storage', () => {
-		const adapter = new LimitedMemoryAdapter();
-		adapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' }, ['message.channel-1', 'message-1']);
-		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
-			'message.channel-1',
-			'message-1',
-		]);
-
-		assert.equal(adapter.storage.has('message'), false);
-		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
 
 		adapter.remove('message.message-1');
-
-		assert.equal(adapter.get('message.message-1'), null);
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.relationships.size, 0);
+	});
+
+	test('cleans message indexes and relationships when their bucket evicts them', () => {
+		const adapter = new LimitedMemoryAdapter({ message: { limit: 1 } });
+		adapter.set(
+			'message.message-1',
+			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-1'],
+		);
+		adapter.set(
+			'message.message-2',
+			{ id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-2'],
+		);
+
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.get('message.message-2') !== null, true);
+		assert.equal(adapter.contains('message.channel-1', 'message-2'), true);
+		assert.equal(adapter.keyToStorage.size, 1);
+	});
+
+	test('cleans message indexes and relationships when they expire', () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = new LimitedMemoryAdapter({ message: { expire: 100 } });
+			adapter.set(
+				'message.message-1',
+				{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
+				['message.channel-1', 'message-1'],
+			);
+
+			vi.advanceTimersByTime(100);
+
+			assert.equal(adapter.get('message.message-1'), null);
+			assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+			assert.equal(adapter.storage.size, 0);
+			assert.equal(adapter.keyToStorage.size, 0);
+			assert.equal(adapter.relationships.size, 0);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('does not allocate relationship sets for bucket-owned resources', () => {
@@ -633,16 +699,6 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.get('custom.entry-1'), null);
 		assert.equal(adapter.contains(to, 'entry-1'), false);
 		assert.equal(adapter.contains(to, 'entry-2'), true);
-	});
-
-	test('moves a custom relationship between owners', () => {
-		const adapter = new LimitedMemoryAdapter();
-		adapter.set('custom.entry', { id: 'entry' }, ['custom.guild-1', 'entry']);
-		adapter.set('custom.entry', { id: 'entry', owner: 'guild-2' }, ['custom.guild-2', 'entry']);
-
-		assert.equal(adapter.contains('custom.guild-1', 'entry'), false);
-		assert.deepEqual(adapter.getToRelationship('custom.guild-2'), ['entry']);
-		assert.deepEqual(adapter.get('custom.entry'), { id: 'entry', owner: 'guild-2' });
 	});
 
 	test('stores empty array resources in the relationship-owned bucket', () => {

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -1,7 +1,15 @@
 // biome-ignore assist/source/organizeImports: The root entrypoint must initialize before BaseClient to avoid the client barrel cycle.
 import { assert, describe, expect, test, vi } from 'vitest';
 import { BaseResource } from '../src/cache/resources/default/base';
-import { Cache, CacheFrom, Client, LimitedMemoryAdapter, MemoryAdapter, PresenceUpdateStatus } from '../src/index';
+import {
+	Cache,
+	CacheFrom,
+	Client,
+	GatewayDispatchEvents,
+	LimitedMemoryAdapter,
+	MemoryAdapter,
+	PresenceUpdateStatus,
+} from '../src/index';
 import type { APIUser, PresenceUpdateReceiveStatus } from '../src/index';
 import { BaseClient } from '../src/client/base';
 import { PRESENCE_UPDATE } from '../src/events/hooks/presence';
@@ -196,10 +204,12 @@ describe.each(adapterKinds)('%s guild-scoped presences', kind => {
 			[CacheFrom.Test, 'presences', presenceData('guild-2', PresenceUpdateStatus.Idle), 'user-1', 'guild-2'],
 		]);
 
-		expect(await cache.bulkGet([
-			['presences', 'user-1', 'guild-1'],
-			['presences', 'user-1', 'guild-2'],
-		])).toEqual({
+		expect(
+			await cache.bulkGet([
+				['presences', 'user-1', 'guild-1'],
+				['presences', 'user-1', 'guild-2'],
+			]),
+		).toEqual({
 			presences: [
 				expect.objectContaining({ guild_id: 'guild-1', status: 'online' }),
 				expect.objectContaining({ guild_id: 'guild-2', status: 'idle' }),
@@ -237,13 +247,34 @@ describe.each(adapterKinds)('%s guild-scoped presences', kind => {
 			'guild-1',
 			presenceData('guild-1', PresenceUpdateStatus.Online),
 		);
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
+		await cache.guilds?.remove('guild-1');
+
+		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
+		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
+	});
+
+	test('member removal removes only that guild presence', async () => {
+		const client: any = {};
+		const cache = new Cache(0, createTestAdapter(kind), {}, client);
+		client.cache = cache;
 		await cache.presences?.set(
 			CacheFrom.Test,
 			'user-1',
-			'guild-2',
-			presenceData('guild-2', PresenceUpdateStatus.Idle),
+			'guild-1',
+			presenceData('guild-1', PresenceUpdateStatus.Online),
 		);
-		await cache.guilds?.remove('guild-1');
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
+
+		await cache.onPacket({
+			d: {
+				guild_id: 'guild-1',
+				user: { avatar: null, discriminator: '0', global_name: null, id: 'user-1', username: 'user' },
+			},
+			op: 0,
+			s: 1,
+			t: GatewayDispatchEvents.GuildMemberRemove,
+		});
 
 		expect(await cache.presences?.get('user-1', 'guild-1')).toBeNull();
 		expect(await cache.presences?.get('user-1', 'guild-2')).toMatchObject({ status: 'idle' });
@@ -259,12 +290,7 @@ describe.each(adapterKinds)('%s guild-scoped presences', kind => {
 			'guild-1',
 			presenceData('guild-1', PresenceUpdateStatus.Online),
 		);
-		await cache.presences?.set(
-			CacheFrom.Test,
-			'user-1',
-			'guild-2',
-			presenceData('guild-2', PresenceUpdateStatus.Idle),
-		);
+		await cache.presences?.set(CacheFrom.Test, 'user-1', 'guild-2', presenceData('guild-2', PresenceUpdateStatus.Idle));
 
 		const [, previous] = await PRESENCE_UPDATE(
 			client,
@@ -525,16 +551,8 @@ describe('limited memory cache adapter ownership', () => {
 
 	test('relocates message storage without changing its relationship owner', () => {
 		const adapter = new LimitedMemoryAdapter();
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-1'],
-		);
-		adapter.patch(
-			'message.message-1',
-			{ guild_id: 'guild-1' },
-			['message.channel-1', 'message-1'],
-		);
+		adapter.set('message.message-1', { id: 'message-1', channel_id: 'channel-1' }, ['message.channel-1', 'message-1']);
+		adapter.patch('message.message-1', { guild_id: 'guild-1' }, ['message.channel-1', 'message-1']);
 
 		assert.equal(adapter.storage.has('message'), false);
 		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
@@ -555,11 +573,10 @@ describe('limited memory cache adapter ownership', () => {
 
 	test('keeps an explicit secondary index when message ownership differs from storage', () => {
 		const adapter = new LimitedMemoryAdapter();
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-1'],
-		);
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
 
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
 		assert.deepEqual(adapter.keys('message.channel-1'), ['message.message-1']);
@@ -572,18 +589,40 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.relationships.size, 0);
 	});
 
+	test('preserves distinct physical and relationship message IDs', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set('message.physical-id', { id: 'physical-id', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'relationship-id',
+		]);
+
+		assert.deepEqual(adapter.keys('message.channel-1'), ['message.physical-id']);
+		assert.deepEqual(adapter.getToRelationship('message.channel-1'), ['relationship-id']);
+
+		adapter.removeToRelationship('message.channel-1', 'relationship-id');
+		assert.equal(adapter.get('message.physical-id'), null);
+		assert.equal(adapter.count('message.channel-1'), 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+
+		adapter.set('message.physical-id', { id: 'physical-id', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'relationship-id',
+		]);
+		adapter.removeRelationship('message.channel-1');
+		assert.equal(adapter.get('message.physical-id'), null);
+		assert.equal(adapter.relationships.size, 0);
+	});
+
 	test('cleans message indexes and relationships when their bucket evicts them', () => {
 		const adapter = new LimitedMemoryAdapter({ message: { limit: 1 } });
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-1'],
-		);
-		adapter.set(
-			'message.message-2',
-			{ id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-2'],
-		);
+		adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-1',
+		]);
+		adapter.set('message.message-2', { id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+			'message.channel-1',
+			'message-2',
+		]);
 
 		assert.equal(adapter.get('message.message-1'), null);
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
@@ -596,11 +635,10 @@ describe('limited memory cache adapter ownership', () => {
 		vi.useFakeTimers();
 		try {
 			const adapter = new LimitedMemoryAdapter({ message: { expire: 100 } });
-			adapter.set(
-				'message.message-1',
-				{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
-				['message.channel-1', 'message-1'],
-			);
+			adapter.set('message.message-1', { id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' }, [
+				'message.channel-1',
+				'message-1',
+			]);
 
 			vi.advanceTimersByTime(100);
 

--- a/tests/channel-overwrites.test.mts
+++ b/tests/channel-overwrites.test.mts
@@ -1,8 +1,45 @@
 import { createMockBot, mockWorld, Routes } from '@slipher/testing';
 import { describe, expect, test } from 'vitest';
-import { OverwriteType } from '../lib';
+import { Client, GatewayIntentBits, LimitedMemoryAdapter, MemoryAdapter, OverwriteType } from '../lib';
 
 describe('channel overwrites endpoint', () => {
+	test.each([
+		['MemoryAdapter', MemoryAdapter],
+		['LimitedMemoryAdapter', LimitedMemoryAdapter],
+	] as const)('channel edits preserve guild ownership with %s', async (_name, Adapter) => {
+		const world = mockWorld();
+		const guild = world.registerGuild();
+		const role = world.registerRole(guild.id);
+		const channel = world.registerChannel(guild.id, {
+			overwrites: [{ id: role.id, type: 'role', allow: ['KickMembers'], deny: [] }],
+		});
+		const client = new Client();
+		const adapter = new Adapter();
+		client.setServices({ cache: { adapter } });
+		await using bot = await createMockBot({ world, client });
+		client.cache.intents = 0;
+		const raw = await client.channels.raw(channel.id, true);
+		bot.rest.intercept(Routes.editChannel, () => ({ ...raw, name: 'edited', permission_overwrites: [] }));
+
+		await client.channels.edit(channel.id, { name: 'edited', permission_overwrites: [] });
+
+		expect(await client.cache.channels?.raw(channel.id)).toMatchObject({ guild_id: guild.id, name: 'edited' });
+		expect(await client.cache.overwrites?.raw(channel.id)).toEqual([]);
+		expect(await client.cache.channels?.keys('@me')).toEqual([]);
+		expect(await client.cache.overwrites?.keys('@me')).toEqual([]);
+
+		client.cache.intents = GatewayIntentBits.Guilds;
+		const overwrites = [{ id: role.id, type: OverwriteType.Role, allow: '2', deny: '0' }];
+		bot.rest.intercept(Routes.editChannel, () => ({ ...raw, name: 'pending', permission_overwrites: overwrites }));
+		await client.channels.edit(channel.id, { name: 'pending', permission_overwrites: overwrites });
+		expect(await client.cache.channels?.raw(channel.id)).toMatchObject({ name: 'edited' });
+		expect(await client.cache.overwrites?.raw(channel.id)).toEqual([]);
+
+		await client.cache.guilds?.remove(guild.id);
+		expect(adapter.scan('channel.*')).toEqual([]);
+		expect(adapter.scan('overwrite.*')).toEqual([]);
+	});
+
 	test('edit and delete overwrite keeps the real cache and world in sync', async () => {
 		const world = mockWorld();
 		const guild = world.registerGuild({ everyonePermissions: ['ManageRoles'] });

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -408,6 +408,23 @@ describe('LimitedCollection', () => {
 		assert.deepEqual(observed, { hasKey: true, size: 2 });
 	});
 
+	test('deleting an entry also cancels the expiration its callback creates', () => {
+		vi.useFakeTimers();
+		try {
+			const c = new LimitedCollection<string, string>({
+				onDelete: (key, value) => c.set(key, value, 5),
+			});
+			c.set('entry', 'value');
+			c.delete('entry');
+
+			assert.equal(c.size, 0);
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+
 	test('clear empties collection', () => {
 		const c = new LimitedCollection<number, string>();
 		c.set(1, 'one');

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -249,8 +249,28 @@ describe('LimitedCollection', () => {
 
 	test('limit 0 rejects all inserts', () => {
 		const c = new LimitedCollection<number, string>({ limit: 0 });
-		c.set(1, 'one');
+		assert.equal(c.set(1, 'one'), false);
 		assert.equal(c.size, 0);
+	});
+
+	test('set reports limit acceptance independently of reentrant deletion', () => {
+		const retained = new LimitedCollection<number, string>();
+		assert.equal(retained.set(1, 'one'), true);
+
+		const fractionalLimit = new LimitedCollection<number, string>({ limit: 0.5 });
+		assert.equal(fractionalLimit.set(1, 'one'), false);
+		assert.equal(fractionalLimit.size, 0);
+
+		let reentrant: LimitedCollection<number, string>;
+		reentrant = new LimitedCollection({
+			limit: 1,
+			onDelete(key) {
+				if (key === 1) reentrant.delete(2);
+			},
+		});
+		reentrant.set(1, 'one');
+		assert.equal(reentrant.set(2, 'two'), true);
+		assert.equal(reentrant.has(2), false);
 	});
 
 	test('rejects NaN limits but preserves zero and infinity behavior', () => {

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -63,9 +63,11 @@ import {
 	Groups,
 	GroupsT,
 	GuildBan,
+	type GuildBased,
 	type GuildBasedResource,
 	GuildMember,
 	type GuildMemberStructure,
+	type GuildRelated,
 	type GuildRelatedResource,
 	type GuildRoleStructure,
 	type InferMiddlewares,
@@ -268,10 +270,11 @@ const cacheBulkGetKeys = [
 	['users', 'user-id'],
 	['roles', 'role-id'],
 	['members', 'member-id', 'guild-id'],
+	['presences', 'user-id', 'guild-id'],
 ] as const satisfies readonly BulkGetKey[];
 const cacheBulkGetResult = cacheContract.bulkGet(cacheBulkGetKeys);
 type CacheBulkGetResult = Awaited<typeof cacheBulkGetResult>;
-expectType<true>(true as Equal<keyof CacheBulkGetResult, 'users' | 'roles' | 'members'>);
+expectType<true>(true as Equal<keyof CacheBulkGetResult, 'users' | 'roles' | 'members' | 'presences'>);
 // @ts-expect-error tuple-aware bulkGet results only include requested resource keys.
 expectType<CacheBulkGetResult['channels']>([]);
 declare const dynamicBulkGetKeys: BulkGetKey[];
@@ -296,6 +299,29 @@ cacheContract.overwrites?.values(wildcardCacheSelector);
 cacheContract.members?.values(cacheResourceSelector);
 cacheContract.bans?.values(cacheResourceSelector);
 cacheContract.voiceStates?.values(wildcardCacheSelector);
+cacheContract.presences?.values(cacheResourceSelector);
+cacheContract.presences?.get('user-id', 'guild-id');
+cacheContract.presences?.flush('guild-id');
+expectType<GuildBased>('presences');
+// @ts-expect-error Presences are guild-based, not globally keyed guild-related resources.
+expectType<GuildRelated>('presences');
+// @ts-expect-error Presence cache reads require the guild that owns the entry.
+cacheContract.presences?.get('user-id');
+// @ts-expect-error Guild-based presence flushes require an explicit guild selector.
+cacheContract.presences?.flush();
+// @ts-expect-error Bulk presence reads require a guild ID.
+const invalidPresenceBulkGetKey = ['presences', 'user-id'] as const satisfies BulkGetKey;
+
+declare const memberPresenceShorter: MemberShorter;
+memberPresenceShorter.presence('guild-id', 'user-id');
+// @ts-expect-error MemberShorter.presence requires both guild and user IDs.
+memberPresenceShorter.presence('user-id');
+declare const isolatedUser: UserStructure;
+isolatedUser.presence('guild-id');
+// @ts-expect-error A User has no implicit guild for presence lookup.
+isolatedUser.presence();
+declare const guildMemberPresence: GuildMemberStructure;
+guildMemberPresence.presence();
 
 type ChannelPinResult = Awaited<ReturnType<Client['channels']['pins']>>;
 expectType<true>(true as Equal<ChannelPinResult['items'][number]['pinnedAt'], number>);

--- a/tests/plugin-authoring-contract.ts
+++ b/tests/plugin-authoring-contract.ts
@@ -63,11 +63,9 @@ import {
 	Groups,
 	GroupsT,
 	GuildBan,
-	type GuildBased,
 	type GuildBasedResource,
 	GuildMember,
 	type GuildMemberStructure,
-	type GuildRelated,
 	type GuildRelatedResource,
 	type GuildRoleStructure,
 	type InferMiddlewares,
@@ -299,12 +297,8 @@ cacheContract.overwrites?.values(wildcardCacheSelector);
 cacheContract.members?.values(cacheResourceSelector);
 cacheContract.bans?.values(cacheResourceSelector);
 cacheContract.voiceStates?.values(wildcardCacheSelector);
-cacheContract.presences?.values(cacheResourceSelector);
 cacheContract.presences?.get('user-id', 'guild-id');
 cacheContract.presences?.flush('guild-id');
-expectType<GuildBased>('presences');
-// @ts-expect-error Presences are guild-based, not globally keyed guild-related resources.
-expectType<GuildRelated>('presences');
 // @ts-expect-error Presence cache reads require the guild that owns the entry.
 cacheContract.presences?.get('user-id');
 // @ts-expect-error Guild-based presence flushes require an explicit guild selector.
@@ -320,8 +314,6 @@ declare const isolatedUser: UserStructure;
 isolatedUser.presence('guild-id');
 // @ts-expect-error A User has no implicit guild for presence lookup.
 isolatedUser.presence();
-declare const guildMemberPresence: GuildMemberStructure;
-guildMemberPresence.presence();
 
 type ChannelPinResult = Awaited<ReturnType<Client['channels']['pins']>>;
 expectType<true>(true as Equal<ChannelPinResult['items'][number]['pinnedAt'], number>);

--- a/tests/presence.test.mts
+++ b/tests/presence.test.mts
@@ -1,0 +1,57 @@
+import { apiMember, apiUser } from '@slipher/testing';
+import { describe, expect, test, vi } from 'vitest';
+import { PresenceUpdateStatus } from '../lib';
+import type { PresenceUpdateReceiveStatus } from '../lib';
+import { MemberShorter } from '../lib/common/shorters/members';
+import { GuildMember, User } from '../lib/structures';
+import { PresenceUpdateHandler } from '../lib/websocket/discord/events/presenceUpdate';
+
+const guildId = '100000000000000001';
+const userId = '200000000000000002';
+
+const presenceData = (currentGuildId: string, status: PresenceUpdateReceiveStatus = PresenceUpdateStatus.Online) => ({
+	activities: [],
+	client_status: {},
+	guild_id: currentGuildId,
+	status,
+	user: { id: userId },
+});
+
+describe('guild-scoped presence consumers', () => {
+	test('member shorter reads the member from the requested guild', () => {
+		const get = vi.fn().mockReturnValue({ status: 'online' });
+		const shorter = new MemberShorter({ cache: { presences: { get } } } as any);
+
+		expect(shorter.presence(guildId, userId)).toEqual({ status: 'online' });
+		expect(get).toHaveBeenCalledWith(userId, guildId);
+	});
+
+	test('guild members provide their guild while isolated users require one', () => {
+		const presence = vi.fn().mockReturnValue({ status: 'online' });
+		const client = { members: { presence } } as any;
+		const userData = apiUser({ id: userId, username: 'user' });
+		const member = new GuildMember(client, apiMember({ roles: [] }), userData, guildId);
+		const user = new User(client, userData);
+
+		expect(member.presence()).toEqual({ status: 'online' });
+		expect(user.presence(guildId)).toEqual({ status: 'online' });
+		expect(presence.mock.calls).toEqual([
+			[guildId, userId],
+			[guildId, userId],
+		]);
+	});
+
+	test('deduplicates presence updates independently per guild', () => {
+		vi.useFakeTimers();
+		try {
+			const handler = new PresenceUpdateHandler();
+			expect(handler.check(presenceData('guild-1'))).toBe(true);
+			expect(handler.check(presenceData('guild-2'))).toBe(true);
+			expect(handler.check(presenceData('guild-1'))).toBe(false);
+			expect(handler.presenceUpdate.size).toBe(2);
+		} finally {
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+});

--- a/tests/presence.test.mts
+++ b/tests/presence.test.mts
@@ -1,7 +1,7 @@
 import { apiMember, apiUser } from '@slipher/testing';
 import { describe, expect, test, vi } from 'vitest';
-import { CacheFrom, Client, PresenceUpdateStatus } from '../lib';
 import type { PresenceUpdateReceiveStatus } from '../lib';
+import { CacheFrom, Client, PresenceUpdateStatus } from '../lib';
 import { GuildMember, User } from '../lib/structures';
 import { PresenceUpdateHandler } from '../lib/websocket/discord/events/presenceUpdate';
 

--- a/tests/presence.test.mts
+++ b/tests/presence.test.mts
@@ -1,8 +1,7 @@
 import { apiMember, apiUser } from '@slipher/testing';
 import { describe, expect, test, vi } from 'vitest';
-import { PresenceUpdateStatus } from '../lib';
+import { CacheFrom, Client, PresenceUpdateStatus } from '../lib';
 import type { PresenceUpdateReceiveStatus } from '../lib';
-import { MemberShorter } from '../lib/common/shorters/members';
 import { GuildMember, User } from '../lib/structures';
 import { PresenceUpdateHandler } from '../lib/websocket/discord/events/presenceUpdate';
 
@@ -18,27 +17,22 @@ const presenceData = (currentGuildId: string, status: PresenceUpdateReceiveStatu
 });
 
 describe('guild-scoped presence consumers', () => {
-	test('member shorter reads the member from the requested guild', () => {
-		const get = vi.fn().mockReturnValue({ status: 'online' });
-		const shorter = new MemberShorter({ cache: { presences: { get } } } as any);
-
-		expect(shorter.presence(guildId, userId)).toEqual({ status: 'online' });
-		expect(get).toHaveBeenCalledWith(userId, guildId);
-	});
-
-	test('guild members provide their guild while isolated users require one', () => {
-		const presence = vi.fn().mockReturnValue({ status: 'online' });
-		const client = { members: { presence } } as any;
+	test('shorter and structures resolve the presence from their requested guild', async () => {
+		const client = new Client();
 		const userData = apiUser({ id: userId, username: 'user' });
 		const member = new GuildMember(client, apiMember({ roles: [] }), userData, guildId);
 		const user = new User(client, userData);
+		await client.cache.presences?.set(CacheFrom.Test, userId, guildId, presenceData(guildId));
+		await client.cache.presences?.set(
+			CacheFrom.Test,
+			userId,
+			'guild-2',
+			presenceData('guild-2', PresenceUpdateStatus.Idle),
+		);
 
-		expect(member.presence()).toEqual({ status: 'online' });
-		expect(user.presence(guildId)).toEqual({ status: 'online' });
-		expect(presence.mock.calls).toEqual([
-			[guildId, userId],
-			[guildId, userId],
-		]);
+		expect(await client.members.presence(guildId, userId)).toMatchObject({ guild_id: guildId, status: 'online' });
+		expect(await member.presence()).toMatchObject({ guild_id: guildId, status: 'online' });
+		expect(await user.presence('guild-2')).toMatchObject({ guild_id: 'guild-2', status: 'idle' });
 	});
 
 	test('deduplicates presence updates independently per guild', () => {
@@ -48,7 +42,6 @@ describe('guild-scoped presence consumers', () => {
 			expect(handler.check(presenceData('guild-1'))).toBe(true);
 			expect(handler.check(presenceData('guild-2'))).toBe(true);
 			expect(handler.check(presenceData('guild-1'))).toBe(false);
-			expect(handler.presenceUpdate.size).toBe(2);
 		} finally {
 			vi.clearAllTimers();
 			vi.useRealTimers();


### PR DESCRIPTION
## Problem

`PRESENCE_UPDATE` identifies a presence by `(guild_id, user.id)`, but the cache currently stores it as `presence.<userId>`. Under #439's atomic ownership contract, receiving the same user from a second guild moves that single physical entry to the second guild; before #439, both guild relationships could instead point at the same last-written payload. Neither representation can retain distinct presence state per guild.

For example, an `online` update for user `U` in guild `A` followed by an `idle` update for `U` in guild `B` must leave two independent entries. A later update or guild cleanup for `A` must not alter `B`.

## Fix

Presences now use the guild-based resource model and physical keys `presence.<guildId>.<userId>`, with each entry owned only by `presence.<guildId>`. Bulk reads and writes carry the guild ID, guild cleanup removes only that guild's entries, and the gateway hook resolves its previous presence from the event's guild. The short-lived presence deduplicator uses the same composite identity so equivalent updates from different guilds are not suppressed.

The public lookup contract now makes guild context explicit: `MemberShorter.presence(guildId, userId)` and `User.presence(guildId)` require it, while `GuildMember.presence()` supplies its existing `guildId` automatically.

This is stacked directly on #439. The PR base is `refactor/atomic-cache-writes`, not `main`.
