### PR TITLE
refactor(cache): remove relationship owner moves

### DIFF
--- a/benchmarks/limited-cache.mjs
+++ b/benchmarks/limited-cache.mjs
@@ -38,6 +38,11 @@ const comparisons = [
 		label: 'Memory working tree compared with Limited working tree',
 	},
 ];
+const messageProbes = [
+	{ key: 'message.0', relationship: 'message.channel-0' },
+	{ key: 'message.100000', relationship: 'message.channel-0' },
+	{ key: 'message.199999', relationship: 'message.channel-19999' },
+];
 
 const scenarios = [
 	{
@@ -134,6 +139,22 @@ const scenarios = [
 		write: writeUser,
 	},
 	{
+		id: 'indexed-misses',
+		label: 'Indexed cache misses',
+		description: '6,680 retained channel buckets followed by 10k missing channel reads',
+		writes: 0,
+		preloadWrites: 6_680,
+		readOperations: 10_000,
+		expectedEntries: 6_680,
+		probes: [
+			{ key: 'channel.0', relationship: 'channel.guild-0' },
+			{ key: 'channel.3339', relationship: 'channel.guild-3339' },
+			{ key: 'channel.6679', relationship: 'channel.guild-6679' },
+		],
+		write: writeChannel,
+		read: readMissingChannel,
+	},
+	{
 		id: 'bulk',
 		label: 'Bulk writes',
 		description: '200k user writes in 1k-entry batches, with one repeated ID per batch',
@@ -149,7 +170,68 @@ const scenarios = [
 		batchSize: 1_000,
 		writeBatch: writeUserBatch,
 	},
+	{
+		id: 'message-writes',
+		label: 'Message writes',
+		description: '200k individual message writes distributed across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+	},
+	{
+		id: 'message-bulk',
+		label: 'Message bulk writes',
+		description: '200k message writes in 1k-entry batches across 6,680 guild buckets and 20k channels',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		batchSize: 1_000,
+		writeBatch: writeMessageBatch,
+	},
+	{
+		id: 'message-hits',
+		label: 'Message cache hits',
+		description: '200k retained messages followed by 1m deterministic cache hits',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 1_000_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMessage,
+	},
+	{
+		id: 'message-misses',
+		label: 'Message cache misses',
+		description: '200k retained messages followed by 300k deterministic cache misses',
+		writes: 0,
+		preloadWrites: 200_000,
+		readOperations: 300_000,
+		expectedEntries: 200_000,
+		probes: messageProbes,
+		write: writeMessage,
+		read: readMissingMessage,
+	},
+	{
+		id: 'message-ttl',
+		label: 'Message TTL expiration wave',
+		description: '200k message writes across 6,680 guild buckets, expiring after 3s',
+		writes: 200_000,
+		expectedEntries: 200_000,
+		expectedLimitedEntries: 0,
+		probes: messageProbes,
+		limitedProbes: messageProbes.map(probe => ({ ...probe, present: false })),
+		write: writeMessage,
+		adapterOptions: { message: { expire: 3_000 } },
+		waitForCleanup: true,
+	},
 ];
+
+const scenarioArgument = process.argv.indexOf('--scenario');
+const selectedScenarios =
+	scenarioArgument === -1 ? scenarios : scenarios.filter(scenario => scenario.id === process.argv[scenarioArgument + 1]);
+if (selectedScenarios.length === 0) throw new Error(`Unknown scenario ${process.argv[scenarioArgument + 1]}`);
 
 function evaluateCommonJs(source, filename, dependencies) {
 	const typescript = requireFromRepository('typescript');
@@ -258,10 +340,9 @@ function countEntries(adapter, arm) {
 }
 
 function countRelationshipIds(adapter, arm) {
+	if (isMemoryArm(arm)) return countEntries(adapter, arm);
 	let count = 0;
-	if (isMemoryArm(arm) && !hasBucketedStorage(adapter)) {
-		for (const values of adapter.relationships.values()) count += values.size;
-	} else if (usesAtomicWrites(adapter)) {
+	if (usesAtomicWrites(adapter)) {
 		for (const [namespace, storage] of adapter.storage) {
 			for (const key of storage.keys()) {
 				if (adapter.keyToRelationship?.has(key) || namespace === 'message' || namespace.startsWith('message.')) continue;
@@ -305,6 +386,25 @@ function countBuckets(adapter, arm) {
 	return isMemoryArm(arm) && !hasBucketedStorage(adapter) ? 1 : adapter.storage.size;
 }
 
+function countSchedules(adapter, arm) {
+	if (isMemoryArm(arm) || !hasBucketedStorage(adapter)) return 0;
+	let schedules = 0;
+	for (const bucket of adapter.storage.values()) {
+		if (bucket.expirationSchedule !== undefined) schedules++;
+	}
+	return schedules;
+}
+
+function retainedState(adapter, arm) {
+	return {
+		entries: countEntries(adapter, arm),
+		buckets: countBuckets(adapter, arm),
+		relationshipIds: countRelationshipIds(adapter, arm),
+		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
+		schedules: countSchedules(adapter, arm),
+	};
+}
+
 function usesAtomicWrites(adapter) {
 	return adapter.set.length >= 3;
 }
@@ -344,6 +444,34 @@ function writeChannel(adapter, id) {
 	);
 }
 
+function messageEntry(id) {
+	const stringId = String(id);
+	const guildId = `guild-${id % 6_680}`;
+	const channelId = `channel-${id % 20_000}`;
+	return [
+		`message.${stringId}`,
+		{ id: stringId, guild_id: guildId, channel_id: channelId, content: `message-${stringId}` },
+		[`message.${channelId}`, stringId],
+	];
+}
+
+function writeMessage(adapter, id) {
+	setWithRelationship(adapter, ...messageEntry(id));
+}
+
+function readMessage(adapter, randomState, scenario) {
+	const id = String(randomState % scenario.preloadWrites);
+	return adapter.get(`message.${id}`)?.id === id;
+}
+
+function readMissingMessage(adapter, randomState) {
+	return adapter.get(`message.missing-${randomState}`) === null;
+}
+
+function readMissingChannel(adapter, randomState) {
+	return adapter.get(`channel.missing-${randomState}`) === null;
+}
+
 function writeUserBatch(adapter, start, end) {
 	const ids = [];
 	const entries = [];
@@ -358,6 +486,21 @@ function writeUserBatch(adapter, start, end) {
 		return;
 	}
 	adapter.bulkAddToRelationShip({ user: ids });
+	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
+	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+}
+
+function writeMessageBatch(adapter, start, end) {
+	const entries = [];
+	for (let index = start; index < end; index++) entries.push(messageEntry(index));
+	if (usesAtomicWrites(adapter)) {
+		adapter.bulkSet(entries);
+		for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
+		return;
+	}
+	const relationships = {};
+	for (const [, , [to, id]] of entries) (relationships[to] ??= []).push(id);
+	adapter.bulkAddToRelationShip(relationships);
 	adapter.bulkSet(entries.map(([key, value]) => [key, value]));
 	for (const [key, , relationship] of entries) trackRelationship(adapter, key, relationship);
 }
@@ -418,9 +561,13 @@ async function executeWorkload(adapter, scenario, observe) {
 			scenario.readOperations,
 			() => {
 				randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
-				const id = String(randomState % scenario.preloadWrites);
 				expectedReads++;
-				if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				if (scenario.read) {
+					if (scenario.read(adapter, randomState, scenario)) validatedReads++;
+				} else {
+					const id = String(randomState % scenario.preloadWrites);
+					if (adapter.get(`user.${id}`)?.id === id) validatedReads++;
+				}
 			},
 			observe,
 		);
@@ -476,12 +623,7 @@ async function verifyScenarioRelationships(arm, scenario, adapters) {
 		await prepareWorkload(adapter, scenario, () => {});
 		await executeWorkload(adapter, scenario, () => {});
 		await waitForCleanup(adapter, arm, scenario, () => {});
-		const retained = {
-			entries: countEntries(adapter, arm),
-			buckets: countBuckets(adapter, arm),
-			relationshipIds: countRelationshipIds(adapter, arm),
-			indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-		};
+		const retained = retainedState(adapter, arm);
 		assertRetainedState(adapter, arm, scenario, retained);
 		const verifiedRelationships = countVerifiedRelationships(adapter);
 		if (verifiedRelationships !== retained.relationshipIds) {
@@ -503,8 +645,8 @@ async function runChild(arm, scenarioId) {
 	globalThis.gc?.();
 	await immediate();
 	const adapter = createAdapter(arm, scenario, adapters);
-	const baselineRss = process.memoryUsage().rss;
-	let peakRss = baselineRss;
+	const baselineMemory = process.memoryUsage();
+	let peakRss = baselineMemory.rss;
 	const observe = () => {
 		peakRss = Math.max(peakRss, process.memoryUsage().rss);
 	};
@@ -523,13 +665,11 @@ async function runChild(arm, scenarioId) {
 	observe();
 	eventLoopDelay.disable();
 	const cpu = process.cpuUsage(cpuStart);
-	const retained = {
-		entries: countEntries(adapter, arm),
-		buckets: countBuckets(adapter, arm),
-		relationshipIds: countRelationshipIds(adapter, arm),
-		indexes: (adapter.keyToStorage?.size ?? 0) + (adapter.keyToRelationship?.size ?? 0),
-	};
+	const retained = retainedState(adapter, arm);
 	assertRetainedState(adapter, arm, scenario, retained);
+	globalThis.gc?.();
+	await immediate();
+	const retainedMemory = process.memoryUsage();
 	adapter.flush();
 	if (process.env.SEYFERT_CACHE_BENCH_VERIFY_RELATIONSHIPS === '1') {
 		await verifyScenarioRelationships(arm, scenario, adapters);
@@ -541,7 +681,9 @@ async function runChild(arm, scenarioId) {
 		...workload,
 		cleanupMilliseconds,
 		cpuMilliseconds: (cpu.user + cpu.system) / 1_000,
-		peakRssDeltaMiB: (peakRss - baselineRss) / mebibyte,
+		peakRssDeltaMiB: (peakRss - baselineMemory.rss) / mebibyte,
+		rssAfterGcDeltaMiB: (retainedMemory.rss - baselineMemory.rss) / mebibyte,
+		heapAfterGcDeltaMiB: (retainedMemory.heapUsed - baselineMemory.heapUsed) / mebibyte,
 		eventLoopP95Milliseconds: eventLoopDelay.percentile(95) / 1e6,
 		eventLoopMaxMilliseconds: eventLoopDelay.max / 1e6,
 		retained,
@@ -563,6 +705,8 @@ function summarize(runs) {
 		'throughputOpsPerSecond',
 		'cpuMilliseconds',
 		'peakRssDeltaMiB',
+		'rssAfterGcDeltaMiB',
+		'heapAfterGcDeltaMiB',
 		'eventLoopP95Milliseconds',
 		'eventLoopMaxMilliseconds',
 	];
@@ -653,6 +797,8 @@ function printMetricTable(summary) {
 				'Throughput ↑': formatMeasuredMetric(value, 'throughputOpsPerSecond', 'ops/s', 0),
 				'CPU ↓': formatMeasuredMetric(value, 'cpuMilliseconds', 'ms'),
 				'RSS growth ↓': formatMeasuredMetric(value, 'peakRssDeltaMiB', 'MiB'),
+				'RSS after GC ↓': formatMeasuredMetric(value, 'rssAfterGcDeltaMiB', 'MiB'),
+				'Heap after GC ↓': formatMeasuredMetric(value, 'heapAfterGcDeltaMiB', 'MiB'),
 				'Loop p95 ↓': formatMeasuredMetric(value, 'eventLoopP95Milliseconds', 'ms', 2),
 				'Loop max ↓': formatMeasuredMetric(value, 'eventLoopMaxMilliseconds', 'ms', 2),
 				'Cleanup wait ↓':
@@ -693,6 +839,22 @@ function printComparison(summary, comparison) {
 		)}`,
 	);
 	console.log(
+		`  RSS after GC ↓   ${markInconclusive(
+			describeAbsoluteChange(candidate.rssAfterGcDeltaMiB, baseline.rssAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'rssAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
+		`  Heap after GC ↓  ${markInconclusive(
+			describeAbsoluteChange(candidate.heapAfterGcDeltaMiB, baseline.heapAfterGcDeltaMiB, 'MiB'),
+			candidate,
+			baseline,
+			'heapAfterGcDeltaMiB',
+		)}`,
+	);
+	console.log(
 		`  Event-loop max ↓ ${markInconclusive(
 			describeRelativeChange(candidate.eventLoopMaxMilliseconds, baseline.eventLoopMaxMilliseconds),
 			candidate,
@@ -721,6 +883,7 @@ function printRetainedState(summary) {
 				Buckets: retained.buckets,
 				'Logical relationships': retained.relationshipIds,
 				Indexes: retained.indexes,
+				Schedules: retained.schedules,
 			};
 		}),
 	);
@@ -797,14 +960,14 @@ async function runCoordinator() {
 	console.log('Direction:  ↑ higher is better; ↓ lower is better; retained-state counts are descriptive');
 	console.log('Metrics:    values are medians; ± is median absolute deviation as a percentage; loop values are event-loop delays\n');
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		for (let repetition = 1; repetition <= maximumRepetitions; repetition++) {
 			for (const arm of balancedArms(repetition)) runs.push(runIsolated(arm, scenario, repetition));
 			if (repetition >= minimumRepetitions && hasEnoughMeasuredTime(runs, scenario.id)) break;
 		}
 	}
 
-	for (const scenario of scenarios) {
+	for (const scenario of selectedScenarios) {
 		const summary = Object.fromEntries(
 			arms.map(arm => [
 				arm.id,

--- a/src/cache/adapters/default.ts
+++ b/src/cache/adapters/default.ts
@@ -83,14 +83,6 @@ export class MemoryAdapter<T> implements Adapter {
 		return storageEntry;
 	}
 
-	private _moveIndexedEntry(key: string, namespace: string) {
-		const previousNamespace = this.keyToStorage.get(key);
-		if (previousNamespace === undefined || previousNamespace === namespace) return;
-		const previousStorage = this.storage.get(previousNamespace);
-		previousStorage?.delete(key);
-		if (previousStorage?.size === 0) this.storage.delete(previousNamespace);
-	}
-
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
 		const data = patch && !Array.isArray(value) ? { ...(this.get(key) ?? {}), ...value } : value;
 		const encoded = this.options.encode(data);
@@ -101,7 +93,6 @@ export class MemoryAdapter<T> implements Adapter {
 			this.storage.set(namespace, storageEntry);
 		}
 		const indexed = needsCacheStorageIndex(key, namespace);
-		if (indexed) this._moveIndexedEntry(key, namespace);
 		storageEntry.set(key, encoded);
 		if (indexed) this.keyToStorage.set(key, namespace);
 	}

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -31,13 +31,16 @@ export interface LimitedMemoryAdapterOptions<T> {
 	decode?(data: T): unknown;
 }
 
+export type LimitedMemoryStorageIndex<T> =
+	| LimitedCollection<string, T>
+	| readonly [storage: LimitedCollection<string, T>, relationship: string];
+
 export class LimitedMemoryAdapter<T> implements Adapter {
 	isAsync = false;
 
 	readonly storage = new Map<string, LimitedCollection<string, T>>();
 	readonly relationships = new Map<string, Map<string, Set<string>>>();
-	readonly keyToStorage = new Map<string, LimitedCollection<string, T>>();
-	private readonly keyToRelationship = new Map<string, AdapterRelationship>();
+	readonly keyToStorage = new Map<string, LimitedMemoryStorageIndex<T>>();
 
 	options: MakeRequired<LimitedMemoryAdapterOptions<T>, 'default' | 'encode' | 'decode'>;
 
@@ -102,11 +105,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return key.indexOf('.', resource.length + 1) !== -1;
 	}
 
-	private _setIndexedStorage(key: string, namespace: string, storageEntry: LimitedCollection<string, T>) {
-		if (needsCacheStorageIndex(key, namespace)) this.keyToStorage.set(key, storageEntry);
+	private _getIndexedStorage(index: LimitedMemoryStorageIndex<T>) {
+		return Array.isArray(index) ? index[0] : index;
 	}
 
-	private _deleteIndexedStorage(key: string) {
+	private _deleteIndexedStorage(key: string, storageEntry: LimitedCollection<string, T>) {
+		const index = this.keyToStorage.get(key);
+		if (!index || this._getIndexedStorage(index) !== storageEntry) return;
+		this._removeExplicitRelationship(key, index);
 		this.keyToStorage.delete(key);
 	}
 
@@ -119,39 +125,26 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return scopeEnd === -1 ? resource : key.slice(0, scopeEnd);
 	}
 
-	private _isResourceNamespace(resource: string, namespace: string) {
-		return namespace === resource || namespace.startsWith(`${resource}.`);
-	}
-
-	private _findNamespaceByStorage(resource: string, storageEntry: LimitedCollection<string, T>) {
-		for (const [namespace, candidate] of this.storage) {
-			if (candidate === storageEntry && this._isResourceNamespace(resource, namespace)) return namespace;
-		}
-		return undefined;
-	}
-
 	private _getMessageNamespace(data: any) {
 		const scope = Array.isArray(data) ? data[0]?.guild_id : data?.guild_id;
 		return scope ? `message.${scope}` : 'message';
 	}
 
 	private _getStorageEntry(key: string) {
+		const index = this.keyToStorage.get(key);
+		if (index) {
+			const indexedStorage = this._getIndexedStorage(index);
+			if (indexedStorage.has(key)) return { storageEntry: indexedStorage };
+			this._deleteIndexedStorage(key, indexedStorage);
+			return undefined;
+		}
+
 		const resource = this._getKeyResource(key);
 		const layout = getCacheResourceLayout(resource);
-		const indexedStorage = this.keyToStorage.get(key);
-		if (indexedStorage?.has(key)) return { resource, layout, storageEntry: indexedStorage };
-		if (indexedStorage) this.keyToStorage.delete(key);
-
 		if (layout !== 'guild-indexed' && layout !== 'message') {
 			const namespace = this._getStorageNamespaceFromKey(resource, layout, key);
 			const storageEntry = this.storage.get(namespace);
-			if (storageEntry?.has(key)) return { resource, layout, namespace, storageEntry };
-		}
-
-		for (const [namespace, storageEntry] of this.storage) {
-			if (!this._isResourceNamespace(resource, namespace) || !storageEntry.has(key)) continue;
-			this._setIndexedStorage(key, namespace, storageEntry);
-			return { resource, layout, namespace, storageEntry };
+			if (storageEntry?.has(key)) return { storageEntry };
 		}
 		return undefined;
 	}
@@ -192,28 +185,20 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return ids;
 	}
 
-	private _removeExplicitRelationship(key: string) {
-		const relationship = this.keyToRelationship.get(key);
-		if (!relationship) return;
-		const [to, id] = relationship;
+	private _removeExplicitRelationship(key: string, index: LimitedMemoryStorageIndex<T>) {
+		if (!Array.isArray(index)) return;
+		const to = index[1];
+		const id = key.slice(key.lastIndexOf('.') + 1);
 		const [resource, scope] = this._getRelationshipData(to);
 		const relationships = this.relationships.get(resource);
 		const ids = relationships?.get(scope);
 		ids?.delete(id);
 		if (ids?.size === 0) relationships?.delete(scope);
 		if (relationships?.size === 0) this.relationships.delete(resource);
-		this.keyToRelationship.delete(key);
 	}
 
-	private _syncRelationship(
-		key: string,
-		layout: CacheResourceLayout,
-		namespace: string,
-		relationship: AdapterRelationship,
-	) {
-		if (layout !== 'message' && namespace === relationship[0]) return;
+	private _syncMessageRelationship(relationship: AdapterRelationship) {
 		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
-		this.keyToRelationship.set(key, relationship);
 	}
 
 	private _deleteEmptyStorage(namespace: string, storageEntry: LimitedCollection<string, T>) {
@@ -229,8 +214,7 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 			limit: resourceOptions?.limit ?? this.options.default.limit,
 			resetOnDemand: (expire ?? 0) > 0,
 			onDelete: key => {
-				this._deleteIndexedStorage(key);
-				this._removeExplicitRelationship(key);
+				this._deleteIndexedStorage(key, bucket);
 				if (bucket.size === 1 && bucket.has(key) && this.storage.get(namespace) === bucket) {
 					this.storage.delete(namespace);
 				}
@@ -250,13 +234,14 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 		const storageEntry = this.storage.get(namespace) ?? this._createStorageEntry(resource, namespace);
 		const usesIndex = layout === 'message' || needsCacheStorageIndex(key, namespace);
-		const previousMessageStorage = layout === 'message' ? this.keyToStorage.get(key) : undefined;
-		storageEntry.set(key, encoded);
-
-		if (storageEntry.has(key)) {
+		const previousMessageIndex = layout === 'message' ? this.keyToStorage.get(key) : undefined;
+		const previousMessageStorage = previousMessageIndex ? this._getIndexedStorage(previousMessageIndex) : undefined;
+		if (storageEntry.set(key, encoded)) {
 			if (previousMessageStorage && previousMessageStorage !== storageEntry) previousMessageStorage.delete(key);
-			if (usesIndex) this.keyToStorage.set(key, storageEntry);
-			this._syncRelationship(key, layout, namespace, relationship);
+			if (usesIndex) {
+				this.keyToStorage.set(key, layout === 'message' ? [storageEntry, relationship[0]] : storageEntry);
+			}
+			if (layout === 'message') this._syncMessageRelationship(relationship);
 		}
 		this._deleteEmptyStorage(namespace, storageEntry);
 	}
@@ -293,11 +278,10 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 	keys(to: string) {
 		const bucket = this._getRelationshipBucket(to);
 		if (bucket) return [...bucket.keys()];
-		const keys: string[] = [];
-		for (const [key, relationship] of this.keyToRelationship) {
-			if (relationship[0] === to) keys.push(key);
-		}
-		return keys;
+		const ids = this._getExplicitRelationshipSet(to);
+		if (!ids) return [];
+		const resource = this._getKeyResource(to);
+		return [...ids].map(id => `${resource}.${id}`);
 	}
 
 	count(to: string) {
@@ -336,10 +320,6 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		const entry = this._getStorageEntry(key);
 		if (!entry) return;
 		entry.storageEntry.delete(key);
-		this._deleteIndexedStorage(key);
-		if (entry.storageEntry.size !== 0) return;
-		const namespace = entry.namespace ?? this._findNamespaceByStorage(entry.resource, entry.storageEntry);
-		if (namespace) this.storage.delete(namespace);
 	}
 
 	removeToRelationship(to: string, keys: string | string[]) {
@@ -358,6 +338,5 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		this.storage.clear();
 		this.relationships.clear();
 		this.keyToStorage.clear();
-		this.keyToRelationship.clear();
 	}
 }

--- a/src/cache/adapters/limited.ts
+++ b/src/cache/adapters/limited.ts
@@ -205,26 +205,15 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		this.keyToRelationship.delete(key);
 	}
 
-	private _setExplicitRelationship(key: string, relationship: AdapterRelationship) {
-		const previous = this.keyToRelationship.get(key);
-		if (previous && (previous[0] !== relationship[0] || previous[1] !== relationship[1])) {
-			this._removeExplicitRelationship(key);
-		}
-		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
-		this.keyToRelationship.set(key, relationship);
-	}
-
 	private _syncRelationship(
 		key: string,
 		layout: CacheResourceLayout,
 		namespace: string,
 		relationship: AdapterRelationship,
 	) {
-		if (layout !== 'message' && namespace === relationship[0]) {
-			this._removeExplicitRelationship(key);
-			return;
-		}
-		this._setExplicitRelationship(key, relationship);
+		if (layout !== 'message' && namespace === relationship[0]) return;
+		this._ensureExplicitRelationshipSet(relationship[0]).add(relationship[1]);
+		this.keyToRelationship.set(key, relationship);
 	}
 
 	private _deleteEmptyStorage(namespace: string, storageEntry: LimitedCollection<string, T>) {
@@ -251,19 +240,6 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 		return bucket;
 	}
 
-	private _moveStoredEntry(
-		resource: string,
-		key: string,
-		storageEntry: LimitedCollection<string, T>,
-		previousStorageEntry: LimitedCollection<string, T> | undefined,
-	) {
-		if (!previousStorageEntry || previousStorageEntry === storageEntry) return;
-		previousStorageEntry.delete(key);
-		if (previousStorageEntry.size !== 0) return;
-		const previousNamespace = this._findNamespaceByStorage(resource, previousStorageEntry);
-		if (previousNamespace) this.storage.delete(previousNamespace);
-	}
-
 	private _set(key: string, value: any, relationship: AdapterRelationship, patch: boolean) {
 		const data = patch && !Array.isArray(value) ? { ...(this._getWithoutRefresh(key) ?? {}), ...value } : value;
 		const encoded = this.options.encode(data);
@@ -274,10 +250,11 @@ export class LimitedMemoryAdapter<T> implements Adapter {
 
 		const storageEntry = this.storage.get(namespace) ?? this._createStorageEntry(resource, namespace);
 		const usesIndex = layout === 'message' || needsCacheStorageIndex(key, namespace);
-		this._moveStoredEntry(resource, key, storageEntry, this.keyToStorage.get(key));
+		const previousMessageStorage = layout === 'message' ? this.keyToStorage.get(key) : undefined;
 		storageEntry.set(key, encoded);
 
 		if (storageEntry.has(key)) {
+			if (previousMessageStorage && previousMessageStorage !== storageEntry) previousMessageStorage.delete(key);
 			if (usesIndex) this.keyToStorage.set(key, storageEntry);
 			this._syncRelationship(key, layout, namespace, relationship);
 		}

--- a/src/cache/adapters/types.ts
+++ b/src/cache/adapters/types.ts
@@ -2,9 +2,10 @@ import type { Awaitable } from '../../common';
 
 export type AdapterRelationship = readonly [to: string, id: string];
 /**
- * A cache value and the relationship that owns it.
+ * A cache value and the relationship derived by its resource model.
  * Keys must use `resource.id` or `resource.scope.id`; IDs and namespace segments cannot contain dots.
  * Each resource namespace must consistently use one of those layouts.
+ * A physical key must keep the same relationship; adapters do not reconcile conflicting ownership.
  * Adapters assume these preconditions and do not validate them at runtime.
  */
 export type AdapterEntry = readonly [key: string, value: any, relationship: AdapterRelationship];

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -365,6 +365,7 @@ export class LimitedCollection<K, V> {
 	 * @param key The key of the element.
 	 * @param value The value of the element.
 	 * @param customExpire The custom expiration time for the element.
+	 * @returns Whether the configured limit accepted the entry. Reentrant mutations from `onDelete` do not change this result.
 	 * @example
 	 * const collection = new LimitedCollection<number, string>({ limit: 3 });
 	 * collection.set(1, 'one');
@@ -377,8 +378,9 @@ export class LimitedCollection<K, V> {
 	 */
 	set(key: K, value: V, customExpire = this.options.expire) {
 		if (this.options.limit <= 0) {
-			return;
+			return false;
 		}
+		const retained = this.options.limit >= 1;
 		validateLimitedCollectionExpiration(customExpire);
 
 		const expireOn = Number.isFinite(customExpire) && customExpire > 0 ? Date.now() + customExpire : -1;
@@ -391,7 +393,7 @@ export class LimitedCollection<K, V> {
 					this.delete(keyValue);
 				}
 			}
-			return;
+			return retained;
 		}
 
 		const previousCloser = this.expirations?.first;
@@ -418,6 +420,7 @@ export class LimitedCollection<K, V> {
 				this.rescheduleExpiration();
 			}
 		}
+		return retained;
 	}
 
 	/**

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -150,17 +150,17 @@ describe('memory cache adapter bucket ownership', () => {
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
 
-	test('indexes only globally keyed relationships and cleans up owner moves', () => {
+	test('indexes globally keyed relationships for lookup and cleanup', () => {
 		const adapter = new MemoryAdapter();
 		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-1' }, ['channel.guild-1', 'channel-1']);
-		adapter.set('channel.channel-1', { id: 'channel-1', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-1']);
 
 		assert.equal(adapter.keyToStorage.size, 1);
 		assert.equal(adapter.storage.size, 1);
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 
-		adapter.removeToRelationship('channel.guild-2', 'channel-1');
+		adapter.remove('channel.channel-1');
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
@@ -430,7 +430,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		assert.deepEqual(adapter.keys('custom.guild-1'), ['custom.entry']);
 	});
 
-	test('preserves the old value and relationship when a replacement cannot encode', () => {
+	test('preserves the old value when a replacement cannot encode', () => {
 		let reject = false;
 		const adapter = createTestAdapter(kind, {
 			encode(data) {
@@ -441,10 +441,9 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		reject = true;
-		expect(() => adapter.set(...channelWrite('guild-2', 'new'))).toThrow('encode failed');
+		expect(() => adapter.set(...channelWrite('guild-1', 'new'))).toThrow('encode failed');
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 
 	test('propagates bulk failures without leaving an orphaned entry', () => {
@@ -469,7 +468,7 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		}
 	});
 
-	test('patch decode failures leave both value and relationship untouched', () => {
+	test('patch decode failures leave the value untouched', () => {
 		let rejectDecode = false;
 		const adapter = createTestAdapter(kind, {
 			decode(data) {
@@ -480,11 +479,10 @@ describe.each(adapterKinds)('%s atomic write failures', kind => {
 		adapter.set(...channelWrite('guild-1', 'old'));
 
 		rejectDecode = true;
-		expect(() => adapter.patch(...channelWrite('guild-2', 'new'))).toThrow('decode failed');
+		expect(() => adapter.patch(...channelWrite('guild-1', 'new'))).toThrow('decode failed');
 		rejectDecode = false;
 		assert.equal((adapter.get('channel.channel-1') as { name: string }).name, 'old');
 		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), false);
 	});
 });
 
@@ -505,15 +503,48 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.contains('member.guild-2', 'user-2'), false);
 	});
 
-	test('moves a globally keyed resource between bucket-owned relationships', () => {
+	test('uses the global-key index for lookup and cleanup', () => {
 		const adapter = new LimitedMemoryAdapter();
 		adapter.set(...channelWrite('guild-1'));
-		adapter.set(...channelWrite('guild-2'));
 
-		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), false);
-		assert.equal(adapter.contains('channel.guild-2', 'channel-1'), true);
-		assert.deepEqual(adapter.keys('channel.guild-2'), ['channel.channel-1']);
+		assert.deepEqual(adapter.get('channel.channel-1'), { id: 'channel-1', guild_id: 'guild-1', name: 'guild-1' });
+		assert.equal(adapter.contains('channel.guild-1', 'channel-1'), true);
+		assert.deepEqual(adapter.keys('channel.guild-1'), ['channel.channel-1']);
 		assert.equal(adapter.storage.size, 1);
+		assert.equal(adapter.relationships.size, 0);
+
+		adapter.remove('channel.channel-1');
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
+	});
+
+	test('relocates message storage without changing its relationship owner', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(
+			'message.message-1',
+			{ id: 'message-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-1'],
+		);
+		adapter.patch(
+			'message.message-1',
+			{ guild_id: 'guild-1' },
+			['message.channel-1', 'message-1'],
+		);
+
+		assert.equal(adapter.storage.has('message'), false);
+		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
+		assert.deepEqual(adapter.get('message.message-1'), {
+			id: 'message-1',
+			guild_id: 'guild-1',
+			channel_id: 'channel-1',
+		});
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+
+		adapter.remove('message.message-1');
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.storage.size, 0);
+		assert.equal(adapter.keyToStorage.size, 0);
 		assert.equal(adapter.relationships.size, 0);
 	});
 
@@ -524,40 +555,16 @@ describe('limited memory cache adapter ownership', () => {
 			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
 			['message.channel-1', 'message-1'],
 		);
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-2' },
-			['message.channel-2', 'message-1'],
-		);
 
-		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
-		assert.equal(adapter.contains('message.channel-2', 'message-1'), true);
-		assert.deepEqual(adapter.keys('message.channel-2'), ['message.message-1']);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), true);
+		assert.deepEqual(adapter.keys('message.channel-1'), ['message.message-1']);
 		assert.equal(adapter.relationships.size, 1);
-	});
-
-	test('removes an unscoped message after moving it into guild storage', () => {
-		const adapter = new LimitedMemoryAdapter();
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-1'],
-		);
-		adapter.set(
-			'message.message-1',
-			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
-			['message.channel-1', 'message-1'],
-		);
-
-		assert.equal(adapter.storage.has('message'), false);
-		assert.equal(adapter.storage.get('message.guild-1')?.size, 1);
 
 		adapter.remove('message.message-1');
-
-		assert.equal(adapter.get('message.message-1'), null);
 		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
+		assert.equal(adapter.relationships.size, 0);
 	});
 
 	test('does not allocate relationship sets for bucket-owned resources', () => {
@@ -645,16 +652,6 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.get('custom.entry-1'), null);
 		assert.equal(adapter.contains(to, 'entry-1'), false);
 		assert.equal(adapter.contains(to, 'entry-2'), true);
-	});
-
-	test('moves a custom relationship between owners', () => {
-		const adapter = new LimitedMemoryAdapter();
-		adapter.set('custom.entry', { id: 'entry' }, ['custom.guild-1', 'entry']);
-		adapter.set('custom.entry', { id: 'entry', owner: 'guild-2' }, ['custom.guild-2', 'entry']);
-
-		assert.equal(adapter.contains('custom.guild-1', 'entry'), false);
-		assert.deepEqual(adapter.getToRelationship('custom.guild-2'), ['entry']);
-		assert.deepEqual(adapter.get('custom.entry'), { id: 'entry', owner: 'guild-2' });
 	});
 
 	test('stores empty array resources in the relationship-owned bucket', () => {

--- a/tests/cache.test.mts
+++ b/tests/cache.test.mts
@@ -518,6 +518,16 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.keyToStorage.size, 0);
 	});
 
+	test('does not scan guild buckets for a globally keyed miss', () => {
+		const adapter = new LimitedMemoryAdapter();
+		adapter.set(...channelWrite('guild-1'));
+		adapter.set('channel.channel-2', { id: 'channel-2', guild_id: 'guild-2' }, ['channel.guild-2', 'channel-2']);
+		const iterateStorage = vi.spyOn(adapter.storage, Symbol.iterator);
+
+		assert.equal(adapter.get('channel.missing'), null);
+		expect(iterateStorage).not.toHaveBeenCalled();
+	});
+
 	test('relocates message storage without changing its relationship owner', () => {
 		const adapter = new LimitedMemoryAdapter();
 		adapter.set(
@@ -565,6 +575,48 @@ describe('limited memory cache adapter ownership', () => {
 		assert.equal(adapter.storage.size, 0);
 		assert.equal(adapter.keyToStorage.size, 0);
 		assert.equal(adapter.relationships.size, 0);
+	});
+
+	test('cleans message indexes and relationships when their bucket evicts them', () => {
+		const adapter = new LimitedMemoryAdapter({ message: { limit: 1 } });
+		adapter.set(
+			'message.message-1',
+			{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-1'],
+		);
+		adapter.set(
+			'message.message-2',
+			{ id: 'message-2', guild_id: 'guild-1', channel_id: 'channel-1' },
+			['message.channel-1', 'message-2'],
+		);
+
+		assert.equal(adapter.get('message.message-1'), null);
+		assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+		assert.equal(adapter.get('message.message-2') !== null, true);
+		assert.equal(adapter.contains('message.channel-1', 'message-2'), true);
+		assert.equal(adapter.keyToStorage.size, 1);
+	});
+
+	test('cleans message indexes and relationships when they expire', () => {
+		vi.useFakeTimers();
+		try {
+			const adapter = new LimitedMemoryAdapter({ message: { expire: 100 } });
+			adapter.set(
+				'message.message-1',
+				{ id: 'message-1', guild_id: 'guild-1', channel_id: 'channel-1' },
+				['message.channel-1', 'message-1'],
+			);
+
+			vi.advanceTimersByTime(100);
+
+			assert.equal(adapter.get('message.message-1'), null);
+			assert.equal(adapter.contains('message.channel-1', 'message-1'), false);
+			assert.equal(adapter.storage.size, 0);
+			assert.equal(adapter.keyToStorage.size, 0);
+			assert.equal(adapter.relationships.size, 0);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test('does not allocate relationship sets for bucket-owned resources', () => {

--- a/tests/collection.test.mts
+++ b/tests/collection.test.mts
@@ -201,8 +201,28 @@ describe('LimitedCollection', () => {
 
 	test('limit 0 rejects all inserts', () => {
 		const c = new LimitedCollection<number, string>({ limit: 0 });
-		c.set(1, 'one');
+		assert.equal(c.set(1, 'one'), false);
 		assert.equal(c.size, 0);
+	});
+
+	test('set reports limit acceptance independently of reentrant deletion', () => {
+		const retained = new LimitedCollection<number, string>();
+		assert.equal(retained.set(1, 'one'), true);
+
+		const fractionalLimit = new LimitedCollection<number, string>({ limit: 0.5 });
+		assert.equal(fractionalLimit.set(1, 'one'), false);
+		assert.equal(fractionalLimit.size, 0);
+
+		let reentrant: LimitedCollection<number, string>;
+		reentrant = new LimitedCollection({
+			limit: 1,
+			onDelete(key) {
+				if (key === 1) reentrant.delete(2);
+			},
+		});
+		reentrant.set(1, 'one');
+		assert.equal(reentrant.set(2, 'two'), true);
+		assert.equal(reentrant.has(2), false);
 	});
 
 	test('rejects NaN limits but preserves zero and infinity behavior', () => {


### PR DESCRIPTION
## Contract

Relationship identity comes from the cache resource model. Reusing one physical key with a different relationship is outside the adapter contract, so the in-memory adapters no longer look up the previous owner, delete its membership, or otherwise implement a move/rejection policy. The public adapter entry contract now states that the relationship for a physical key is stable.

Reverse lookup state remains where the key layout cannot identify its bucket directly. `MemoryAdapter` and `LimitedMemoryAdapter` still index globally keyed resources stored in relationship-owned buckets, and `LimitedMemoryAdapter` still tracks the explicit `message.<channel>` relationship separately from its `message` or `message.<guild>` storage bucket. Those indexes are used by lookup, remove, eviction, expiration, and relationship cleanup; they are not owner-move support. A message may still relocate between physical message buckets when `guild_id` becomes known, because its relationship owner does not change, and the replacement is retained before the old bucket is removed.

## Extra coordination

[Extra #42](https://github.com/tiramisulabs/extra/pull/42) should keep its reverse-owner state only to locate globally keyed entries for reads, removals, and atomic cleanup. Its old-owner comparison/deletion path, owner parsing used solely by that path, and relationship-move benchmark scenarios should be removed. Conflicting-owner rewrites should not gain a rejection branch; they remain outside the resource contract.

Stacked on #440.